### PR TITLE
Make KData a frozen dataclass

### DIFF
--- a/src/mrpro/data/_KData.py
+++ b/src/mrpro/data/_KData.py
@@ -42,17 +42,8 @@ KDIM_SORT_LABELS = (
 )
 
 
+@dataclasses.dataclass(slots=True, frozen=True)
 class KData:
-    def __init__(
-        self,
-        header: KHeader,
-        data: torch.Tensor,
-        traj: torch.Tensor,
-    ) -> None:
-        self._header: KHeader = header
-        self._data: torch.Tensor = data
-        self._traj: torch.Tensor = traj
-
     @classmethod
     def from_file(
         cls,
@@ -159,15 +150,3 @@ class KData:
             )
 
         return cls(kheader, kdata, ktraj)
-
-    @property
-    def traj(self) -> torch.Tensor:
-        return self._traj
-
-    @property
-    def data(self) -> torch.Tensor:
-        return self._data
-
-    @property
-    def header(self) -> KHeader:
-        return self._header

--- a/src/mrpro/data/_KData.py
+++ b/src/mrpro/data/_KData.py
@@ -44,6 +44,10 @@ KDIM_SORT_LABELS = (
 
 @dataclasses.dataclass(slots=True, frozen=True)
 class KData:
+    header: KHeader
+    data: torch.Tensor
+    traj: torch.Tensor
+
     @classmethod
     def from_file(
         cls,


### PR DESCRIPTION
KData can be a dataclass.

Seeting frozen makes the attributes read-only, i.e. data and header can only be set at init. This matches the previous behavior.

We might want to keep this as a regular class depening on how much we want to to in the getters or setters. Or make it a dataclass for now and maybe switch to something more flexible later on..

Fixes #35

