### PR TITLE
Fix mypy ignore missing imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ warn_no_return = "True"
 warn_unreachable = "True"
 exclude = ["docs"]
 
-[mypy-ismrmrd]
+[[tool.mypy.overrides]]
+module = ["ismrmrd.*", "h5py"]
 ignore_missing_imports = true
 
 # Black section


### PR DESCRIPTION
As suggested by @ckolbPTB.
The previous version a) did not cover h5py and b) missed the .* for ismrmrd. If we have multiple module overwrites, this syntax is also cleaner.

Closes #44 