### PR TITLE
Add torch, numpy to pre-commit/mypy venv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,35 +28,40 @@ repos:
       - id: autopep8
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
         args: [--exclude=__init__.py]
         exclude: ^docs/
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev: v1.5.1
     hooks:
       - id: mypy
+        additional_dependencies:
+          - numpy
+          - torch
+          - --index-url=https://download.pytorch.org/whl/cpu
+          - --extra-index-url=https://pypi.python.org/simple
         exclude: "docs/.*|tests/.*"
 
   - repo: https://github.com/myint/docformatter
-    rev: v1.4
+    rev: v1.7.5
     hooks:
       - id: docformatter
         args: ["--in-place"]
 
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.1.1
+    rev: 6.3.0
     hooks:
       - id: pydocstyle
         exclude: __init__.py
         files: ^src/
         additional_dependencies:
-          - toml
+          - tomli
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.9.0
+    rev: v3.10.1
     hooks:
     -   id: pyupgrade
         args: ["--py310-plus"]


### PR DESCRIPTION
Otherwise, e.g, torch.Tensor will be considered as Any.

The index-url ist a pytoch-wheel repo with cpu-only wheels (listed at https://pytorch.org/get-started/locally), the extra-index-url the default pypi URL for all other packages not found in the pytorch repo.

Also, update some pre-commit hooks (mypy, flake8, pydocstyle and pyupgrade)

closes #47 

@schuenke @ckolbPTB 
Please check if the wheel installation works on Windows / MacOS, respectively. I checked anylinux.

And maybe let's wait with merging until at least both of @schuenke and @ckolbPTB  got the chance to voice their opinion regarding how we want to handle #47 -- if adding torch to the mypy precommit venv is our way to go...