### PR TITLE
Pytest warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ docs = ["sphinx", "sphinx_rtd_theme"]
 # PyTest section
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+filterwarnings = ["error"]
 
 # MyPy section
 [tool.mypy]
@@ -99,7 +100,4 @@ builtin = "en-GB_to_en-US"
 ignore-words-list = "te,TE"
 
 [tool.coverage.paths]
-source = [
-    "src",
-    "*/site-packages",
-]
+source = ["src", "*/site-packages"]

--- a/tests/data/_Dicom2DTestImage.py
+++ b/tests/data/_Dicom2DTestImage.py
@@ -41,10 +41,10 @@ class Dicom2DTestImage:
 
         # Create image
         self.imref = self.phantom.image_space(matrix_size, matrix_size)
-        self.imref = (self.imref * 2**16).astype(np.uint16)
+        self.imref = np.abs(self.imref * 2**16).astype(np.uint16)
 
         # Metadata
-        fileMeta = pydicom.Dataset()
+        fileMeta = pydicom.dataset.FileMetaDataset()
         fileMeta.MediaStorageSOPClassUID = pydicom._storage_sopclass_uids.MRImageStorage
         fileMeta.MediaStorageSOPInstanceUID = pydicom.uid.generate_uid()
         fileMeta.TransferSyntaxUID = pydicom.uid.ExplicitVRLittleEndian


### PR DESCRIPTION
- changed pytest config in _pyproject.toml_ to handle Warnings (e.g., DeprecationWarnings) as errors
- fixed the following warnings/errors in [Dicom2DTestImage](https://github.com/ckolbPTB/mrpro/blob/main/tests/data/_Dicom2DTestImage.py): 
`DeprecationWarning: Starting in pydicom 3.0, Dataset.file_meta must be a FileMetaDataset class instance`
`numpy.exceptions.ComplexWarning: Casting complex values to real discards the imaginary part`

closes #63 