### PR TITLE
Suggestions for Refactor of DCF/Trajectory Logic

### DIFF
--- a/src/mrpro/data/_AcqInfo.py
+++ b/src/mrpro/data/_AcqInfo.py
@@ -112,7 +112,7 @@ class AcqInfo:
 
         def spatialdimension(data):
             # all spatial dimensions are float32
-            return SpatialDimension[torch.Tensor].from_array(torch.tensor(data.astype(np.float32)))
+            return SpatialDimension[torch.Tensor].from_array_xyz(torch.tensor(data.astype(np.float32)))
 
         acq_idx = AcqIdx(
             k1=tensor(idx['kspace_encode_step_1']),

--- a/src/mrpro/data/_DcfData.py
+++ b/src/mrpro/data/_DcfData.py
@@ -21,11 +21,11 @@ from itertools import product
 
 import numpy as np
 import torch
-from mpro.utils import smap
 from scipy.spatial import ConvexHull
 from scipy.spatial import Voronoi
 
 from mrpro.data import KTrajectory
+from mrpro.utils import smap
 
 UNIQUE_ROUNDING_DECIMALS = 15
 

--- a/src/mrpro/data/_DcfData.py
+++ b/src/mrpro/data/_DcfData.py
@@ -103,10 +103,10 @@ class DcfData:
         Parameters
         ----------
         traj
-            torch.Tensor containing k-space points (d4, 2 or 3, k2, k1, k0).
+            torch.Tensor containing k-space points (other, 2 or 3, k2, k1, k0).
         """
 
-        ks = [traj.kx, traj.ky, traj.kz]
+        ks = [traj.kz, traj.ky, traj.kx]
         for i, k in enumerate(ks):
             if any(all(k.shape[ax] == 1 for ax in two_axes) for two_axes in [(-1, -2), (-1, -3), (-2, -3)]):
                 # Found a direction with at least two singleton dimensions, i.e. we have a 2D trajectory in 3D space

--- a/src/mrpro/data/_DcfData.py
+++ b/src/mrpro/data/_DcfData.py
@@ -13,9 +13,11 @@
 #   limitations under the License.
 
 from __future__ import annotations
+
 import dataclasses
 from concurrent.futures import ThreadPoolExecutor
 from itertools import product
+
 import numpy as np
 import torch
 from scipy.spatial import ConvexHull
@@ -108,7 +110,8 @@ class DcfData:
         for i, k in enumerate(ks):
             if any(all(k.shape[ax] == 1 for ax in two_axes) for two_axes in [(-1, -2), (-1, -3), (-2, -3)]):
                 # Found a direction with at least two singleton dimensions, i.e. we have a 2D trajectory in 3D space
-                # Remove this direction from the list of k-space points and calculate dcf for the remaining 2D trajectory
+                # Remove this direction from the list of k-space points and
+                # calculate dcf for the remaining 2D trajectory
                 ks.pop(i)
                 new_traj = torch.stack(torch.broadcast_tensors(*ks), 1)
                 dcf = torch.stack([DcfData._dcf_using_voronoi(t) for t in new_traj])

--- a/src/mrpro/data/_DcfData.py
+++ b/src/mrpro/data/_DcfData.py
@@ -15,7 +15,9 @@
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
+from functools import reduce
 from itertools import product
 
 import numpy as np
@@ -25,6 +27,8 @@ from scipy.spatial import Voronoi
 
 from mrpro.data import KTrajectory
 
+UNIQUE_ROUNDING_DECIMALS = 15
+
 
 @dataclasses.dataclass(slots=True, frozen=False)
 class DcfData:
@@ -33,7 +37,38 @@ class DcfData:
     data: torch.Tensor
 
     @staticmethod
-    def _dcf_using_voronoi(traj: torch.Tensor) -> torch.Tensor:
+    def _dcf_1d(traj: torch.Tensor) -> torch.Tensor:
+        """Calculate sample density compensation function for 1D trajectory.
+
+        Parameters
+        ----------
+        traj:
+            k-space positions, 1D tensor
+        """
+
+        traj_sorted, inverse, counts = torch.unique(
+            torch.round(traj, decimals=UNIQUE_ROUNDING_DECIMALS), sorted=True, return_inverse=True, return_counts=True
+        )
+
+        # For a sorted trajectory: x0 x1 x2 ... xN
+        # We assign the point at x0 the area (x1-x0) / 2 * 2
+        # We assign the point at x1 the area (x1-x0) / 2  + (x2-x1) / 2
+        # We assign the pint at xN the area (xN-XN-1) / 2 * 2
+        # This is done by central differences (-1,0,1). As the be complicated,
+        # we just append/prepend the correct values afterwards.
+
+        kernel = torch.tensor([-1 / 2, 0, 1 / 2], dtype=torch.float32, device=traj.device).reshape(1, 1, 3)
+        central_diff = torch.nn.functional.conv1d(traj_sorted[None, None, :], kernel)[0, 0]
+        first = traj_sorted[1] - traj_sorted[0]
+        last = traj_sorted[-1] - traj_sorted[-2]
+        central_diff = torch.cat((first[None], central_diff, last[None]), -1)
+
+        # Repeated points are reduced by the number of repeats
+        dcf = torch.nan_to_num(1 / (central_diff * counts))[inverse]
+        return dcf
+
+    @staticmethod
+    def _dcf_2d3d_voronoi(traj: torch.Tensor) -> torch.Tensor:
         """Calculate sample density compensation function using voronoi method.
 
         Points at the edge of k-space are detected as outliers and assigned the
@@ -48,10 +83,8 @@ class DcfData:
         -------
             density compensation values (1, k2, k1, k0)
         """
-        UNIQUE_ROUNDING_DECIMALS = 15
 
         # 2D and 3D trajectories supported
-
         dim = traj.shape[0]
         if dim not in (2, 3):
             raise ValueError(f'Only 2D or 3D trajectories supported, not {dim}D.')
@@ -74,7 +107,7 @@ class DcfData:
         regions = [vdiagram.regions[r] for r in vdiagram.point_region[: -len(corner_points)]]  # Ignore corner points
         vertices = [vdiagram.vertices[region] for region in regions]
 
-        # Calculate volume/area of voronoi cells
+        # Calculate volume/area of voronoi cells using threads (ConvexHull is thread safe and drops the GIL)
         future = ThreadPoolExecutor(max_workers=torch.get_num_threads()).map(lambda v: ConvexHull(v).volume, vertices)
         dcf = np.array(list(future))
 
@@ -106,19 +139,64 @@ class DcfData:
             torch.Tensor containing k-space points (other, 2 or 3, k2, k1, k0).
         """
 
-        ks = [traj.kz, traj.ky, traj.kx]
-        for i, k in enumerate(ks):
-            if any(all(k.shape[ax] == 1 for ax in two_axes) for two_axes in [(-1, -2), (-1, -3), (-2, -3)]):
-                # Found a direction with at least two singleton dimensions, i.e. we have a 2D trajectory in 3D space
-                # Remove this direction from the list of k-space points and
-                # calculate dcf for the remaining 2D trajectory
-                ks.pop(i)
-                new_traj = torch.stack(torch.broadcast_tensors(*ks), 1)
-                dcf = torch.stack([DcfData._dcf_using_voronoi(t) for t in new_traj])
-                dcf = dcf.expand(traj.broadcasted_shape)
-                break
-        else:
-            # Full 3D trajectory
-            dcf = torch.stack([DcfData._dcf_using_voronoi(t) for t in traj.as_tensor(1)])
-
+        ks_needing_voronoi = []
+        dcfs = []
+        for k in [traj.kz, traj.ky, traj.kx]:
+            non_singleton_dims = tuple(dim for dim in (-1, -2, -3) if k.shape[dim] != 1)
+            if len(non_singleton_dims) == 1:
+                # Found a direction with two singleton dimensions and one non-singleton dimension
+                # We can handle this as a 1D trajectory
+                dcfs.append(smap(DcfData._dcf_1d, k, non_singleton_dims))
+            elif len(non_singleton_dims) == 0:
+                # Found a direction with only singleton dimensions, i.e. constant dcf
+                dcfs.append(torch.ones_like(k))
+            else:
+                # A Full Dimension needing voronoi
+                ks_needing_voronoi.append(k)
+        if ks_needing_voronoi:
+            # Any full dimensions needing voronoi
+            dcfs.append(smap(DcfData._dcf_2d3d_voronoi, torch.stack(ks_needing_voronoi, -4), 4))
+        # Multiply all dcfs together
+        dcf = reduce(torch.mul, dcfs)
         return cls(data=dcf)
+
+
+def smap(
+    fun: Callable[[torch.Tensor], torch.Tensor], tensor: torch.Tensor, fun_dims: tuple[int, ...] | int = (-1,)
+) -> torch.Tensor:
+    """Apply a function to a tensor serially along multiple dimensions.
+
+    The function is applied serially without a batch dimensions.
+    Compared to torch.vmap, it works with arbitrary functions, but is slower.
+
+    Parameters
+    ----------
+    fun
+        Function to apply to the tensor.
+        Should handle len(fun_dims) dimensions and not change the number of dimensions.
+    tensor
+        Tensor to apply the function to.
+    fun_dims
+        Dimensions NOT to be batched / dimensions that are passed to the function
+        tuple of dimension indices (negative indices are supported) or an integer
+        an integer n means the last n dimensions are passed to the function
+    """
+    # TODO: Move to utilities
+    if isinstance(fun_dims, int):
+        # use the last fun_dims dimensions for the function
+        moved = tensor
+        first_fun_dim = -fun_dims
+    else:
+        # Move fun_dims to the end
+        fun_dims_dst = tuple(range(-len(fun_dims), 0))
+        moved = tensor.moveaxis(fun_dims, fun_dims_dst)
+        first_fun_dim = fun_dims_dst[0]
+
+    reshaped = moved.flatten(end_dim=first_fun_dim - 1)  # shape: (prod(batch_dims), fun_dim_1, ..., fun_dim_n)
+    result_reshaped = torch.stack([fun(x) for x in reshaped])
+    result = result_reshaped.reshape(moved.shape[:first_fun_dim] + result_reshaped.shape[1:])
+
+    if not isinstance(fun_dims, int):
+        # Move fun_dims back to their original position if we moved them
+        result = result.moveaxis(fun_dims_dst, fun_dims)
+    return result

--- a/src/mrpro/data/_DcfData.py
+++ b/src/mrpro/data/_DcfData.py
@@ -15,13 +15,13 @@
 from __future__ import annotations
 
 import dataclasses
-from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from functools import reduce
 from itertools import product
 
 import numpy as np
 import torch
+from mpro.utils import smap
 from scipy.spatial import ConvexHull
 from scipy.spatial import Voronoi
 
@@ -159,44 +159,3 @@ class DcfData:
         # Multiply all dcfs together
         dcf = reduce(torch.mul, dcfs)
         return cls(data=dcf)
-
-
-def smap(
-    fun: Callable[[torch.Tensor], torch.Tensor], tensor: torch.Tensor, fun_dims: tuple[int, ...] | int = (-1,)
-) -> torch.Tensor:
-    """Apply a function to a tensor serially along multiple dimensions.
-
-    The function is applied serially without a batch dimensions.
-    Compared to torch.vmap, it works with arbitrary functions, but is slower.
-
-    Parameters
-    ----------
-    fun
-        Function to apply to the tensor.
-        Should handle len(fun_dims) dimensions and not change the number of dimensions.
-    tensor
-        Tensor to apply the function to.
-    fun_dims
-        Dimensions NOT to be batched / dimensions that are passed to the function
-        tuple of dimension indices (negative indices are supported) or an integer
-        an integer n means the last n dimensions are passed to the function
-    """
-    # TODO: Move to utilities
-    if isinstance(fun_dims, int):
-        # use the last fun_dims dimensions for the function
-        moved = tensor
-        first_fun_dim = -fun_dims
-    else:
-        # Move fun_dims to the end
-        fun_dims_dst = tuple(range(-len(fun_dims), 0))
-        moved = tensor.moveaxis(fun_dims, fun_dims_dst)
-        first_fun_dim = fun_dims_dst[0]
-
-    reshaped = moved.flatten(end_dim=first_fun_dim - 1)  # shape: (prod(batch_dims), fun_dim_1, ..., fun_dim_n)
-    result_reshaped = torch.stack([fun(x) for x in reshaped])
-    result = result_reshaped.reshape(moved.shape[:first_fun_dim] + result_reshaped.shape[1:])
-
-    if not isinstance(fun_dims, int):
-        # Move fun_dims back to their original position if we moved them
-        result = result.moveaxis(fun_dims_dst, fun_dims)
-    return result

--- a/src/mrpro/data/_KData.py
+++ b/src/mrpro/data/_KData.py
@@ -27,7 +27,7 @@ from einops import rearrange
 from mrpro.data import AcqInfo
 from mrpro.data import KHeader
 from mrpro.data import KTrajectory
-from mrpro.data._EncodingLimits import Limits
+from mrpro.data import Limits
 from mrpro.data.enums import AcqFlags
 from mrpro.data.traj_calculators import KTrajectoryCalculator
 

--- a/src/mrpro/data/_KHeader.py
+++ b/src/mrpro/data/_KHeader.py
@@ -30,7 +30,7 @@ from mrpro.data import TrajectoryDescription
 from mrpro.data import enums
 
 if TYPE_CHECKING:
-    # avoid circular imports by importing onlz when type checking
+    # avoid circular imports by importing only when type checking
     from mrpro.data.traj_calculators import KTrajectoryCalculator
 
 UNKNOWN = 'unknown'

--- a/src/mrpro/data/_KHeader.py
+++ b/src/mrpro/data/_KHeader.py
@@ -31,7 +31,7 @@ from mrpro.data import enums
 
 if TYPE_CHECKING:
     # avoid circular imports by importing onlz when type checking
-    from mrpro.data.traj_calculators import KTrajectory
+    from mrpro.data.traj_calculators import KTrajectoryCalculator
 
 UNKNOWN = 'unknown'
 
@@ -46,7 +46,7 @@ class KHeader:
     is not guaranteed to be correct or tested.
     """
 
-    trajectory: KTrajectory
+    trajectory: KTrajectoryCalculator
     b0: float
     encoding_limits: EncodingLimits
     # acc_factor: AccelerationFactor # TODO: decide if we want to keep this

--- a/src/mrpro/data/_KTrajectory.py
+++ b/src/mrpro/data/_KTrajectory.py
@@ -78,10 +78,10 @@ class KTrajectory:
 
         try:
             shape = self.broadcasted_shape
-            if len(shape) != 4:
-                raise ValueError('The k-space trajectory tensors should each have 4 dimensions.')
         except ValueError:
             raise ValueError('The k-space trajectory dimensions must be broadcastable.')
+        if len(shape) != 4:
+            raise ValueError('The k-space trajectory tensors should each have 4 dimensions.')
 
     @classmethod
     def from_tensor(
@@ -105,7 +105,7 @@ class KTrajectory:
             Set to None to disable.
         """
 
-        kz, ky, kx = torch.split(tensor, 1, dim=stack_dim)
+        kz, ky, kx = torch.unbind(tensor, dim=stack_dim)
         return cls(kz, ky, kx, repeat_detection_tolerance=repeat_detection_tolerance)
 
     @staticmethod

--- a/src/mrpro/data/_KTrajectory.py
+++ b/src/mrpro/data/_KTrajectory.py
@@ -1,0 +1,65 @@
+"""KTrajectory dataclass."""
+
+# Copyright 2023 Physikalisch-Technische Bundesanstalt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from __future__ import annotations
+from dataclasses import dataclass
+import torch
+import numpy as np
+
+
+@dataclass(slots=True)
+class KTrajectory:
+    """k-space trajectory"""
+
+    kx: torch.Tensor
+    ky: torch.Tensor
+    kz: torch.Tensor
+
+    @property
+    def broadcasted_shape(self) -> tuple[int, ...]:
+        """The broadcasted shape of the trajectory."""
+        shape = np.broadcast_shapes(self.kx.shape, self.ky.shape, self.kz.shape)
+        return tuple(shape)
+
+    def as_tensor(self, stack_dim=0):
+        """A tensor representation of the trajectory.
+
+        Parameters
+        ----------
+        stack_dim:
+            The dimension to stack the tensor along.
+        """
+        shape = self.broadcasted_shape
+        return torch.stack([traj.expand(*shape) for traj in (self.kx, self.ky, self.kz)], dim=stack_dim)
+
+    @classmethod
+    def from_tensor(cls, tensor: torch.Tensor, stack_dim=0) -> KTrajectory:
+        """Create a KTrajectory from a tensor representation of the trajectory.
+
+        Parameters
+        ----------
+        tensor:
+            The tensor representation of the trajectory.
+        stack_dim:
+            The dimension in the tensor the directions have been stacked along.
+        """
+        return cls(*torch.split(tensor, 1, dim=stack_dim))
+
+    def __post_init__(self):
+        try:
+            shape = self.broadcasted_shape
+            if len(shape) != 4:
+                raise ValueError("The k-space trajectory tensors should each have 4 dimensions.")
+        except ValueError:
+            raise ValueError("The k-space trajectory dimensions must be broadcastable.")

--- a/src/mrpro/data/_KTrajectory.py
+++ b/src/mrpro/data/_KTrajectory.py
@@ -20,13 +20,23 @@ import numpy as np
 import torch
 
 
-@dataclass(slots=True)
+@dataclass(slots=True, init=False)
 class KTrajectory:
-    """K-space trajectory."""
+    """K-space trajectory.
 
-    kx: torch.Tensor
-    ky: torch.Tensor
-    kz: torch.Tensor
+    Order of directions is always kz, ky, kx
+    Shape of each of kx,ky,kz is (other,k2,k1,k0)
+
+    Example for 2D-Cartesian Trajectories:
+        kx changes along k0 and is Frequency Encoding
+        ky changes along k2 and is Phase Encoding
+        kz is zero(1,1,1,1)
+
+    """
+
+    kz: torch.Tensor  # (other,k2,k1,k0) #Phase Encoding direction, k2 if Cartesian
+    ky: torch.Tensor  # (other,k2,k1,k0) #Phase Encoding direction, k1 if Cartesian
+    kx: torch.Tensor  # (other,k2,k1,k0) #Frequency Encoding direction, k0 if Cartesian
 
     @property
     def broadcasted_shape(self) -> tuple[int, ...]:
@@ -43,25 +53,87 @@ class KTrajectory:
             The dimension to stack the tensor along.
         """
         shape = self.broadcasted_shape
-        return torch.stack([traj.expand(*shape) for traj in (self.kx, self.ky, self.kz)], dim=stack_dim)
+        return torch.stack([traj.expand(*shape) for traj in (self.kz, self.ky, self.kx)], dim=stack_dim)
 
-    @classmethod
-    def from_tensor(cls, tensor: torch.Tensor, stack_dim=0) -> KTrajectory:
-        """Create a KTrajectory from a tensor representation of the trajectory.
+    def __init__(
+        self, kz: torch.Tensor, ky: torch.Tensor, kx: torch.Tensor, repeat_detection_tolerance: float | None = 1e-8
+    ):
+        """K-Space Trajectory dataclass
+
+        Reduces repeated dimensions to singletons if repeat_detection_tolerance
+        is not set to None.
 
         Parameters
         ----------
-        tensor:
-            The tensor representation of the trajectory.
-        stack_dim:
-            The dimension in the tensor the directions have been stacked along.
+        kz, ky, kx:
+            Trajectory coordinates to set
+        repeat_detection_tolerance:
+            Tolerance for repeat detection. Set to None to disable.
         """
-        return cls(*torch.split(tensor, 1, dim=stack_dim))
+        if repeat_detection_tolerance is not None:
+            kz, ky, kx = (KTrajectory._remove_repeat(tensor, repeat_detection_tolerance) for tensor in (kz, ky, kx))
 
-    def __post_init__(self):
+        self.kz = kz
+        self.ky = ky
+        self.kx = kx
+
         try:
             shape = self.broadcasted_shape
             if len(shape) != 4:
                 raise ValueError('The k-space trajectory tensors should each have 4 dimensions.')
         except ValueError:
             raise ValueError('The k-space trajectory dimensions must be broadcastable.')
+
+    @classmethod
+    def from_tensor(
+        cls, tensor: torch.Tensor, stack_dim: int = 0, repeat_detection_tolerance: float | None = 1e-8
+    ) -> KTrajectory:
+        """Create a KTrajectory from a tensor representation of the trajectory.
+
+        Reduces repeated dimensions to singletons if repeat_detection_tolerance
+        is not set to None.
+
+
+        Parameters
+        ----------
+        tensor:
+            The tensor representation of the trajectory.
+            This should be a 5-dim tensor, with (kz,ky,kx) stacked in this order along stack_dim
+        stack_dim:
+            The dimension in the tensor the directions have been stacked along.
+        repeat_detection_tolerance:
+            detects if broadcasting can be used, i.e. if dimensions are repeated.
+            Set to None to disable.
+
+        """
+
+        split_ks = torch.split(tensor, 1, dim=stack_dim)
+
+        if repeat_detection_tolerance is not None:
+            split_ks = (KTrajectory._remove_repeat(tensor, repeat_detection_tolerance) for tensor in split_ks)
+
+        return cls(*split_ks)
+
+    @staticmethod
+    def _remove_repeat(tensor: torch.Tensor, tol: float):
+        """Replace dimensions with all equal values with singletons
+
+        Parameters
+        ----------
+        tensor:
+            The tensor. Must be real
+        tol:
+            The tolerance
+
+
+        """
+        # TODO: Move to utilities
+
+        def can_be_singleton(dim: int) -> bool:
+            # If the distance between min and max is smaller than the tolerance, all values are the same.
+            return torch.all((tensor.amax(dim=dim) - tensor.amin(dim=dim)) <= tol).item()
+
+        take_first = slice(0, 1)
+        take_all = slice(None)
+        index = tuple(take_first if can_be_singleton(dim) else take_all for dim in range(tensor.ndim))
+        return tensor[index]

--- a/src/mrpro/data/_KTrajectory.py
+++ b/src/mrpro/data/_KTrajectory.py
@@ -33,9 +33,9 @@ class KTrajectory:
         kz is zero(1,1,1,1)
     """
 
-    kz: torch.Tensor  # (other,k2,k1,k0) #Phase Encoding direction, k2 if Cartesian
-    ky: torch.Tensor  # (other,k2,k1,k0) #Phase Encoding direction, k1 if Cartesian
-    kx: torch.Tensor  # (other,k2,k1,k0) #Frequency Encoding direction, k0 if Cartesian
+    kz: torch.Tensor  # (other,k2,k1,k0) #phase encoding direction, k2 if Cartesian
+    ky: torch.Tensor  # (other,k2,k1,k0) #phase encoding direction, k1 if Cartesian
+    kx: torch.Tensor  # (other,k2,k1,k0) #frequency encoding direction, k0 if Cartesian
 
     @property
     def broadcasted_shape(self) -> tuple[int, ...]:

--- a/src/mrpro/data/_KTrajectory.py
+++ b/src/mrpro/data/_KTrajectory.py
@@ -31,7 +31,6 @@ class KTrajectory:
         kx changes along k0 and is Frequency Encoding
         ky changes along k2 and is Phase Encoding
         kz is zero(1,1,1,1)
-
     """
 
     kz: torch.Tensor  # (other,k2,k1,k0) #Phase Encoding direction, k2 if Cartesian
@@ -58,7 +57,7 @@ class KTrajectory:
     def __init__(
         self, kz: torch.Tensor, ky: torch.Tensor, kx: torch.Tensor, repeat_detection_tolerance: float | None = 1e-8
     ):
-        """K-Space Trajectory dataclass
+        """K-Space Trajectory dataclass.
 
         Reduces repeated dimensions to singletons if repeat_detection_tolerance
         is not set to None.
@@ -104,19 +103,14 @@ class KTrajectory:
         repeat_detection_tolerance:
             detects if broadcasting can be used, i.e. if dimensions are repeated.
             Set to None to disable.
-
         """
 
-        split_ks = torch.split(tensor, 1, dim=stack_dim)
-
-        if repeat_detection_tolerance is not None:
-            split_ks = (KTrajectory._remove_repeat(tensor, repeat_detection_tolerance) for tensor in split_ks)
-
-        return cls(*split_ks)
+        kz, ky, kx = torch.split(tensor, 1, dim=stack_dim)
+        return cls(kz, ky, kx, repeat_detection_tolerance=repeat_detection_tolerance)
 
     @staticmethod
-    def _remove_repeat(tensor: torch.Tensor, tol: float):
-        """Replace dimensions with all equal values with singletons
+    def _remove_repeat(tensor: torch.Tensor, tol: float) -> torch.Tensor:
+        """Replace dimensions with all equal values with singletons.
 
         Parameters
         ----------
@@ -124,14 +118,12 @@ class KTrajectory:
             The tensor. Must be real
         tol:
             The tolerance
-
-
         """
         # TODO: Move to utilities
 
         def can_be_singleton(dim: int) -> bool:
             # If the distance between min and max is smaller than the tolerance, all values are the same.
-            return torch.all((tensor.amax(dim=dim) - tensor.amin(dim=dim)) <= tol).item()
+            return bool(torch.all((tensor.amax(dim=dim) - tensor.amin(dim=dim)) <= tol).item())
 
         take_first = slice(0, 1)
         take_all = slice(None)

--- a/src/mrpro/data/_KTrajectory.py
+++ b/src/mrpro/data/_KTrajectory.py
@@ -13,14 +13,16 @@
 #   limitations under the License.
 
 from __future__ import annotations
+
 from dataclasses import dataclass
-import torch
+
 import numpy as np
+import torch
 
 
 @dataclass(slots=True)
 class KTrajectory:
-    """k-space trajectory"""
+    """K-space trajectory."""
 
     kx: torch.Tensor
     ky: torch.Tensor
@@ -33,7 +35,7 @@ class KTrajectory:
         return tuple(shape)
 
     def as_tensor(self, stack_dim=0):
-        """A tensor representation of the trajectory.
+        """Tensor representation of the trajectory.
 
         Parameters
         ----------
@@ -60,6 +62,6 @@ class KTrajectory:
         try:
             shape = self.broadcasted_shape
             if len(shape) != 4:
-                raise ValueError("The k-space trajectory tensors should each have 4 dimensions.")
+                raise ValueError('The k-space trajectory tensors should each have 4 dimensions.')
         except ValueError:
-            raise ValueError("The k-space trajectory dimensions must be broadcastable.")
+            raise ValueError('The k-space trajectory dimensions must be broadcastable.')

--- a/src/mrpro/data/_SpatialDimension.py
+++ b/src/mrpro/data/_SpatialDimension.py
@@ -35,7 +35,7 @@ class XYZ(Protocol[T]):
 
 @dataclass(slots=True)
 class SpatialDimension(Generic[T]):
-    """Spatial dataclass of float/int/tensors (z, y, x)"""
+    """Spatial dataclass of float/int/tensors (z, y, x)."""
 
     z: T
     y: T

--- a/src/mrpro/data/_SpatialDimension.py
+++ b/src/mrpro/data/_SpatialDimension.py
@@ -35,11 +35,11 @@ class XYZ(Protocol[T]):
 
 @dataclass(slots=True)
 class SpatialDimension(Generic[T]):
-    """Spatial dataclass."""
+    """Spatial dataclass of float/int/tensors (z, y, x)"""
 
-    x: T
-    y: T
     z: T
+    y: T
+    x: T
 
     @classmethod
     def from_xyz(cls, data: XYZ[T], conversion: Callable[[T], T] | None = None) -> SpatialDimension[T]:
@@ -53,11 +53,11 @@ class SpatialDimension(Generic[T]):
             will be called for each value to convert it
         """
         if conversion is not None:
-            return cls(conversion(data.x), conversion(data.y), conversion(data.z))
-        return cls(data.x, data.y, data.z)
+            return cls(conversion(data.z), conversion(data.y), conversion(data.x))
+        return cls(data.z, data.y, data.x)
 
     @staticmethod
-    def from_array(
+    def from_array_xyz(
         data: ArrayLike,
         conversion: Callable[[torch.Tensor], torch.Tensor] | None = None,
     ) -> SpatialDimension[torch.Tensor]:
@@ -66,7 +66,7 @@ class SpatialDimension(Generic[T]):
         Parameters
         ----------
         data:
-            shape (..., 3)
+            shape (..., 3) in the order (x,y,z)
         conversion, optional:
             will be called for each value to convert it, by default None
         """
@@ -84,4 +84,4 @@ class SpatialDimension(Generic[T]):
             x = conversion(x)
             y = conversion(y)
             z = conversion(z)
-        return SpatialDimension(x, y, z)
+        return SpatialDimension(z, y, x)

--- a/src/mrpro/data/__init__.py
+++ b/src/mrpro/data/__init__.py
@@ -5,6 +5,7 @@ from mrpro.data._TrajectoryDescription import TrajectoryDescription
 # from mrpro.data._AccelerationFactor import AccelerationFactor
 from mrpro.data._AcqInfo import AcqIdx
 from mrpro.data._AcqInfo import AcqInfo
+from mrpro.data._KTrajectory import KTrajectory
 from mrpro.data._EncodingLimits import EncodingLimits
 from mrpro.data._KHeader import KHeader
 from mrpro.data._KData import KData

--- a/src/mrpro/data/__init__.py
+++ b/src/mrpro/data/__init__.py
@@ -1,12 +1,11 @@
 import mrpro.data.enums
 from mrpro.data._SpatialDimension import SpatialDimension
 from mrpro.data._TrajectoryDescription import TrajectoryDescription
-
-# from mrpro.data._AccelerationFactor import AccelerationFactor
 from mrpro.data._AcqInfo import AcqIdx
 from mrpro.data._AcqInfo import AcqInfo
 from mrpro.data._KTrajectory import KTrajectory
 from mrpro.data._EncodingLimits import EncodingLimits
+from mrpro.data._EncodingLimits import Limits
 from mrpro.data._KHeader import KHeader
 from mrpro.data._KData import KData
 from mrpro.data._IHeader import IHeader

--- a/src/mrpro/data/traj_calculators/_KTrajectoryCalculator.py
+++ b/src/mrpro/data/traj_calculators/_KTrajectoryCalculator.py
@@ -19,8 +19,8 @@ from abc import abstractmethod
 
 import torch
 
-from mrpro.data._KHeader import KHeader
-from mrpro.data._KTrajectory import KTrajectory
+from mrpro.data import KHeader
+from mrpro.data import KTrajectory
 
 
 class KTrajectoryCalculator(ABC):

--- a/src/mrpro/data/traj_calculators/_KTrajectoryCalculator.py
+++ b/src/mrpro/data/traj_calculators/_KTrajectoryCalculator.py
@@ -30,8 +30,8 @@ class KTrajectoryCalculator(ABC):
     def __call__(self, header: KHeader) -> KTrajectory:
         """Calculate the trajectory for given KHeader.
 
-        The shape of the calculated trajectory must be broadcastable to
-        (prod(all_other_dimensions), 3, k2, k1, k0)
+        The shapes of kz, ky and kx of the calculated trajectory must be
+        broadcastable to (prod(all_other_dimensions), k2, k1, k0).
         """
         ...
 
@@ -39,10 +39,11 @@ class KTrajectoryCalculator(ABC):
 class DummyTrajectory(KTrajectoryCalculator):
     """Simple Dummy trajectory that returns zeros.
 
-    Shape will not fit to all data. Only used as dummy for testing.
+    Shape will fit to all data. Only used as dummy for testing.
     """
 
     def __call__(self, header: KHeader) -> KTrajectory:
         """Calculate dummy trajectory for given KHeader."""
-        kx = ky = kz = torch.zeros(1, 1, 1, header.encoding_limits.k0.length)
-        return KTrajectory(kx, ky, kz)
+        kx = torch.zeros(1, 1, 1, header.encoding_limits.k0.length)
+        ky = kz = torch.zeros(1, 1, 1, 1)
+        return KTrajectory(kz, ky, kx)

--- a/src/mrpro/data/traj_calculators/_KTrajectoryCalculator.py
+++ b/src/mrpro/data/traj_calculators/_KTrajectoryCalculator.py
@@ -13,16 +13,14 @@
 #   limitations under the License.
 
 from __future__ import annotations
-from mrpro.data._KTrajectory import KTrajectory
 
-import dataclasses
 from abc import ABC
 from abc import abstractmethod
 
-import numpy as np
 import torch
 
 from mrpro.data._KHeader import KHeader
+from mrpro.data._KTrajectory import KTrajectory
 
 
 class KTrajectoryCalculator(ABC):

--- a/src/mrpro/data/traj_calculators/_KTrajectoryRpe.py
+++ b/src/mrpro/data/traj_calculators/_KTrajectoryRpe.py
@@ -170,7 +170,7 @@ class KTrajectoryRpe(KTrajectoryCalculator):
         # K-space locations along phase encoding lines
         krad = self._krad(kheader)
 
-        kz = (krad * torch.cos(kang))[..., None]
-        ky = (krad * torch.sin(kang))[..., None]
+        kz = (krad * torch.sin(kang))[..., None]
+        ky = (krad * torch.cos(kang))[..., None]
         kx = kfreq[None, None, None, :]
         return KTrajectory(kz, ky, kx)

--- a/src/mrpro/data/traj_calculators/_KTrajectoryRpe.py
+++ b/src/mrpro/data/traj_calculators/_KTrajectoryRpe.py
@@ -170,7 +170,7 @@ class KTrajectoryRpe(KTrajectoryCalculator):
         # K-space locations along phase encoding lines
         krad = self._krad(kheader)
 
-        kx = (krad * torch.cos(kang))[..., None]
+        kz = (krad * torch.cos(kang))[..., None]
         ky = (krad * torch.sin(kang))[..., None]
-        kz = kfreq[None, None, None, :]
+        kx = kfreq[None, None, None, :]
         return KTrajectory(kz, ky, kx)

--- a/src/mrpro/data/traj_calculators/_KTrajectoryRpe.py
+++ b/src/mrpro/data/traj_calculators/_KTrajectoryRpe.py
@@ -82,7 +82,7 @@ class KTrajectoryRpe(KTrajectoryCalculator):
             krad[curr_angle_idx] = curr_krad
         return krad
 
-    def _k0(self, kheader: KHeader):
+    def _kfreq(self, kheader: KHeader):
         """Calculate the trajectory along one readout (k0 dimension).
 
         Parameters
@@ -162,7 +162,7 @@ class KTrajectoryRpe(KTrajectoryCalculator):
         """
 
         # Trajectory along readout
-        k0 = self._k0(kheader)
+        kfreq = self._kfreq(kheader)
 
         # Angles of phase encoding lines
         kang = self._kang(kheader)
@@ -172,5 +172,5 @@ class KTrajectoryRpe(KTrajectoryCalculator):
 
         kx = (krad * torch.cos(kang))[..., None]
         ky = (krad * torch.sin(kang))[..., None]
-        kz = k0[None, None, None, :]
-        return KTrajectory(kx, ky, kz)
+        kz = kfreq[None, None, None, :]
+        return KTrajectory(kz, ky, kx)

--- a/src/mrpro/data/traj_calculators/__init__.py
+++ b/src/mrpro/data/traj_calculators/__init__.py
@@ -1,3 +1,3 @@
-from mrpro.data.traj_calculators._KTrajectory import KTrajectory
+from mrpro.data.traj_calculators._KTrajectoryCalculator import KTrajectoryCalculator
 from mrpro.data.traj_calculators._KTrajectoryRpe import KTrajectoryRpe
 from mrpro.data.traj_calculators._KTrajectorySunflowerGoldenRpe import KTrajectorySunflowerGoldenRpe

--- a/src/mrpro/phantoms/_EllipsePhantom.py
+++ b/src/mrpro/phantoms/_EllipsePhantom.py
@@ -37,7 +37,7 @@ class EllipsePhantom:
     ):
         self.ellipses: list[EllipsePars] = ellipses
 
-    def kspace(self, kx: np.ndarray, ky: np.ndarray):
+    def kspace(self, ky: np.ndarray, kx: np.ndarray):
         """Create 2D analytic kspace data based on given k-space locations.
 
         For a corresponding image with 256 x 256 voxel, the k-space locations should be defined within [-128, 127]
@@ -47,10 +47,10 @@ class EllipsePhantom:
 
         Parameters
         ----------
-        kx
-            k-space locations in kx
         ky
-            k-space loations in ky. Same shape as kx.
+            k-space locations in ky
+        kx
+            k-space loations in kx (Frequency Encoding Direction). Same shape as ky.
         """
         # kx and ky have to be of same shape
         if kx.shape != ky.shape:
@@ -71,15 +71,15 @@ class EllipsePhantom:
         kdat *= np.sqrt(kdat.size)
         return kdat
 
-    def image_space(self, nx: int, ny: int):
+    def image_space(self, ny: int, nx: int):
         """Create image representation of phantom.
 
         Parameters
         ----------
-        nx
-            Number of voxel along x direction
         ny
             Number of voxel along y direction
+        nx
+            Number of voxel along x direction
         """
         # Calculate image representation of phantom
         ix_idx = range(-nx // 2, nx // 2)

--- a/src/mrpro/phantoms/_EllipsePhantom.py
+++ b/src/mrpro/phantoms/_EllipsePhantom.py
@@ -50,7 +50,7 @@ class EllipsePhantom:
         ky
             k-space locations in ky
         kx
-            k-space loations in kx (Frequency Encoding Direction). Same shape as ky.
+            k-space locations in kx (frequency encoding direction). Same shape as ky.
         """
         # kx and ky have to be of same shape
         if kx.shape != ky.shape:

--- a/src/mrpro/utils/__init__.py
+++ b/src/mrpro/utils/__init__.py
@@ -1,2 +1,3 @@
 from mrpro.utils._smap import smap
 from mrpro.utils._remove_repeat import remove_repeat
+from mrpro.utils._rgetattr import rgetattr

--- a/src/mrpro/utils/__init__.py
+++ b/src/mrpro/utils/__init__.py
@@ -1,0 +1,2 @@
+from mrpro.utils._smap import smap
+from mrpro.utils._remove_repeat import remove_repeat

--- a/src/mrpro/utils/_remove_repeat.py
+++ b/src/mrpro/utils/_remove_repeat.py
@@ -1,4 +1,4 @@
-"""remove_repeat utility function"""
+"""remove_repeat utility function."""
 
 # Copyright 2023 Physikalisch-Technische Bundesanstalt
 #

--- a/src/mrpro/utils/_remove_repeat.py
+++ b/src/mrpro/utils/_remove_repeat.py
@@ -1,0 +1,36 @@
+"""remove_repeat utility function"""
+
+# Copyright 2023 Physikalisch-Technische Bundesanstalt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import torch
+
+
+def remove_repeat(tensor: torch.Tensor, tol: float) -> torch.Tensor:
+    """Replace dimensions with all equal values with singletons.
+
+    Parameters
+    ----------
+    tensor:
+        The tensor. Must be real
+    tol:
+        The tolerance
+    """
+
+    def can_be_singleton(dim: int) -> bool:
+        # If the distance between min and max is smaller than the tolerance, all values are the same.
+        return bool(torch.all((tensor.amax(dim=dim) - tensor.amin(dim=dim)) <= tol).item())
+
+    take_first = slice(0, 1)
+    take_all = slice(None)
+    index = tuple(take_first if can_be_singleton(dim) else take_all for dim in range(tensor.ndim))
+    return tensor[index]

--- a/src/mrpro/utils/_rgetattr.py
+++ b/src/mrpro/utils/_rgetattr.py
@@ -1,4 +1,4 @@
-"""Utility functions for data handling."""
+"""Recursive getattr."""
 
 # Copyright 2023 Physikalisch-Technische Bundesanstalt
 #
@@ -12,20 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from __future__ import annotations
-
 import functools
-
-import ismrmrd.xsd.ismrmrdschema.ismrmrd as ismrmrdschema
-
-
-def return_coil_label_dict(
-    coil_label: list[ismrmrdschema.coilLabelType],
-) -> dict:
-    coil_label_dict = {}
-    for idx, label in enumerate(coil_label):
-        coil_label_dict[idx] = [label.coilNumber, label.coilName]
-    return coil_label_dict
 
 
 def rgetattr(obj, attr, *args):

--- a/src/mrpro/utils/_smap.py
+++ b/src/mrpro/utils/_smap.py
@@ -1,4 +1,4 @@
-"""smap utility function"""
+"""Smap utility function."""
 
 # Copyright 2023 Physikalisch-Technische Bundesanstalt
 #
@@ -12,8 +12,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+from collections.abc import Callable
+
 import torch
-from typing import Callable
 
 
 def smap(

--- a/src/mrpro/utils/_smap.py
+++ b/src/mrpro/utils/_smap.py
@@ -1,0 +1,56 @@
+"""smap utility function"""
+
+# Copyright 2023 Physikalisch-Technische Bundesanstalt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import torch
+from typing import Callable
+
+
+def smap(
+    fun: Callable[[torch.Tensor], torch.Tensor], tensor: torch.Tensor, fun_dims: tuple[int, ...] | int = (-1,)
+) -> torch.Tensor:
+    """Apply a function to a tensor serially along multiple dimensions.
+
+    The function is applied serially without a batch dimensions.
+    Compared to torch.vmap, it works with arbitrary functions, but is slower.
+
+    Parameters
+    ----------
+    fun
+        Function to apply to the tensor.
+        Should handle len(fun_dims) dimensions and not change the number of dimensions.
+    tensor
+        Tensor to apply the function to.
+    fun_dims
+        Dimensions NOT to be batched / dimensions that are passed to the function
+        tuple of dimension indices (negative indices are supported) or an integer
+        an integer n means the last n dimensions are passed to the function
+    """
+    if isinstance(fun_dims, int):
+        # use the last fun_dims dimensions for the function
+        moved = tensor
+        first_fun_dim = -fun_dims
+    else:
+        # Move fun_dims to the end
+        fun_dims_dst = tuple(range(-len(fun_dims), 0))
+        moved = tensor.moveaxis(fun_dims, fun_dims_dst)
+        first_fun_dim = fun_dims_dst[0]
+
+    reshaped = moved.flatten(end_dim=first_fun_dim - 1)  # shape: (prod(batch_dims), fun_dim_1, ..., fun_dim_n)
+    result_reshaped = torch.stack([fun(x) for x in reshaped])
+    result = result_reshaped.reshape(moved.shape[:first_fun_dim] + result_reshaped.shape[1:])
+
+    if not isinstance(fun_dims, int):
+        # Move fun_dims back to their original position if we moved them
+        result = result.moveaxis(fun_dims_dst, fun_dims)
+    return result

--- a/tests/data/_IsmrmrdRawTestData.py
+++ b/tests/data/_IsmrmrdRawTestData.py
@@ -102,8 +102,8 @@ class IsmrmrdRawTestData:
         [kx, ky] = np.meshgrid(kx_idx, ky_idx)
 
         # Create analytic k-space and reference image
-        ktrue = self.phantom.kspace(kx, ky)
-        self.imref = self.phantom.image_space(nkx, nky)
+        ktrue = self.phantom.kspace(ky, kx)
+        self.imref = self.phantom.image_space(nky, nkx)
 
         # Multi-coil acquisition
         # TODO: proper application of coils

--- a/tests/data/conftest.py
+++ b/tests/data/conftest.py
@@ -175,16 +175,16 @@ def random_kheader(request, random_full_ismrmrd_header, random_acq_info):
     return kheader
 
 
-@pytest.fixture(params=({'seed': 0, 'Nd4': 2, 'Ncoils': 16, 'Nz': 32, 'Ny': 128, 'Nx': 256},))
+@pytest.fixture(params=({'seed': 0, 'Nother': 2, 'Ncoils': 16, 'Nz': 32, 'Ny': 128, 'Nx': 256},))
 def random_test_data(request):
-    seed, Nd4, Ncoils, Nz, Ny, Nx = (
+    seed, Nother, Ncoils, Nz, Ny, Nx = (
         request.param['seed'],
-        request.param['Nd4'],
+        request.param['Nother'],
         request.param['Ncoils'],
         request.param['Nz'],
         request.param['Ny'],
         request.param['Nx'],
     )
     generator = RandomGenerator(seed)
-    test_data = generate_random_data(generator, (Nd4, Ncoils, Nz, Ny, Nx))
+    test_data = generate_random_data(generator, (Nother, Ncoils, Nz, Ny, Nx))
     return test_data

--- a/tests/data/test_dcf_data.py
+++ b/tests/data/test_dcf_data.py
@@ -26,7 +26,7 @@ def example_traj_rpe(nkr, nka, nk0):
     kx = (torch.cos(kang[:, None]) * krad[None, :])[None, :, :, None]
     ky = (torch.sin(kang[:, None]) * krad[None, :])[None, :, :, None]
     kz = (torch.linspace(-nk0 // 2, nk0 // 2 - 1, nk0) / nk0)[None, None, None, :]
-    ktraj = KTrajectory(kx, ky, kz)
+    ktraj = KTrajectory(kz, ky, kx)
     return ktraj
 
 
@@ -37,7 +37,7 @@ def example_traj_rad_2d(nkr, nka):
     kx = (torch.cos(kang[:, None]) * krad[None, :])[None, None, :, :]
     ky = (torch.sin(kang[:, None]) * krad[None, :])[None, None, :, :]
     kz = torch.zeros(1, 1, 1, 1)
-    ktraj = KTrajectory(kx, ky, kz)
+    ktraj = KTrajectory(kz, ky, kx)
     return ktraj
 
 

--- a/tests/data/test_dcf_data.py
+++ b/tests/data/test_dcf_data.py
@@ -16,25 +16,29 @@ import torch
 from einops import rearrange
 
 from mrpro.data import DcfData
+from mrpro.data import KTrajectory
+
+
+def example_traj_rpe(nkr, nka, nk0):
+    """Create RPE trajectory with uniform angular gap."""
+    krad = torch.linspace(-nkr // 2, nkr // 2 - 1, nkr) / nkr
+    kang = torch.linspace(0, nka - 1, nka) * (torch.pi / nka)
+    kx = (torch.cos(kang[:, None]) * krad[None, :])[None, :, :, None]
+    ky = (torch.sin(kang[:, None]) * krad[None, :])[None, :, :, None]
+    kz = (torch.linspace(-nk0 // 2, nk0 // 2 - 1, nk0) / nk0)[None, None, None, :]
+    ktraj = KTrajectory(kx, ky, kz)
+    return ktraj
 
 
 def example_traj_rad_2d(nkr, nka):
     """Create 2D radial trajectory with uniform angular gap."""
     krad = torch.linspace(-nkr // 2, nkr // 2 - 1, nkr) / nkr
     kang = torch.linspace(0, nka - 1, nka) * (torch.pi / nka)
-    kx = torch.matmul(torch.cos(kang[:, None]), krad[None, :])[None, None, None, :, :]
-    ky = torch.matmul(torch.sin(kang[:, None]), krad[None, :])[None, None, None, :, :]
-    ktraj = torch.concatenate((kx, ky), dim=1)
+    kx = (torch.cos(kang[:, None]) * krad[None, :])[None, None, :, :]
+    ky = (torch.sin(kang[:, None]) * krad[None, :])[None, None, :, :]
+    kz = torch.zeros(1, 1, 1, 1)
+    ktraj = KTrajectory(kx, ky, kz)
     return ktraj
-
-
-def example_traj_rpe(nkr, nka, nk0):
-    """Create RPE trajectory with uniform angular gap."""
-    ktraj = example_traj_rad_2d(nkr, nka)
-    ktraj = torch.repeat_interleave(ktraj[:, :, 0, :, :, None], nk0, dim=4)
-    k0 = torch.linspace(-nk0 // 2, nk0 // 2 - 1, nk0) / nk0
-    k0 = torch.tile(k0[None, None, None, None, :], dims=[1, 1, nka, nkr, 1])
-    return torch.cat((k0, ktraj), dim=1)
 
 
 def test_dcf_2d_rad_traj_voronoi():
@@ -49,13 +53,13 @@ def test_dcf_2d_rad_traj_voronoi():
     krad_idx = torch.linspace(-nkr // 2, nkr // 2 - 1, nkr)
     dcf_analytical = torch.pi / nka * torch.abs(krad_idx) * (1 / nkr) ** 2
     dcf_analytical[krad_idx == 0] = 2 * torch.pi / nka * 1 / 8 * (1 / nkr) ** 2
-    dcf_analytical = torch.repeat_interleave(dcf_analytical[None, ...], nka, dim=0)[None, None, None, :, :]
+    dcf_analytical = torch.repeat_interleave(dcf_analytical[None, ...], nka, dim=0)[None, None, :, :]
 
     dcf = DcfData.from_traj_voronoi(ktraj)
 
     # Do not test outer points because they have to be approximated and cannot be calculated
     # accurately using voronoi
-    torch.testing.assert_close(dcf_analytical[:, :, :, :, 1:-1], dcf.data[:, :, :, :, 1:-1])
+    torch.testing.assert_close(dcf_analytical[:, :, :, 1:-1], dcf.data[:, :, :, 1:-1])
 
 
 def test_dcf_3d_cart_traj_voronoi():
@@ -65,21 +69,20 @@ def test_dcf_3d_cart_traj_voronoi():
     nk0 = 20
     nk1 = 16
     nk2 = 40
-    k0, k1, k2 = torch.meshgrid(
+    kx, ky, kz = torch.meshgrid(
         torch.linspace(-nk1 // 2, nk1 // 2 - 1, nk1),
         torch.linspace(-nk2 // 2, nk2 // 2 - 1, nk2),
         torch.linspace(-nk0 // 2, nk0 // 2 - 1, nk0),
         indexing='xy',
     )
-    ktraj = rearrange([k0, k1, k2], '(dir other) k2 k1 k0 -> other dir k2 k1 k0', other=1)
+    ktraj = KTrajectory(kx[None, ...], ky[None, ...], kz[None, ...])
 
     # Analytical dcf
-    dcf_analytical = torch.ones((1, 1, nk2, nk1, nk0))
-
+    dcf_analytical = torch.ones((1, nk2, nk1, nk0))
     dcf = DcfData.from_traj_voronoi(ktraj)
     # Do not test outer points because they have to be approximated and cannot be calculated
     # accurately using voronoi
-    torch.testing.assert_close(dcf.data[:, :, 1:-1, 1:-1, 1:-1], dcf_analytical[:, :, 1:-1, 1:-1, 1:-1])
+    torch.testing.assert_close(dcf.data[:, 1:-1, 1:-1, 1:-1], dcf_analytical[:, 1:-1, 1:-1, 1:-1])
 
 
 def test_dcf_rpe_traj_voronoi():
@@ -89,14 +92,4 @@ def test_dcf_rpe_traj_voronoi():
     nka = 6
     nk0 = 20
     ktraj = example_traj_rpe(nkr, nka, nk0)
-
-    dcf_rpe = DcfData.from_rpe_traj_voronoi(ktraj)
-    dcf_3d = DcfData.from_traj_voronoi(ktraj)
-
-    # Do not test outer points because they have to be approximated and cannot be calculated
-    # accurately using voronoi
-    dcf_rpe.data = dcf_rpe.data[:, :, :, 1:-1, 1:-1]
-    dcf_3d.data = dcf_3d.data[:, :, :, 1:-1, 1:-1]
-
-    # Compare normalized values
-    torch.testing.assert_close(dcf_rpe.data / torch.sum(dcf_rpe.data), dcf_3d.data / torch.sum(dcf_3d.data))
+    dcf = DcfData.from_traj_voronoi(ktraj)

--- a/tests/data/test_dcf_data.py
+++ b/tests/data/test_dcf_data.py
@@ -12,8 +12,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import math
+
 import torch
-from einops import rearrange
 
 from mrpro.data import DcfData
 from mrpro.data import KTrajectory
@@ -63,8 +64,9 @@ def test_dcf_2d_rad_traj_voronoi():
 
 
 def test_dcf_3d_cart_traj_broadcast_voronoi():
-    """Compare voronoi-based dcf calculation for 3D regular Cartesian
-    trajectory to analytical solution which is 1 for each k-space point."""
+    """Compare voronoi-based dcf calculation for broadcasted 3D regular
+    Cartesian trajectory to analytical solution which is 1 for each k-space
+    point."""
     # 3D trajectory with points on Cartesian grid with step size of 1
     nk0 = 20
     nk1 = 16
@@ -83,13 +85,13 @@ def test_dcf_3d_cart_traj_broadcast_voronoi():
 
 
 def test_dcf_3d_cart_full_traj_voronoi():
-    """Compare voronoi-based dcf calculation for 3D regular Cartesian
+    """Compare voronoi-based dcf calculation for full 3D regular Cartesian
     trajectory to analytical solution which is 1 for each k-space point."""
     # 3D trajectory with points on Cartesian grid with step size of 1
     nk0 = 20
     nk1 = 16
     nk2 = 40
-    kx, ky, kz = torch.meshgrid(
+    ky, kz, kx = torch.meshgrid(
         torch.linspace(-nk1 // 2, nk1 // 2 - 1, nk1),
         torch.linspace(-nk2 // 2, nk2 // 2 - 1, nk2),
         torch.linspace(-nk0 // 2, nk0 // 2 - 1, nk0),
@@ -103,6 +105,53 @@ def test_dcf_3d_cart_full_traj_voronoi():
     # Do not test outer points because they have to be approximated and cannot be calculated
     # accurately using voronoi
     torch.testing.assert_close(dcf.data[:, 1:-1, 1:-1, 1:-1], dcf_analytical[:, 1:-1, 1:-1, 1:-1])
+
+
+def test_dcf_3d_cart_nonuniform_traj_voronoi():
+    """Compare voronoi-based dcf calculation for 3D nonunifrm Cartesian
+    trajectory to analytical solution which is 1 for each k-space point."""
+
+    def k_range(N: int, *steps: float):
+        """Create a tensor with N values, steps appart."""
+        r = torch.tensor(steps).repeat(math.ceil(N / len(steps))).ravel()[:N]
+        r = torch.cumsum(r, 0)
+        r -= r.mean()
+        return r
+
+    k0_range = k_range(10, 1.0, 0.5)
+    k1_range = k_range(20, 1.0, 0.5, 0.25)
+    k2_range = k_range(30, 1.0)
+
+    ky_full, kz_full, kx_full = torch.meshgrid(
+        k1_range,
+        k2_range,
+        k0_range,
+        indexing='xy',
+    )
+    ktraj_full = KTrajectory(
+        kz_full[None, ...], ky_full[None, ...], kx_full[None, ...], repeat_detection_tolerance=None
+    )
+
+    kx_broadcast = k0_range[None, None, :]
+    ky_broadcast = k1_range[None, :, None]
+    kz_broadcast = k2_range[:, None, None]
+    ktraj_broadcast = KTrajectory(
+        kz_broadcast[None, ...], ky_broadcast[None, ...], kx_broadcast[None, ...], repeat_detection_tolerance=None
+    )
+
+    # Sanity check inputs
+    torch.testing.assert_close(ktraj_full.as_tensor(), ktraj_broadcast.as_tensor())
+    assert ktraj_full.broadcasted_shape == (1, len(k2_range), len(k1_range), len(k0_range))
+    torch.testing.assert_close(kx_full[0, 0, :], k0_range)  # kx changes along k0
+    torch.testing.assert_close(ky_full[0, :, 0], k1_range)  # ky changes along k1
+    torch.testing.assert_close(kz_full[:, 0, 0], k2_range)  # kz changes along k2
+
+    dcf_full = DcfData.from_traj_voronoi(ktraj_full)
+    dcf_broadcast = DcfData.from_traj_voronoi(ktraj_broadcast)
+
+    # Do not test outer points because they have to be approximated and cannot be calculated
+    # accurately using voronoi
+    torch.testing.assert_close(dcf_full.data[:, 1:-1, 1:-1, 1:-1], dcf_broadcast.data[:, 1:-1, 1:-1, 1:-1])
 
 
 def test_dcf_rpe_traj_voronoi():

--- a/tests/data/test_dcf_data.py
+++ b/tests/data/test_dcf_data.py
@@ -23,9 +23,9 @@ def example_traj_rpe(nkr, nka, nk0):
     """Create RPE trajectory with uniform angular gap."""
     krad = torch.linspace(-nkr // 2, nkr // 2 - 1, nkr) / nkr
     kang = torch.linspace(0, nka - 1, nka) * (torch.pi / nka)
-    kx = (torch.cos(kang[:, None]) * krad[None, :])[None, :, :, None]
-    ky = (torch.sin(kang[:, None]) * krad[None, :])[None, :, :, None]
-    kz = (torch.linspace(-nk0 // 2, nk0 // 2 - 1, nk0) / nk0)[None, None, None, :]
+    kz = (torch.sin(kang[:, None]) * krad[None, :])[None, :, :, None]
+    ky = (torch.cos(kang[:, None]) * krad[None, :])[None, :, :, None]
+    kx = (torch.linspace(-nk0 // 2, nk0 // 2 - 1, nk0) / nk0)[None, None, None, :]
     ktraj = KTrajectory(kz, ky, kx)
     return ktraj
 
@@ -34,9 +34,9 @@ def example_traj_rad_2d(nkr, nka):
     """Create 2D radial trajectory with uniform angular gap."""
     krad = torch.linspace(-nkr // 2, nkr // 2 - 1, nkr) / nkr
     kang = torch.linspace(0, nka - 1, nka) * (torch.pi / nka)
-    kx = (torch.cos(kang[:, None]) * krad[None, :])[None, None, :, :]
-    ky = (torch.sin(kang[:, None]) * krad[None, :])[None, None, :, :]
     kz = torch.zeros(1, 1, 1, 1)
+    ky = (torch.sin(kang[:, None]) * krad[None, :])[None, None, :, :]
+    kx = (torch.cos(kang[:, None]) * krad[None, :])[None, None, :, :]
     ktraj = KTrajectory(kz, ky, kx)
     return ktraj
 
@@ -113,6 +113,4 @@ def test_dcf_rpe_traj_voronoi():
     nk0 = 20
     ktraj = example_traj_rpe(nkr, nka, nk0)
     dcf = DcfData.from_traj_voronoi(ktraj)
-
-    # TODO: Test against analytical solution
     assert dcf.data.shape == (1, nka, nkr, nk0)

--- a/tests/data/test_kdata.py
+++ b/tests/data/test_kdata.py
@@ -15,7 +15,7 @@
 import pytest
 
 from mrpro.data import KData
-from mrpro.data.traj_calculators._KTrajectory import DummyTrajectory
+from mrpro.data.traj_calculators._KTrajectoryCalculator import DummyTrajectory
 from tests.data import IsmrmrdRawTestData
 from tests.phantoms.test_phantoms import ph_ellipse
 from tests.utils import kspace_to_image

--- a/tests/data/test_kdata.py
+++ b/tests/data/test_kdata.py
@@ -13,8 +13,10 @@
 #   limitations under the License.
 
 import pytest
+import torch
 
 from mrpro.data import KData
+from mrpro.data import KTrajectory
 from mrpro.data.traj_calculators._KTrajectoryCalculator import DummyTrajectory
 from tests.data import IsmrmrdRawTestData
 from tests.phantoms.test_phantoms import ph_ellipse
@@ -46,6 +48,14 @@ def test_KData_from_file(ismrmrd_cart):
     assert k is not None
 
 
+def test_KData_raise_wrong_ktraj_shape(ismrmrd_cart):
+    """Wrong KTrajectory shape raises exception."""
+    kx = ky = kz = torch.zeros(1, 2, 3, 4)
+    ktraj = KTrajectory(kz, ky, kx, repeat_detection_tolerance=None)
+    with pytest.raises(ValueError):
+        _ = KData.from_file(ismrmrd_cart.filename, ktraj)
+
+
 def test_KData_from_file_diff_nky_for_rep(ismrmrd_cart_invalid_reps):
     """Multiple repetitions with different number of phase encoding lines is
     not supported."""
@@ -64,13 +74,7 @@ def test_KData_kspace(ismrmrd_cart):
     assert rel_image_diff(irec[0, 0, 0, ...], ismrmrd_cart.imref) <= 0.05
 
 
-@pytest.mark.parametrize(
-    'field,value',
-    [
-        ('b0', 11.3),
-        ('tr', [24.3]),
-    ],
-)
+@pytest.mark.parametrize('field,value', [('b0', 11.3), ('tr', [24.3])])
 def test_KData_modify_header(ismrmrd_cart, field, value):
     """Overwrite some parameters in the header."""
     par_dict = {field: value}

--- a/tests/data/test_ktraj.py
+++ b/tests/data/test_ktraj.py
@@ -15,8 +15,9 @@
 import numpy as np
 import pytest
 import torch
-from tests.data import RandomGenerator
+
 from mrpro.data import KTrajectory
+from tests.data import RandomGenerator
 
 
 @pytest.fixture(params=({'seed': 0},))

--- a/tests/data/test_ktraj.py
+++ b/tests/data/test_ktraj.py
@@ -1,0 +1,104 @@
+"""Tests for KTrajectory class."""
+
+# Copyright 2023 Physikalisch-Technische Bundesanstalt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import numpy as np
+import pytest
+import torch
+from tests.data import RandomGenerator
+from mrpro.data import KTrajectory
+
+
+@pytest.fixture(params=({'seed': 0},))
+def cartesian_grid(request):
+    generator = RandomGenerator(request.param['seed'])
+
+    def generate(nk2: int, nk1: int, nk0: int, jitter: float) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        k0_range = torch.arange(nk0)
+        k1_range = torch.arange(nk1)
+        k2_range = torch.arange(nk2)
+        ky, kz, kx = torch.meshgrid(
+            k1_range,
+            k2_range,
+            k0_range,
+            indexing='xy',
+        )
+        if jitter > 0:
+            kx = kx + generator.float32_tensor((nk2, nk1, nk0), high=jitter)
+            ky = ky + generator.float32_tensor((nk2, nk1, nk0), high=jitter)
+            kz = kz + generator.float32_tensor((nk2, nk1, nk0), high=jitter)
+        return kz.unsqueeze(0), ky.unsqueeze(0), kx.unsqueeze(0)
+
+    return generate
+
+
+def test_ktraj_repeat_detection_tol(cartesian_grid):
+    """Test the automatic detection of repeated values"""
+    nk0 = 10
+    nk1 = 20
+    nk2 = 30
+    kz_full, ky_full, kx_full = cartesian_grid(nk2, nk1, nk0, jitter=0.1)
+    ktraj_sparse = KTrajectory(kz_full, ky_full, kx_full, repeat_detection_tolerance=0.1)
+
+    assert ktraj_sparse.broadcasted_shape == (1, nk2, nk1, nk0)
+    assert ktraj_sparse.kx.shape == (1, 1, 1, nk0)
+    assert ktraj_sparse.ky.shape == (1, 1, nk1, 1)
+    assert ktraj_sparse.kz.shape == (1, nk2, 1, 1)
+
+
+def test_ktraj_repeat_detection_exact(cartesian_grid):
+    """Test the automatic detection of repeated values"""
+    nk0 = 10
+    nk1 = 20
+    nk2 = 30
+    kz_full, ky_full, kx_full = cartesian_grid(nk2, nk1, nk0, jitter=0.1)
+    ktraj_full = KTrajectory(kz_full, ky_full, kx_full, repeat_detection_tolerance=None)
+
+    assert ktraj_full.broadcasted_shape == (1, nk2, nk1, nk0)
+    assert ktraj_full.kx.shape == (1, nk2, nk1, nk0)
+    assert ktraj_full.ky.shape == (1, nk2, nk1, nk0)
+    assert ktraj_full.kz.shape == (1, nk2, nk1, nk0)
+
+
+def test_ktraj_tensor_conversion(cartesian_grid):
+    nk0 = 10
+    nk1 = 20
+    nk2 = 30
+    kz_full, ky_full, kx_full = cartesian_grid(nk2, nk1, nk0, jitter=0.0)
+    ktraj = KTrajectory(kz_full, ky_full, kx_full)
+    tensor = torch.stack((kz_full, ky_full, kx_full), dim=0)
+
+    tensor_from_traj = ktraj.as_tensor()  # stack_dim=0
+    tensor_from_traj_dim2 = ktraj.as_tensor(stack_dim=2).moveaxis(2, 0)
+    tensor_from_traj_from_tensor_dim3 = KTrajectory.from_tensor(tensor.moveaxis(0, 3), stack_dim=3).as_tensor()
+    tensor_from_traj_from_tensor = KTrajectory.from_tensor(tensor).as_tensor()  # stack_dim=0
+
+    torch.testing.assert_close(tensor, tensor_from_traj)
+    torch.testing.assert_close(tensor, tensor_from_traj_dim2)
+    torch.testing.assert_close(tensor, tensor_from_traj_from_tensor)
+    torch.testing.assert_close(tensor, tensor_from_traj_from_tensor_dim3)
+
+
+def test_ktraj_raise_not_broadcastable():
+    """Non broadcastable shapes should raise"""
+    kx = ky = torch.arange(1 * 2 * 3 * 4).reshape(1, 2, 3, 4)
+    kz = torch.arange(1 * 2 * 3 * 100).reshape(1, 2, 3, 100)
+    with pytest.raises(ValueError):
+        ktraj = KTrajectory(kz, ky, kx)
+
+
+def test_ktraj_raise_wrong_dim():
+    """Wrong number of dimensions after broadcasting should raise"""
+    kx = ky = kz = torch.arange(1 * 2 * 3).reshape(1, 2, 3)
+    with pytest.raises(ValueError):
+        ktraj = KTrajectory(kz, ky, kx)

--- a/tests/data/test_ktraj.py
+++ b/tests/data/test_ktraj.py
@@ -44,7 +44,7 @@ def cartesian_grid(request):
 
 
 def test_ktraj_repeat_detection_tol(cartesian_grid):
-    """Test the automatic detection of repeated values"""
+    """Test the automatic detection of repeated values."""
     nk0 = 10
     nk1 = 20
     nk2 = 30
@@ -58,7 +58,7 @@ def test_ktraj_repeat_detection_tol(cartesian_grid):
 
 
 def test_ktraj_repeat_detection_exact(cartesian_grid):
-    """Test the automatic detection of repeated values"""
+    """Test the automatic detection of repeated values."""
     nk0 = 10
     nk1 = 20
     nk2 = 30
@@ -91,7 +91,7 @@ def test_ktraj_tensor_conversion(cartesian_grid):
 
 
 def test_ktraj_raise_not_broadcastable():
-    """Non broadcastable shapes should raise"""
+    """Non broadcastable shapes should raise."""
     kx = ky = torch.arange(1 * 2 * 3 * 4).reshape(1, 2, 3, 4)
     kz = torch.arange(1 * 2 * 3 * 100).reshape(1, 2, 3, 100)
     with pytest.raises(ValueError):
@@ -99,7 +99,7 @@ def test_ktraj_raise_not_broadcastable():
 
 
 def test_ktraj_raise_wrong_dim():
-    """Wrong number of dimensions after broadcasting should raise"""
+    """Wrong number of dimensions after broadcasting should raise."""
     kx = ky = kz = torch.arange(1 * 2 * 3).reshape(1, 2, 3)
     with pytest.raises(ValueError):
         ktraj = KTrajectory(kz, ky, kx)

--- a/tests/data/test_traj_calculators.py
+++ b/tests/data/test_traj_calculators.py
@@ -51,40 +51,47 @@ def rpe_traj_shape(valid_rpe_kheader):
     nk0 = valid_rpe_kheader.acq_info.number_of_samples[0, 0, 0]
     nk1 = valid_rpe_kheader.acq_info.idx.k1.shape[2]
     nk2 = valid_rpe_kheader.acq_info.idx.k1.shape[1]
-    return torch.Size([1, 3, nk2, nk1, nk0])
+    nother = 1
+    return (torch.Size([nother, nk2, nk1, 1]), torch.Size([nother, nk2, nk1, 1]), torch.Size([nother, 1, 1, nk0]))
 
 
 def test_KTrajectoryRpe_golden(valid_rpe_kheader):
     """Calculate RPE trajectory with golden angle."""
     ktrajectory = KTrajectoryRpe(angle=torch.pi * 0.618034)
-    ktraj = ktrajectory.calc_traj(valid_rpe_kheader)
-    assert ktraj.shape == rpe_traj_shape(valid_rpe_kheader)
+    ktraj = ktrajectory(valid_rpe_kheader)
+    valid_shape = rpe_traj_shape(valid_rpe_kheader)
+    assert ktraj.kx.shape == valid_shape[0]
+    assert ktraj.ky.shape == valid_shape[1]
+    assert ktraj.kz.shape == valid_shape[2]
 
 
 def test_KTrajectoryRpe_uniform(valid_rpe_kheader):
     """Calculate RPE trajectory with uniform angle."""
     num_rpe_lines = valid_rpe_kheader.acq_info.idx.k1.shape[1]
     ktrajectory1 = KTrajectoryRpe(angle=torch.pi / num_rpe_lines, shift_between_rpe_lines=torch.tensor([0]))
-    ktraj1 = ktrajectory1.calc_traj(valid_rpe_kheader)
+    ktraj1 = ktrajectory1(valid_rpe_kheader)
     # Calculate trajectory with half the angular gap such that every second line should be the same as above
     ktrajectory2 = KTrajectoryRpe(angle=torch.pi / (2 * num_rpe_lines), shift_between_rpe_lines=torch.tensor([0]))
-    ktraj2 = ktrajectory2.calc_traj(valid_rpe_kheader)
-    torch.testing.assert_close(ktraj1[:, :, : num_rpe_lines // 2, :, :], ktraj2[:, :, ::2, :, :])
+    ktraj2 = ktrajectory2(valid_rpe_kheader)
+
+    torch.testing.assert_close(ktraj1.kx[:, : num_rpe_lines // 2, :, :], ktraj2.kx[:, ::2, :, :])
+    torch.testing.assert_close(ktraj1.ky[:, : num_rpe_lines // 2, :, :], ktraj2.ky[:, ::2, :, :])
+    torch.testing.assert_close(ktraj1.kz[:, : num_rpe_lines // 2, :, :], ktraj2.kz[:, ::2, :, :])
 
 
 def test_KTrajectoryRpe_shift(valid_rpe_kheader):
     """Evaluate radial shifts for RPE trajectory."""
     ktrajectory1 = KTrajectoryRpe(angle=torch.pi * 0.618034, shift_between_rpe_lines=torch.tensor([0.25]))
-    ktraj1 = ktrajectory1.calc_traj(valid_rpe_kheader)
+    ktraj1 = ktrajectory1(valid_rpe_kheader)
     ktrajectory2 = KTrajectoryRpe(
         angle=torch.pi * 0.618034, shift_between_rpe_lines=torch.tensor([0.25, 0.25, 0.25, 0.25])
     )
-    ktraj2 = ktrajectory2.calc_traj(valid_rpe_kheader)
-    torch.testing.assert_close(ktraj1, ktraj2)
+    ktraj2 = ktrajectory2(valid_rpe_kheader)
+    torch.testing.assert_close(ktraj1.as_tensor(), ktraj2.as_tensor())
 
 
 def test_KTrajectorySunflowerGoldenRpe(valid_rpe_kheader):
     """Calculate RPE Sunflower trajectory."""
     ktrajectory = KTrajectorySunflowerGoldenRpe(rad_us_factor=2)
-    ktraj = ktrajectory.calc_traj(valid_rpe_kheader)
-    assert ktraj.shape == rpe_traj_shape(valid_rpe_kheader)
+    ktraj = ktrajectory(valid_rpe_kheader)
+    assert ktraj.broadcasted_shape == np.broadcast_shapes(*rpe_traj_shape(valid_rpe_kheader))

--- a/tests/data/test_traj_calculators.py
+++ b/tests/data/test_traj_calculators.py
@@ -1,4 +1,4 @@
-"""Tests for KTrajectory classes."""
+"""Tests for KTrajectory Calculator classes."""
 
 # Copyright 2023 Physikalisch-Technische Bundesanstalt
 #

--- a/tests/data/test_traj_calculators.py
+++ b/tests/data/test_traj_calculators.py
@@ -29,7 +29,7 @@ def valid_rpe_kheader(monkeypatch, random_kheader):
     nk1 = 20
     nk2 = 10
 
-    # List of k1 and k2 indices in the shape (d4, k2, k1)
+    # List of k1 and k2 indices in the shape (other, k2, k1)
     k1 = torch.linspace(0, nk1 - 1, nk1, dtype=torch.int32)
     k2 = torch.linspace(0, nk2 - 1, nk2, dtype=torch.int32)
     idx_k1, idx_k2 = torch.meshgrid(k1, k2, indexing='xy')

--- a/tests/data/test_traj_calculators.py
+++ b/tests/data/test_traj_calculators.py
@@ -60,9 +60,9 @@ def test_KTrajectoryRpe_golden(valid_rpe_kheader):
     ktrajectory = KTrajectoryRpe(angle=torch.pi * 0.618034)
     ktraj = ktrajectory(valid_rpe_kheader)
     valid_shape = rpe_traj_shape(valid_rpe_kheader)
-    assert ktraj.kx.shape == valid_shape[0]
+    assert ktraj.kz.shape == valid_shape[0]
     assert ktraj.ky.shape == valid_shape[1]
-    assert ktraj.kz.shape == valid_shape[2]
+    assert ktraj.kx.shape == valid_shape[2]
 
 
 def test_KTrajectoryRpe_uniform(valid_rpe_kheader):

--- a/tests/phantoms/_EllipsePhantomTestData.py
+++ b/tests/phantoms/_EllipsePhantomTestData.py
@@ -23,13 +23,13 @@ class EllipsePhantomTestData:
 
     Parameters
     ----------
-    nx
-        number of voxels along x
     ny
         number of voxels along y
+    nx
+        number of voxels along x
     """
 
-    def __init__(self, nx: int = 512, ny: int = 256):
+    def __init__(self, ny: int = 512, nx: int = 256):
         # Define image size and k-space matrix
         self.nx: int = nx
         self.ny: int = ny

--- a/tests/phantoms/test_phantoms.py
+++ b/tests/phantoms/test_phantoms.py
@@ -27,13 +27,13 @@ def ph_ellipse():
 
 def test_image_space(ph_ellipse):
     """Check if image space has correct shape."""
-    im = ph_ellipse.phantom.image_space(ph_ellipse.nx, ph_ellipse.ny)
+    im = ph_ellipse.phantom.image_space(ph_ellipse.ny, ph_ellipse.nx)
     assert im.shape == (ph_ellipse.ny, ph_ellipse.nx)
 
 
 def test_kspace_correct_shape(ph_ellipse):
     """Check if kspace has correct shape."""
-    kdat = ph_ellipse.phantom.kspace(ph_ellipse.kx, ph_ellipse.ky)
+    kdat = ph_ellipse.phantom.kspace(ph_ellipse.ky, ph_ellipse.kx)
     assert kdat.shape == (ph_ellipse.ny, ph_ellipse.nx)
 
 
@@ -43,13 +43,13 @@ def test_kspace_raises_error(ph_ellipse):
         range(-ph_ellipse.nx // 2, ph_ellipse.nx // 2), range(-ph_ellipse.ny // 2, ph_ellipse.ny // 2 + 1)
     )
     with pytest.raises(ValueError):
-        ph_ellipse.phantom.kspace(kx_, ph_ellipse.ky)
+        ph_ellipse.phantom.kspace(ph_ellipse.ky, kx_)
 
 
 def test_kspace_image_match(ph_ellipse):
     """Check if fft of kspace matches image."""
-    im = ph_ellipse.phantom.image_space(ph_ellipse.nx, ph_ellipse.ny)
-    kdat = ph_ellipse.phantom.kspace(ph_ellipse.kx, ph_ellipse.ky)
+    im = ph_ellipse.phantom.image_space(ph_ellipse.ny, ph_ellipse.nx)
+    kdat = ph_ellipse.phantom.kspace(ph_ellipse.ky, ph_ellipse.kx)
     irec = kspace_to_image(kdat)
     # Due to discretisation artifacts the reconstructed image will be different to the reference image. Using standard
     # testing functions such as numpy.testing.assert_almost_equal fails because there are few voxels with high


### PR DESCRIPTION
I had the idea to refactor Kdata.traj into a KTrajectory dataclass with kx, ky, kz properties.

This was partially influenced by somebody asking how a trajectory shape interpreted, partially by the need for a special 'dcf_rpe_voronoi' - logic:

Now the RPE can have a trajectory with broadcasted kz dimension.
And the dcf voronoi logic can look if any of kx,ky,kz has two singleton dimensions. If this happens, then we can ignore this dimension in the calculation (I hope that's correct...)

Also, in a second pass, I refactored the DCF calculation a bit, mostly by simplifying the multiprocessing and sorting logic.
As scipy.spatial calls qhull with nogil from cython, we should be able to use multithreading. 
This is something I should test on one of the recon servers with a bit more demanding DCF example.

I am pretty sure that there are still logic issues in this code, and some style improvements can be made, but I want to open the discussion if this goes in the right direction or if we want to keep it as is.

@schuenke @ckolbPTB 

(If we want to go ahead, I can rebase and split the changes)

