### PR TITLE
CsmData with Walsh-Method implementation

### DIFF
--- a/src/mrpro/data/_CsmData.py
+++ b/src/mrpro/data/_CsmData.py
@@ -14,8 +14,6 @@
 
 from __future__ import annotations
 
-import dataclasses
-
 import torch
 
 from mrpro.data import IData
@@ -24,7 +22,6 @@ from mrpro.data import SpatialDimension
 from mrpro.utils.filters import spatial_uniform_filter_3d
 
 
-@dataclasses.dataclass(init=False, slots=True, frozen=True)
 class CsmData(QData):
     """Coil sensitivity map class."""
 
@@ -66,6 +63,9 @@ class CsmData(QData):
         # nan_to_num does not work for complexfloat, boolean indexing not with vmap.
         csm_data = torch.where(torch.isfinite(csm_data), csm_data, 0.0)
         return csm_data
+
+    def test(self):
+        self.aaaa = 1
 
     @classmethod
     def from_idata_walsh(

--- a/src/mrpro/data/_CsmData.py
+++ b/src/mrpro/data/_CsmData.py
@@ -51,9 +51,6 @@ class CsmData(IData):
         coil_cov = torch.einsum('azyx,bzyx->abzyx', coil_images, coil_images.conj())
 
         # Smooth the covariance along y-x for 2D and z-y-x for 3D data
-        if coil_images.shape[-3] == 1:
-            # 2D case
-            smoothing_width = SpatialDimension(1, smoothing_width.y, smoothing_width.x)
         coil_cov = spatial_uniform_filter_3d(coil_cov, filter_width=smoothing_width)
 
         # At each point in the image, find the dominant eigenvector
@@ -92,7 +89,8 @@ class CsmData(IData):
             Default is None, which means that all elements are processed at once.
         """
         csm_fun = torch.vmap(
-            lambda img: CsmData._iterative_walsh_csm(img, smoothing_width, niter), chunk_size=chunk_size_otherdim
+            lambda img: CsmData._iterative_walsh_csm(img, smoothing_width, niter),
+            chunk_size=chunk_size_otherdim,
         )
         csm_data = csm_fun(idata.data)
 

--- a/src/mrpro/data/_CsmData.py
+++ b/src/mrpro/data/_CsmData.py
@@ -64,9 +64,6 @@ class CsmData(QData):
         csm_data = torch.where(torch.isfinite(csm_data), csm_data, 0.0)
         return csm_data
 
-    def test(self):
-        self.aaaa = 1
-
     @classmethod
     def from_idata_walsh(
         cls,

--- a/src/mrpro/data/_CsmData.py
+++ b/src/mrpro/data/_CsmData.py
@@ -1,0 +1,147 @@
+"""Class for coil sensitivity maps (csm)."""
+
+# Copyright 2023 Physikalisch-Technische Bundesanstalt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from __future__ import annotations
+
+import dataclasses
+
+import torch
+
+from mrpro.data import IData
+from mrpro.data import SpatialDimension
+from mrpro.utils.filters import spatial_uniform_filter_3d
+
+
+@dataclasses.dataclass(slots=True, frozen=True)
+class CsmData(IData):
+    """Coil sensitivity map class."""
+
+    @staticmethod
+    def _iterative_walsh_csm(
+        coil_images: torch.Tensor, smoothing_width: SpatialDimension[int], niter: int
+    ) -> torch.Tensor:
+        """Calculate csm using an iterative version of the Walsh method.
+
+        This function is strongly inspired by https://github.com/ismrmrd/ismrmrd-python-tools. The associated license
+        information can be found at the end of this file.
+
+        More information on the method can be found in
+        https://doi.org/10.1002/(SICI)1522-2594(200005)43:5<682::AID-MRM10>3.0.CO;2-G
+
+        Parameters
+        ----------
+        coil_images
+            Images for each coil element.
+        smoothing_width
+            Width smoothing filter.
+        niter
+            Number if iterations of Walsh method.
+        """
+        ncoils, nz, ny, nx = coil_images.shape
+
+        # Compute the sample covariance pointwise
+        coil_cov = torch.zeros((ncoils, ncoils, nz, ny, nx), dtype=coil_images.dtype)
+        for c1_idx in range(ncoils):
+            for c2_idx in range(c1_idx):
+                coil_cov[c1_idx, c2_idx, ...] = coil_images[c1_idx, ...] * torch.conj(coil_images[c2_idx, ...])
+                coil_cov[c2_idx, c1_idx, ...] = torch.conj(coil_cov[c1_idx, c2_idx, ...].clone())
+            coil_cov[c1_idx, c1_idx, ...] = coil_images[c1_idx, ...] * torch.conj(coil_images[c1_idx, ...])
+
+        # Smooth the covariance along y-x for 2D and z-y-x for 3D data
+        if nz == 1:
+            smoothing_width.z = 1
+        coil_cov = spatial_uniform_filter_3d(coil_cov, filter_width=smoothing_width)
+
+        # At each point in the image, find the dominant eigenvector
+        # and corresponding eigenvalue of the signal covariance
+        # matrix using the power method
+        csm_data = torch.zeros((ncoils, nz, ny, nx), dtype=coil_images.dtype)
+        for z in range(nz):
+            for y in range(ny):
+                for x in range(nx):
+                    coil_cov_curr_vox = coil_cov[:, :, z, y, x]
+                    # v needs to be (ncoils, 1) to allow for torch.mm later on
+                    v = torch.sum(coil_cov_curr_vox, dim=0)[:, None]
+                    lam = torch.linalg.norm(v)
+                    if lam != 0:
+                        v = v / lam
+
+                        for _ in range(niter):
+                            v = torch.mm(coil_cov_curr_vox, v)
+                            lam = torch.linalg.norm(v)
+                            v = v / lam
+
+                    csm_data[:, z, y, x] = v[:, 0]
+
+        # Make sure there are no inf and nan-values due to very small values in the covariance matrix
+        csm_data[torch.isnan(csm_data) | torch.isinf(csm_data)] = 0
+        return csm_data
+
+    @classmethod
+    def from_idata_walsh(
+        cls,
+        idata: IData,
+        downsampling_factor: SpatialDimension[int] = SpatialDimension(1, 1, 1),
+        smoothing_width: SpatialDimension[int] = SpatialDimension(5, 5, 5),
+        niter: int = 3,
+    ) -> CsmData:
+        """Create csm object from image data using iterative Walsh method.
+
+        Parameters
+        ----------
+        idata
+            IData object containing the images for each coil element.
+        smoothing_width
+            Width of smoothing filter.
+        niter
+            Number if iterations of Walsh method.
+        """
+        csm_data = torch.zeros_like(idata.data)
+        for ond in range(csm_data.shape[0]):
+            csm_data[ond, ...] = CsmData._iterative_walsh_csm(idata.data[ond, ...], smoothing_width, niter)
+
+        return cls(header=idata.header, data=csm_data)
+
+
+# License information from https://github.com/ismrmrd/ismrmrd-python-tools
+
+# ISMRMRD-PYTHON-TOOLS SOFTWARE LICENSE JULY 2016
+
+# PERMISSION IS HEREBY GRANTED, FREE OF CHARGE, TO ANY PERSON OBTAINING
+# A COPY OF THIS SOFTWARE AND ASSOCIATED DOCUMENTATION FILES (THE
+# "SOFTWARE"), TO DEAL IN THE SOFTWARE WITHOUT RESTRICTION, INCLUDING
+# WITHOUT LIMITATION THE RIGHTS TO USE, COPY, MODIFY, MERGE, PUBLISH,
+# DISTRIBUTE, SUBLICENSE, AND/OR SELL COPIES OF THE SOFTWARE, AND TO
+# PERMIT PERSONS TO WHOM THE SOFTWARE IS FURNISHED TO DO SO, SUBJECT TO
+# THE FOLLOWING CONDITIONS:
+
+# THE ABOVE COPYRIGHT NOTICE, THIS PERMISSION NOTICE, AND THE LIMITATION
+# OF LIABILITY BELOW SHALL BE INCLUDED IN ALL COPIES OR REDISTRIBUTIONS
+# OF SUBSTANTIAL PORTIONS OF THE SOFTWARE.
+
+# SOFTWARE IS BEING DEVELOPED IN PART AT THE NATIONAL HEART, LUNG, AND BLOOD
+# INSTITUTE, NATIONAL INSTITUTES OF HEALTH BY AN EMPLOYEE OF THE FEDERAL
+# GOVERNMENT IN THE COURSE OF HIS OFFICIAL DUTIES. PURSUANT TO TITLE 17,
+# SECTION 105 OF THE UNITED STATES CODE, THIS SOFTWARE IS NOT SUBJECT TO
+# COPYRIGHT PROTECTION AND IS IN THE PUBLIC DOMAIN. EXCEPT AS CONTAINED IN
+# THIS NOTICE, THE NAME OF THE AUTHORS, THE NATIONAL HEART, LUNG, AND BLOOD
+# INSTITUTE (NHLBI), OR THE NATIONAL INSTITUTES OF HEALTH (NIH) MAY NOT
+# BE USED TO ENDORSE OR PROMOTE PRODUCTS DERIVED FROM THIS SOFTWARE WITHOUT
+# SPECIFIC PRIOR WRITTEN PERMISSION FROM THE NHLBI OR THE NIH.THE SOFTWARE IS
+# PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+# IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/mrpro/data/_CsmData.py
+++ b/src/mrpro/data/_CsmData.py
@@ -59,8 +59,9 @@ class CsmData(IData):
             coil_cov[c1_idx, c1_idx, ...] = coil_images[c1_idx, ...] * torch.conj(coil_images[c1_idx, ...])
 
         # Smooth the covariance along y-x for 2D and z-y-x for 3D data
-        if nz == 1:
-            smoothing_width.z = 1
+        if coil_images.shape[-3] == 1:
+            # 2D case
+            smoothing_width = SpatialDimension(1, smoothing_width.y, smoothing_width.x)
         coil_cov = spatial_uniform_filter_3d(coil_cov, filter_width=smoothing_width)
 
         # At each point in the image, find the dominant eigenvector

--- a/src/mrpro/data/_CsmData.py
+++ b/src/mrpro/data/_CsmData.py
@@ -75,6 +75,7 @@ class CsmData(IData):
         idata: IData,
         smoothing_width: SpatialDimension[int] = SpatialDimension(5, 5, 5),
         niter: int = 3,
+        chunk_size_otherdim: int | None = None,
     ) -> CsmData:
         """Create csm object from image data using iterative Walsh method.
 
@@ -86,9 +87,13 @@ class CsmData(IData):
             Width of smoothing filter.
         niter
             Number of iterations of Walsh method.
+        chunk_size_otherdim:
+            How many elements of the other dimensions should be processed at once.
+            Default is None, which means that all elements are processed at once.
         """
-        # TODO: consider increaseing the chunk_size
-        csm_fun = torch.vmap(lambda img: CsmData._iterative_walsh_csm(img, smoothing_width, niter), chunk_size=1)
+        csm_fun = torch.vmap(
+            lambda img: CsmData._iterative_walsh_csm(img, smoothing_width, niter), chunk_size=chunk_size_otherdim
+        )
         csm_data = csm_fun(idata.data)
 
         return cls(header=idata.header, data=csm_data)

--- a/src/mrpro/data/_CsmData.py
+++ b/src/mrpro/data/_CsmData.py
@@ -19,12 +19,13 @@ import dataclasses
 import torch
 
 from mrpro.data import IData
+from mrpro.data import QData
 from mrpro.data import SpatialDimension
 from mrpro.utils.filters import spatial_uniform_filter_3d
 
 
-@dataclasses.dataclass(slots=True, frozen=True)
-class CsmData(IData):
+@dataclasses.dataclass(init=False, slots=True, frozen=True)
+class CsmData(QData):
     """Coil sensitivity map class."""
 
     @staticmethod

--- a/src/mrpro/data/_CsmData.py
+++ b/src/mrpro/data/_CsmData.py
@@ -33,8 +33,7 @@ class CsmData(IData):
     ) -> torch.Tensor:
         """Calculate csm using an iterative version of the Walsh method.
 
-        This function is strongly inspired by https://github.com/ismrmrd/ismrmrd-python-tools. The associated license
-        information can be found at the end of this file.
+        This function is inspired by https://github.com/ismrmrd/ismrmrd-python-tools.
 
         More information on the method can be found in
         https://doi.org/10.1002/(SICI)1522-2594(200005)43:5<682::AID-MRM10>3.0.CO;2-G
@@ -46,7 +45,7 @@ class CsmData(IData):
         smoothing_width
             Width smoothing filter.
         niter
-            Number if iterations of Walsh method.
+            Number of iterations of Walsh method.
         """
         # Compute the pointwise covariance between coils
         coil_cov = torch.einsum('azyx,bzyx->abzyx', coil_images, coil_images.conj())
@@ -86,43 +85,10 @@ class CsmData(IData):
         smoothing_width
             Width of smoothing filter.
         niter
-            Number if iterations of Walsh method.
+            Number of iterations of Walsh method.
         """
         # TODO: consider increaseing the chunk_size
         csm_fun = torch.vmap(lambda img: CsmData._iterative_walsh_csm(img, smoothing_width, niter), chunk_size=1)
         csm_data = csm_fun(idata.data)
 
         return cls(header=idata.header, data=csm_data)
-
-
-# License information from https://github.com/ismrmrd/ismrmrd-python-tools
-
-# ISMRMRD-PYTHON-TOOLS SOFTWARE LICENSE JULY 2016
-
-# PERMISSION IS HEREBY GRANTED, FREE OF CHARGE, TO ANY PERSON OBTAINING
-# A COPY OF THIS SOFTWARE AND ASSOCIATED DOCUMENTATION FILES (THE
-# "SOFTWARE"), TO DEAL IN THE SOFTWARE WITHOUT RESTRICTION, INCLUDING
-# WITHOUT LIMITATION THE RIGHTS TO USE, COPY, MODIFY, MERGE, PUBLISH,
-# DISTRIBUTE, SUBLICENSE, AND/OR SELL COPIES OF THE SOFTWARE, AND TO
-# PERMIT PERSONS TO WHOM THE SOFTWARE IS FURNISHED TO DO SO, SUBJECT TO
-# THE FOLLOWING CONDITIONS:
-
-# THE ABOVE COPYRIGHT NOTICE, THIS PERMISSION NOTICE, AND THE LIMITATION
-# OF LIABILITY BELOW SHALL BE INCLUDED IN ALL COPIES OR REDISTRIBUTIONS
-# OF SUBSTANTIAL PORTIONS OF THE SOFTWARE.
-
-# SOFTWARE IS BEING DEVELOPED IN PART AT THE NATIONAL HEART, LUNG, AND BLOOD
-# INSTITUTE, NATIONAL INSTITUTES OF HEALTH BY AN EMPLOYEE OF THE FEDERAL
-# GOVERNMENT IN THE COURSE OF HIS OFFICIAL DUTIES. PURSUANT TO TITLE 17,
-# SECTION 105 OF THE UNITED STATES CODE, THIS SOFTWARE IS NOT SUBJECT TO
-# COPYRIGHT PROTECTION AND IS IN THE PUBLIC DOMAIN. EXCEPT AS CONTAINED IN
-# THIS NOTICE, THE NAME OF THE AUTHORS, THE NATIONAL HEART, LUNG, AND BLOOD
-# INSTITUTE (NHLBI), OR THE NATIONAL INSTITUTES OF HEALTH (NIH) MAY NOT
-# BE USED TO ENDORSE OR PROMOTE PRODUCTS DERIVED FROM THIS SOFTWARE WITHOUT
-# SPECIFIC PRIOR WRITTEN PERMISSION FROM THE NHLBI OR THE NIH.THE SOFTWARE IS
-# PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
-# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-# IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/mrpro/data/__init__.py
+++ b/src/mrpro/data/__init__.py
@@ -13,3 +13,4 @@ from mrpro.data._IData import IData
 from mrpro.data._DcfData import DcfData
 from mrpro.data._QHeader import QHeader
 from mrpro.data._QData import QData
+from mrpro.data._CsmData import CsmData

--- a/src/mrpro/utils/filters.py
+++ b/src/mrpro/utils/filters.py
@@ -1,0 +1,45 @@
+"""Spatial and temporal filters."""
+
+# Copyright 2023 Physikalisch-Technische Bundesanstalt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+from mrpro.data import SpatialDimension
+
+
+def spatial_uniform_filter_3d(data: torch.Tensor, filter_width: SpatialDimension[int]) -> torch.Tensor:
+    """Spatial smoothing using convolution with box function.
+
+    Parameters
+    ----------
+    data
+        Data to be smoothed in the shape (... z y x)
+    filter_width
+        Width of 3D the filter
+    """
+    # Ensure (batch z y x)
+    ddim = data.shape
+    data = data.view(-1, *ddim[-3:])
+
+    # Create a box-shaped filter kernel
+    filter_width_zyx = [filter_width.z, filter_width.y, filter_width.x]
+    kernel = torch.ones(filter_width_zyx) / np.prod(filter_width_zyx)
+    kernel = kernel.to(dtype=data.dtype)
+    kernel = kernel.view(1, 1, *kernel.size())
+
+    # Use same filter kernel for each channel
+    kernel = kernel.repeat(data.shape[0], *[1] * (kernel.dim() - 1))
+    return torch.reshape(torch.nn.functional.conv3d(data, weight=kernel, groups=data.shape[0], padding='same'), ddim)

--- a/tests/data/test_csm_data.py
+++ b/tests/data/test_csm_data.py
@@ -1,0 +1,45 @@
+"""Tests the CsmData class."""
+
+# Copyright 2023 Physikalisch-Technische Bundesanstalt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import numpy as np
+
+from mrpro.data import CsmData
+from mrpro.data import IData
+from mrpro.data import SpatialDimension
+from mrpro.phantoms.coils import birdcage_2d
+from tests.data.conftest import random_kheader
+from tests.phantoms.test_ellipse_phantom import ph_ellipse
+from tests.utils import rel_image_diff
+
+
+def test_CsmData_iterative_Walsh(ph_ellipse, random_kheader):
+    """CsmData obtained with the iterative Walsh method."""
+    num_coils = 4
+    im_dim = SpatialDimension(z=1, y=ph_ellipse.ny, x=ph_ellipse.nx)
+
+    # Create reference coil sensitivities
+    csm_ref = birdcage_2d(num_coils, im_dim)
+
+    # Create multi-coil phantom image data
+    im = ph_ellipse.phantom.image_space(im_dim)
+    # +1 to ensure that there is signal everywhere, for voxel == 0 csm cannot be determined.
+    im_multi_coil = (im + 1) * csm_ref
+    idat = IData.from_tensor_and_kheader(data=im_multi_coil, kheader=random_kheader)
+
+    # Estimate coil sensitivity maps
+    smoothing_width = SpatialDimension(z=1, y=5, x=5)
+    csm = CsmData.from_idata_walsh(idat, smoothing_width)
+
+    # Phase is only relative in csm calculation, therefore only the abs values are compared.
+    assert rel_image_diff(np.abs(csm.data), np.abs(csm_ref)) <= 0.01

--- a/tests/data/test_csm_data.py
+++ b/tests/data/test_csm_data.py
@@ -12,15 +12,26 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import dataclasses
+
 import numpy as np
+import pytest
 
 from mrpro.data import CsmData
 from mrpro.data import IData
 from mrpro.data import SpatialDimension
 from mrpro.phantoms.coils import birdcage_2d
 from tests.data.conftest import random_kheader
+from tests.data.conftest import random_test_data
 from tests.phantoms.test_ellipse_phantom import ph_ellipse
 from tests.utils import rel_image_diff
+
+
+def test_CsmData_is_frozen_dataclass(random_test_data, random_kheader):
+    """CsmData inherits frozen dataclass property from QData."""
+    csm = CsmData(data=random_test_data, header=random_kheader)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        csm.data = random_test_data
 
 
 def test_CsmData_iterative_Walsh(ph_ellipse, random_kheader):


### PR DESCRIPTION
Closes #16 and #5

ToDo:

- Derive CsmData from QData once it is available
- Replace for-loop https://github.com/ckolbPTB/mrpro/blob/2ade47482d5be0e0622ad824b1550032d7dbca1b/src/mrpro/data/_CsmData.py#L111 with smap?
- Replace for-loops in _iterative_walsh_csm for speed-up