### PR TITLE
Run tests in parallel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["coverage", "codecov", "pre-commit", "pytest", "pytest-cov"]
+test = [
+    "coverage",
+    "codecov",
+    "pre-commit",
+    "pytest",
+    "pytest-cov",
+    "pytest-xdist",
+]
 lint = ["mypy", "flake8", "isort", "pre-commit", "autopep8", "pydocstyle"]
 docs = ["sphinx", "sphinx_rtd_theme"]
 
@@ -44,6 +51,7 @@ docs = ["sphinx", "sphinx_rtd_theme"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 filterwarnings = ["error"]
+addopts = "-n auto"
 
 # MyPy section
 [tool.mypy]


### PR DESCRIPTION
Closes #87 

I tested it on my Laptop (i3 12. gen) and the runtime decreased (just) by about 15%, but probably it will become more significant in the future when the number of tests increases.

**EDIT: Currently, for our automated workflow on GitHub, no significant runtime reduction is measureable, because of the huge overhead for setting up the python env and dependencies. However, I see no disadvantage and still suggest to merge the PR as it already improves the performance when running the tests in VSCode.**