### PR TITLE
hotfix vscode pytest-xdist issues (#87)

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run PyTest
 
         run: |
-          pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=mrpro | tee pytest-coverage.txt
+          pytest -n 4 --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=mrpro | tee pytest-coverage.txt
 
       - name: Pytest coverage comment
         id: coverageComment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ docs = ["sphinx", "sphinx_rtd_theme"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 filterwarnings = ["error"]
-addopts = "-n auto"
+# addopts = "-n auto" # TODO: debug vscode missing tests if enabled
 
 # MyPy section
 [tool.mypy]


### PR DESCRIPTION
Adresses isses caused by #89, mentioned in #87 by disabling parallel testing for now.

We still test in paralell in the CI.
We still install pytest-xdist.

Any developer not having issues with parallel testing can add "-n auto" in their vscode pytest settings as additional argument to still use parallel test execution.
 