### PR TITLE
Remove oversampling and fft added

### DIFF
--- a/src/mrpro/algorithms/__init__.py
+++ b/src/mrpro/algorithms/__init__.py
@@ -1,1 +1,2 @@
 from mrpro.algorithms._prewhiten_kspace import prewhiten_kspace
+from mrpro.algorithms._remove_readout_os import remove_readout_os

--- a/src/mrpro/algorithms/_remove_readout_os.py
+++ b/src/mrpro/algorithms/_remove_readout_os.py
@@ -37,7 +37,7 @@ def remove_readout_os(kdata: KData) -> KData:
     Raises
     ------
     ValueError
-        If the recon matrix along x is smaller than the encoding matrix along x.
+        If the recon matrix along x is larger than the encoding matrix along x.
     """
     # Ratio between encoded and recon space
     dim_ratio = kdata.header.recon_matrix.x / kdata.header.encoding_matrix.x

--- a/src/mrpro/algorithms/_remove_readout_os.py
+++ b/src/mrpro/algorithms/_remove_readout_os.py
@@ -23,6 +23,8 @@ from mrpro.utils.fft import kspace_to_image
 def remove_readout_os(kdata: KData) -> KData:
     """Remove any oversampling along the readout (k0) direction.
 
+    This function is inspired by https://github.com/gadgetron/gadgetron-python.
+
     Parameters
     ----------
     kdata

--- a/src/mrpro/algorithms/_remove_readout_os.py
+++ b/src/mrpro/algorithms/_remove_readout_os.py
@@ -1,0 +1,77 @@
+"""Remove oversampling along readout."""
+
+# Copyright 2023 Physikalisch-Technische Bundesanstalt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import torch
+
+from mrpro.data import KData
+from mrpro.data import KTrajectory
+from mrpro.utils.fft import image_to_kspace
+from mrpro.utils.fft import kspace_to_image
+
+
+def remove_readout_os(kdata: KData) -> KData:
+    """Remove any oversampling along the readout (k0) direction.
+
+    Parameters
+    ----------
+    kdata
+        K-space data
+
+    Returns
+    -------
+        K-space data with oversampling removed.
+
+    Raises
+    ------
+    ValueError
+        If the recon matrix along x is smaller than the encoding matrix along x.
+    """
+    # Ratio between encoded and recon space
+    dim_ratio = kdata.header.recon_matrix.x / kdata.header.encoding_matrix.x
+
+    # If the encoded and recon space is the same we don't have to do anything
+    if dim_ratio == 1:
+        return kdata
+    elif dim_ratio > 1:
+        raise ValueError('Recon matrix along x should be equal or larger than encoding matrix along x.')
+    else:
+        # Starting and end point of image after removing oversampling
+        start_cropped_readout = (kdata.header.encoding_matrix.x - kdata.header.recon_matrix.x) // 2
+        end_cropped_readout = start_cropped_readout + kdata.header.recon_matrix.x
+
+        def crop_readout(input):
+            return input[..., start_cropped_readout:end_cropped_readout]
+
+        # Transform to image space, crop to reconstruction matrix size and transform back
+        dat = kspace_to_image(kdata.data, dim=(-1,))
+        dat = crop_readout(dat)
+        dat = image_to_kspace(dat, dim=(-1,))
+
+        # Adapt trajectory
+        ks = [kdata.traj.kz, kdata.traj.ky, kdata.traj.kx]
+        for ax in range(3):
+            if ks[ax].shape[-1] > 1:
+                ks[ax] = crop_readout(ks[ax])
+        traj = KTrajectory(kz=ks[0], ky=ks[1], kx=ks[2])
+
+        # Adapt header parameters
+        hdr = kdata.header
+        hdr.acq_info.center_sample -= start_cropped_readout
+        hdr.acq_info.number_of_samples[:] = dat.shape[-1]
+        hdr.encoding_matrix.x = dat.shape[-1]
+
+        hdr.acq_info.discard_post = (hdr.acq_info.discard_post * dim_ratio).to(torch.int32)
+        hdr.acq_info.discard_pre = (hdr.acq_info.discard_pre * dim_ratio).to(torch.int32)
+
+    return KData(hdr, dat, traj)

--- a/src/mrpro/utils/fft.py
+++ b/src/mrpro/utils/fft.py
@@ -1,0 +1,49 @@
+"""Wrapper for FFT and IFFT."""
+
+# Copyright 2023 Physikalisch-Technische Bundesanstalt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import torch
+
+
+def kspace_to_image(kdat: torch.Tensor, dim: tuple[int, ...] = (-1, -2, -3)) -> torch.Tensor:
+    """IFFT from k-space to image space.
+
+    Parameters
+    ----------
+    kdat
+        k-space data on Cartesian grid
+    dim, optional
+        dim along which iFFT is applied, by default last three dimensions (-1, -2, -3)
+
+    Returns
+    -------
+        iFFT of kdat
+    """
+    return torch.fft.fftshift(torch.fft.ifftn(torch.fft.ifftshift(kdat, dim=dim), dim=dim, norm='ortho'), dim=dim)
+
+
+def image_to_kspace(idat: torch.Tensor, dim: tuple[int, ...] = (-1, -2, -3)) -> torch.Tensor:
+    """FFT from image space to k-space.
+
+    Parameters
+    ----------
+    idat
+        image data on Cartesian grid
+    dim, optional
+        dim along which iFFT is applied, by default last three dimensions (-1, -2, -3)
+
+    Returns
+    -------
+        FFT of idat
+    """
+    return torch.fft.ifftshift(torch.fft.fftn(torch.fft.fftshift(idat, dim=dim), dim=dim, norm='ortho'), dim=dim)

--- a/src/mrpro/utils/fft.py
+++ b/src/mrpro/utils/fft.py
@@ -40,7 +40,7 @@ def image_to_kspace(idat: torch.Tensor, dim: tuple[int, ...] = (-1, -2, -3)) -> 
     idat
         image data on Cartesian grid
     dim, optional
-        dim along which iFFT is applied, by default last three dimensions (-1, -2, -3)
+        dim along which FFT is applied, by default last three dimensions (-1, -2, -3)
 
     Returns
     -------

--- a/tests/algorithms/test_remove_readout_os.py
+++ b/tests/algorithms/test_remove_readout_os.py
@@ -1,0 +1,82 @@
+"""Test remove oversampling along readout."""
+
+# Copyright 2023 Physikalisch-Technische Bundesanstalt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import torch
+from einops import repeat
+
+from mrpro.algorithms import remove_readout_os
+from mrpro.data import KData
+from mrpro.data import KTrajectory
+from mrpro.data import SpatialDimension
+from mrpro.utils.fft import kspace_to_image
+from tests import RandomGenerator
+from tests.conftest import random_kheader
+from tests.helper import rel_image_diff
+from tests.phantoms._EllipsePhantomTestData import EllipsePhantomTestData
+
+
+def test_remove_readout_os(monkeypatch, random_kheader):
+    # Dimensions
+    ncoils = 4
+    nk0 = 240
+    nk1 = 240
+    nk0_os = 320
+    discard_pre = 10
+    discard_post = 20
+
+    random_generator = RandomGenerator(seed=0)
+
+    # List of k1 indices in the shape
+    idx_k1 = torch.arange(nk1, dtype=torch.int32)[None, None, ...]
+
+    # Set parameters need in remove_os
+    monkeypatch.setattr(random_kheader.encoding_matrix, 'x', nk0_os)
+    monkeypatch.setattr(random_kheader.recon_matrix, 'x', nk0)
+    monkeypatch.setattr(random_kheader.acq_info, 'center_sample', torch.zeros_like(idx_k1) + nk0_os // 2)
+    monkeypatch.setattr(random_kheader.acq_info, 'number_of_samples', torch.zeros_like(idx_k1) + nk0_os)
+    monkeypatch.setattr(random_kheader.acq_info, 'discard_pre', torch.tensor(discard_pre, dtype=torch.int32))
+    monkeypatch.setattr(random_kheader.acq_info, 'discard_post', torch.tensor(discard_post, dtype=torch.int32))
+
+    # Create kspace and image with oversampling
+    ph_os = EllipsePhantomTestData(ny=nk1, nx=nk0_os)
+    kdat_os = ph_os.phantom.kspace(ph_os.ky, ph_os.kx)
+    im_dim = SpatialDimension(z=1, y=nk1, x=nk0_os)
+    idat = ph_os.phantom.image_space(im_dim)
+
+    # Crop image data
+    idat_start = (nk0_os - nk0) // 2
+    idat = idat[..., idat_start : idat_start + nk0]
+
+    # Create k-space data with correct dimensions
+    kdat = repeat(kdat_os, 'k1 k0 -> other coils k2 k1 k0', other=1, coils=ncoils, k2=1)
+
+    # Create random 2D Cartesian trajectory
+    kx = random_generator.float32_tensor(size=(1, 1, 1, nk0_os))
+    ky = random_generator.float32_tensor(size=(1, 1, nk1, 1))
+    kz = random_generator.float32_tensor(size=(1, 1, 1, 1))
+    ktraj = KTrajectory(kz, ky, kx)
+
+    # Create KData
+    kdata = KData(header=random_kheader, data=kdat, traj=ktraj)
+
+    # Remove oversampling
+    kdata = remove_readout_os(kdata)
+
+    # Reconstruct image from k-space data of one coil and compare to phantom image
+    idat_rec = kspace_to_image(kdata.data[:, 0, ...], dim=(-1, -2))
+
+    # Due to discretisation artifacts the reconstructed image will be different to the reference image. Using standard
+    # testing functions such as numpy.testing.assert_almost_equal fails because there are few voxels with high
+    # differences along the edges of the elliptic objects.
+    assert rel_image_diff(torch.abs(idat_rec), idat[:, 0, ...]) <= 0.05

--- a/tests/data/test_kdata.py
+++ b/tests/data/test_kdata.py
@@ -18,8 +18,8 @@ import torch
 from mrpro.data import KData
 from mrpro.data import KTrajectory
 from mrpro.data.traj_calculators._KTrajectoryCalculator import DummyTrajectory
+from mrpro.utils.fft import kspace_to_image
 from tests.data import IsmrmrdRawTestData
-from tests.helper import kspace_to_image
 from tests.helper import rel_image_diff
 from tests.phantoms.test_ellipse_phantom import ph_ellipse
 
@@ -66,7 +66,7 @@ def test_KData_from_file_diff_nky_for_rep(ismrmrd_cart_invalid_reps):
 def test_KData_kspace(ismrmrd_cart):
     """Read in data and verify k-space by comparing reconstructed image."""
     k = KData.from_file(ismrmrd_cart.filename, DummyTrajectory())
-    irec = kspace_to_image(k.data)
+    irec = kspace_to_image(k.data, dim=(-1, -2))
 
     # Due to discretisation artifacts the reconstructed image will be different to the reference image. Using standard
     # testing functions such as numpy.testing.assert_almost_equal fails because there are few voxels with high

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -15,23 +15,6 @@
 import torch
 
 
-def kspace_to_image(kdat, dim=(-1, -2)):
-    """IFFT from k-space to image space.
-
-    Parameters
-    ----------
-    kdat
-        k-space data on Cartesian grid
-    dim, optional
-        dim along which iFFT is applied, by default last two dimensions (-1, -2)
-
-    Returns
-    -------
-        FFT of kdat
-    """
-    return torch.fft.fftshift(torch.fft.ifftn(torch.fft.ifftshift(kdat, dim=dim), dim=dim, norm='ortho'), dim=dim)
-
-
 def rel_image_diff(im1, im2):
     """Calculate mean absolute relative difference between two images.
 

--- a/tests/phantoms/test_ellipse_phantom.py
+++ b/tests/phantoms/test_ellipse_phantom.py
@@ -16,7 +16,7 @@ import pytest
 import torch
 
 from mrpro.data import SpatialDimension
-from tests.helper import kspace_to_image
+from mrpro.utils.fft import kspace_to_image
 from tests.helper import rel_image_diff
 from tests.phantoms._EllipsePhantomTestData import EllipsePhantomTestData
 
@@ -55,7 +55,7 @@ def test_kspace_image_match(ph_ellipse):
     im_dim = SpatialDimension(z=1, y=ph_ellipse.ny, x=ph_ellipse.nx)
     im = ph_ellipse.phantom.image_space(im_dim)
     kdat = ph_ellipse.phantom.kspace(ph_ellipse.ky, ph_ellipse.kx)
-    irec = kspace_to_image(kdat)
+    irec = kspace_to_image(kdat, dim=(-1, -2))
     # Due to discretisation artifacts the reconstructed image will be different to the reference image. Using standard
     # testing functions such as numpy.testing.assert_almost_equal fails because there are few voxels with high
     # differences along the edges of the elliptic objects.

--- a/tests/utils/test_fft.py
+++ b/tests/utils/test_fft.py
@@ -1,0 +1,56 @@
+"""Tests for image space - k-space transformations."""
+
+# Copyright 2023 Physikalisch-Technische Bundesanstalt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import numpy as np
+import pytest
+import torch
+
+from mrpro.utils.fft import image_to_kspace
+from mrpro.utils.fft import kspace_to_image
+
+
+@pytest.mark.parametrize('npoints, a', [(100, 20), (300, 20)])
+def test_kspace_to_image(npoints, a):
+    """Test k-space to image transformation using a Gaussian."""
+    # Utilize that a Fourier transform of a Gaussian function is given by
+    # F(exp(-x^2/a)) = sqrt(pi*a)exp(-a*pi^2k^2)
+
+    # Define k-space between [-1, 1) and image space accordingly
+    dk = 2 / npoints
+    k = torch.linspace(-1, 1 - dk, npoints)
+    dx = 1 / 2
+    x = torch.linspace(-1 / (2 * dk), 1 / (2 * dk) - dx, npoints)
+
+    # Create Gaussian function in k-space and image space
+    igauss = torch.exp(-(x**2) / a).to(torch.complex64)
+    kgauss = np.sqrt(torch.pi * a) * torch.exp(-a * torch.pi**2 * k**2).to(torch.complex64)
+
+    # Transform k-space to image
+    kgauss_fft = kspace_to_image(kgauss, dim=(0,))
+
+    # Scaling to "undo" fft scaling
+    kgauss_fft *= 2 / np.sqrt(npoints)
+    torch.testing.assert_close(kgauss_fft, igauss)
+
+
+def test_image_to_kspace_as_inverse():
+    """Test if image_to_kspace is the inverse of kspace_to_image."""
+
+    # Create random 3D data set
+    npoints = [200, 100, 50]
+    idat = torch.randn(*npoints, dtype=torch.complex64)
+
+    # Transform to k-space and back along all three dimensions
+    idat_transform = image_to_kspace(kspace_to_image(idat))
+    torch.testing.assert_close(idat, idat_transform)


### PR DESCRIPTION
Closes #4 

- moved kspace_to_image to utils and added image_to_kspace
- added tests for both
- implemented remove oversampling similar to https://github.com/gadgetron/gadgetron-python/blob/1fa47cc3943542dffd184a541399f57d73347731/gadgetron/examples/recon_acquisitions.py#L49

I am not sure about the test for remove_readout_os. Currently I am only testing if the image is correct but not if all the dimensions and trajectory are correct. 

Maybe sufficient to replace kspace_to_images in the test with the FourierOperator once it is merged to ensure we can still reconstruct an image. This should then implicitly also verify that all dimensions needed for a simple image reconstruction are still correct.