### PR TITLE
update supported python version to 3.10 & 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MR image reconstruction and processing package specifically developed for PyTorc
 
 This package supports ismrmrd-format for MR raw data. All data containers utilize PyTorch-tensors to ensure easy integration in PyTorch-based network schemes.
 
-![Python](https://img.shields.io/badge/python-3.10+-blue)
+![Python](https://img.shields.io/badge/python-3.10%20|%203.11-blue)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 ![Coverage Bagde](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/ckolbPTB/48e334a10caf60e6708d7c712e56d241/raw/coverage.json)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "MRpro"
 version = "0.0.1"
 description = "MR image reconstruction and processing package specifically developed for PyTorch."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.12"
 license = { file = "LICENSE" }
 keywords = ["MRI, reconstruction, processing, PyTorch"]
 authors = [
@@ -25,7 +25,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [


### PR DESCRIPTION
Pytorch does not support Python 3.12, yet.

Therefore, I limited the python version in pyproject.toml to ">3.10, <3.12" and adjusted the badge in the README

closes #100 