### PR TITLE
Gpu support

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run PyTest
 
         run: |
-          pytest -n 4 --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=mrpro | tee pytest-coverage.txt
+          pytest -n 4 -m "not cuda" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=mrpro | tee pytest-coverage.txt
 
       - name: Pytest coverage comment
         id: coverageComment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ docs = ["sphinx", "pydata-sphinx-theme", "sphinx-pyproject"]
 testpaths = ["tests"]
 filterwarnings = ["error"]
 # addopts = "-n auto" # TODO: debug vscode missing tests if enabled
+markers = ["cuda : Tests only to be run when cuda device is available"]
 
 # MyPy section
 [tool.mypy]
@@ -66,6 +67,8 @@ check_untyped_defs = "True"
 warn_no_return = "True"
 warn_unreachable = "True"
 exclude = ["docs"]
+enable_error_code = ["ignore-without-code"]
+warn_unused_ignores = "True"
 
 [[tool.mypy.overrides]]
 module = ["ismrmrd.*", "h5py", "scipy.*"]

--- a/src/mrpro/data/_Data.py
+++ b/src/mrpro/data/_Data.py
@@ -1,0 +1,73 @@
+"""Base class for data objects."""
+
+# Copyright 2023 Physikalisch-Technische Bundesanstalt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from __future__ import annotations
+
+import dataclasses
+from abc import ABC
+from typing import Any
+
+import torch
+
+
+@dataclasses.dataclass(slots=True, frozen=True)
+class Data(ABC):
+    """A general data class with field data and header."""
+
+    data: torch.Tensor
+    header: Any
+
+    def to(self, *args, **kwargs) -> Data:
+        """Perform dtype and/or device conversion of data.
+
+        A torch.dtype and torch.device are inferred from the arguments
+        of self.to(*args, **kwargs). Please have a look at the
+        documentation of torch.Tensor.to() for more details.
+        """
+        return Data(header=self.header, data=self.data.to(*args, **kwargs))
+
+    def cuda(
+        self,
+        device: torch.device | None = None,
+        non_blocking: bool = False,
+        memory_format: torch.memory_format = torch.preserve_format,
+    ) -> Data:
+        """Create copy of object with data in CUDA memory.
+
+        Parameters
+        ----------
+        device
+            The destination GPU device. Defaults to the current CUDA device.
+        non_blocking
+            If True and the source is in pinned memory, the copy will be asynchronous with respect to the host.
+            Otherwise, the argument has no effect.
+        memory_format
+            The desired memory format of returned tensor.
+        """
+        return Data(
+            header=self.header,
+            data=self.data.cuda(
+                device=device, non_blocking=non_blocking, memory_format=memory_format
+            ),  # type: ignore [call-arg]
+        )
+
+    def cpu(self, memory_format: torch.memory_format = torch.preserve_format) -> Data:
+        """Create copy of object in CPU memory.
+
+        Parameters
+        ----------
+        memory_format
+            The desired memory format of returned tensor.
+        """
+        return Data(header=self.header, data=self.data.cpu(memory_format=memory_format))  # type: ignore [call-arg]

--- a/src/mrpro/data/_DcfData.py
+++ b/src/mrpro/data/_DcfData.py
@@ -98,9 +98,9 @@ class DcfData:
 
         # Calculate dcf only for unique k-space positions
         traj_dim = traj.shape
-        traj = np.round(traj.numpy(), decimals=UNIQUE_ROUNDING_DECIMALS)
-        traj = traj.reshape(dim, -1)
-        traj_unique, inverse, counts = np.unique(traj, return_inverse=True, return_counts=True, axis=1)
+        traj_numpy = np.round(traj.cpu().numpy(), decimals=UNIQUE_ROUNDING_DECIMALS)
+        traj_numpy = traj_numpy.reshape(dim, -1)
+        traj_unique, inverse, counts = np.unique(traj_numpy, return_inverse=True, return_counts=True, axis=1)
 
         # Especially in 3D, errors in the calculation of the convex hull can occur for edge points. To avoid this,
         # the corner points of a cube bounding box are added here. The bounding box is chosen very large to ensure these
@@ -135,7 +135,7 @@ class DcfData:
         # Sort dcf values back into the original order (i.e. before calling unique)
         dcf = np.reshape((dcf / counts)[inverse], traj_dim[1:])
 
-        return torch.tensor(dcf, dtype=torch.float32)
+        return torch.tensor(dcf, dtype=torch.float32, device=traj.device)
 
     @classmethod
     def from_traj_voronoi(cls, traj: KTrajectory) -> DcfData:

--- a/src/mrpro/data/_IData.py
+++ b/src/mrpro/data/_IData.py
@@ -24,6 +24,7 @@ from pydicom import dcmread
 from pydicom.dataset import Dataset
 from pydicom.tag import Tag
 
+from mrpro.data import Data
 from mrpro.data import IHeader
 from mrpro.data import KHeader
 
@@ -54,11 +55,10 @@ def _dcm_pixelarray_to_tensor(ds: Dataset) -> torch.Tensor:
 
 
 @dataclasses.dataclass(slots=True, frozen=True)
-class IData:
+class IData(Data):
     """MR image data (IData) class."""
 
     header: IHeader
-    data: torch.Tensor
 
     @classmethod
     def from_tensor_and_kheader(cls, data: torch.Tensor, kheader: KHeader) -> IData:

--- a/src/mrpro/data/_KData.py
+++ b/src/mrpro/data/_KData.py
@@ -171,3 +171,89 @@ class KData:
             )
 
         return cls(kheader, kdata, ktraj)
+
+    def to(
+        self,
+        device: torch.device | str | None = None,
+        dtype: None | torch.dtype = None,
+        non_blocking: bool = False,
+        copy: bool = False,
+        memory_format: torch.memory_format = torch.preserve_format,
+    ) -> KData:
+        """Perform dtype and/or device conversion of trajectory and data.
+
+        Parameters
+        ----------
+        device
+            The destination device. Defaults to the current device.
+        dtype
+            Dtype of the k-space data, can only be torch.complex64 or torch.complex128.
+            The dtype of the trajectory (torch.float32 or torch.float64) is then inferred from this.
+        non_blocking
+            If True and the source is in pinned memory, the copy will be asynchronous with respect to the host.
+            Otherwise, the argument has no effect.
+        copy
+            If True a new Tensor is created even when the Tensor already matches the desired conversion.
+        memory_format
+            The desired memory format of returned Tensor.
+        """
+        # Only complex64 and complex128 supported for kdata.
+        # This will then lead to a trajectory of float32 and float64, respectively.
+        if dtype is None:
+            dtype_traj = None
+        elif dtype == torch.complex64:
+            dtype_traj = torch.float32
+        elif dtype == torch.complex128:
+            dtype_traj = torch.float64
+        else:
+            raise ValueError(f'dtype {dtype} not supported. Only torch.complex64 and torch.complex128 is supported.')
+
+        return KData(
+            header=self.header,
+            data=self.data.to(
+                device=device, dtype=dtype, non_blocking=non_blocking, copy=copy, memory_format=memory_format
+            ),  # type: ignore [call-overload]
+            traj=self.traj.to(
+                device=device, dtype=dtype_traj, non_blocking=non_blocking, copy=copy, memory_format=memory_format
+            ),
+        )
+
+    def cuda(
+        self,
+        device: torch.device | None = None,
+        non_blocking: bool = False,
+        memory_format: torch.memory_format = torch.preserve_format,
+    ) -> KData:
+        """Create copy of object with trajectory and data in CUDA memory.
+
+        Parameters
+        ----------
+        device
+            The destination GPU device. Defaults to the current CUDA device.
+        non_blocking
+            If True and the source is in pinned memory, the copy will be asynchronous with respect to the host.
+            Otherwise, the argument has no effect.
+        memory_format
+            The desired memory format of returned Tensor.
+        """
+        return KData(
+            header=self.header,
+            data=self.data.cuda(
+                device=device, non_blocking=non_blocking, memory_format=memory_format
+            ),  # type: ignore [call-arg]
+            traj=self.traj.cuda(device=device, non_blocking=non_blocking, memory_format=memory_format),
+        )
+
+    def cpu(self, memory_format: torch.memory_format = torch.preserve_format) -> KData:
+        """Create copy of object in CPU memory.
+
+        Parameters
+        ----------
+        memory_format
+            The desired memory format of returned Tensor.
+        """
+        return KData(
+            header=self.header,
+            data=self.data.cpu(memory_format=memory_format),  # type: ignore [call-arg]
+            traj=self.traj.cpu(memory_format=memory_format),
+        )

--- a/src/mrpro/data/_KTrajectory.py
+++ b/src/mrpro/data/_KTrajectory.py
@@ -109,3 +109,58 @@ class KTrajectory:
 
         kz, ky, kx = torch.unbind(tensor, dim=stack_dim)
         return cls(kz, ky, kx, repeat_detection_tolerance=repeat_detection_tolerance)
+
+    def to(self, *args, **kwargs) -> KTrajectory:
+        """Perform dtype and/or device conversion of trajectory.
+
+        A torch.dtype and torch.device are inferred from the arguments
+        of self.to(*args, **kwargs). Please have a look at the
+        documentation of torch.Tensor.to() for more details.
+        """
+        return KTrajectory(
+            kz=self.kz.to(*args, **kwargs), ky=self.ky.to(*args, **kwargs), kx=self.kx.to(*args, **kwargs)
+        )
+
+    def cuda(
+        self,
+        device: torch.device | None = None,
+        non_blocking: bool = False,
+        memory_format: torch.memory_format = torch.preserve_format,
+    ) -> KTrajectory:
+        """Create copy of trajectory in CUDA memory.
+
+        Parameters
+        ----------
+        device
+            The destination GPU device. Defaults to the current CUDA device.
+        non_blocking
+            If True and the source is in pinned memory, the copy will be asynchronous with respect to the host.
+            Otherwise, the argument has no effect.
+        memory_format
+            The desired memory format of returned Tensor.
+        """
+        return KTrajectory(
+            kz=self.kz.cuda(
+                device=device, non_blocking=non_blocking, memory_format=memory_format
+            ),  # type: ignore [call-arg]
+            ky=self.ky.cuda(
+                device=device, non_blocking=non_blocking, memory_format=memory_format
+            ),  # type: ignore [call-arg]
+            kx=self.kx.cuda(
+                device=device, non_blocking=non_blocking, memory_format=memory_format
+            ),  # type: ignore [call-arg]
+        )
+
+    def cpu(self, memory_format: torch.memory_format = torch.preserve_format) -> KTrajectory:
+        """Create copy of trajectory in CPU memory.
+
+        Parameters
+        ----------
+        memory_format
+            The desired memory format of returned Tensor.
+        """
+        return KTrajectory(
+            kz=self.kz.cpu(memory_format=memory_format),  # type: ignore [call-arg]
+            ky=self.ky.cpu(memory_format=memory_format),  # type: ignore [call-arg]
+            kx=self.kx.cpu(memory_format=memory_format),  # type: ignore [call-arg]
+        )

--- a/src/mrpro/data/_QData.py
+++ b/src/mrpro/data/_QData.py
@@ -22,16 +22,16 @@ import torch
 from einops import rearrange
 from pydicom import dcmread
 
+from mrpro.data import Data
 from mrpro.data import IHeader
 from mrpro.data import KHeader
 from mrpro.data import QHeader
 
 
 @dataclasses.dataclass(init=False, slots=True, frozen=True)
-class QData:
+class QData(Data):
     """MR quantitative data (QData) class."""
 
-    data: torch.Tensor
     header: QHeader
 
     def __init__(self, data: torch.Tensor, header: KHeader | IHeader | QHeader) -> None:

--- a/src/mrpro/data/__init__.py
+++ b/src/mrpro/data/__init__.py
@@ -8,6 +8,7 @@ from mrpro.data._KTrajectoryRawShape import KTrajectoryRawShape
 from mrpro.data._EncodingLimits import EncodingLimits
 from mrpro.data._EncodingLimits import Limits
 from mrpro.data._KHeader import KHeader
+from mrpro.data._Data import Data
 from mrpro.data._KData import KData
 from mrpro.data._KNoise import KNoise
 from mrpro.data._IHeader import IHeader

--- a/src/mrpro/operators/_FourierOp.py
+++ b/src/mrpro/operators/_FourierOp.py
@@ -137,10 +137,10 @@ class FourierOp(LinearOperator):
 
             self._omega = torch.stack(omega, dim=-2)
             self._fwd_nufft_op = KbNufft(
-                im_size=nufft_im_size, grid_size=grid_size, numpoints=numpoints, kbwidth=kbwidth
+                im_size=nufft_im_size, grid_size=grid_size, numpoints=numpoints, kbwidth=kbwidth, device=traj.kx.device
             )
             self._adj_nufft_op = KbNufftAdjoint(
-                im_size=nufft_im_size, grid_size=grid_size, numpoints=numpoints, kbwidth=kbwidth
+                im_size=nufft_im_size, grid_size=grid_size, numpoints=numpoints, kbwidth=kbwidth, device=traj.kx.device
             )
 
         self._ignore_dims = tuple(ignore_dims)

--- a/tests/data/test_dcf_data.py
+++ b/tests/data/test_dcf_data.py
@@ -214,3 +214,17 @@ def test_dcf_spiral_traj_voronoi_singlespiral():
     ignore_last = int(nkr / nki)  # ignore the outer points of the spirals
     torch.testing.assert_close(dcf_three_dense.data[..., 1, :-ignore_last], dcf_single.data[..., 0, :-ignore_last])
     torch.testing.assert_close(dcf_three_broadcast.data[..., 1, :-ignore_last], dcf_single.data[..., 0, :-ignore_last])
+
+
+@pytest.mark.cuda
+@pytest.mark.parametrize(
+    'nkr,nka,nk0',
+    [
+        (10, 6, 20),
+    ],
+)
+def test_dcf_rpe_traj_voronoi_cuda(nkr, nka, nk0):
+    """Voronoi-based dcf calculation for RPE trajectory in CUDA memory."""
+    ktraj = example_traj_rpe(nkr, nka, nk0)
+    dcf = DcfData.from_traj_voronoi(ktraj.cuda())
+    assert dcf.data.is_cuda

--- a/tests/data/test_idata.py
+++ b/tests/data/test_idata.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 
 import numpy as np
+import pytest
 import torch
 
 from mrpro.data import IData
@@ -44,3 +45,26 @@ def test_IData_from_kheader_and_tensor(random_kheader, random_test_data):
     """IData from KHeader and data tensor."""
     idat = IData.from_tensor_and_kheader(data=random_test_data, kheader=random_kheader)
     assert idat.header.te == random_kheader.te
+
+
+def test_IData_to_complex128(random_kheader, random_test_data):
+    """Change IData dtype complex128."""
+    idat = IData.from_tensor_and_kheader(data=random_test_data, kheader=random_kheader)
+    idat_complex128 = idat.to(dtype=torch.complex128)
+    assert idat_complex128.data.dtype == torch.complex128
+
+
+@pytest.mark.cuda
+def test_IData_cuda(random_kheader, random_test_data):
+    """Move IData object to CUDA memory."""
+    idat = IData.from_tensor_and_kheader(data=random_test_data, kheader=random_kheader)
+    idat_cuda = idat.cuda()
+    assert idat_cuda.data.is_cuda
+
+
+@pytest.mark.cuda
+def test_IData_cpu(random_kheader, random_test_data):
+    """Move IData object to CUDA memory and back to CPU memory."""
+    idat = IData.from_tensor_and_kheader(data=random_test_data, kheader=random_kheader)
+    idat_cpu = idat.cuda().cpu()
+    assert idat_cpu.data.is_cpu

--- a/tests/data/test_kdata.py
+++ b/tests/data/test_kdata.py
@@ -81,3 +81,47 @@ def test_KData_modify_header(ismrmrd_cart, field, value):
     par_dict = {field: value}
     k = KData.from_file(ismrmrd_cart.filename, DummyTrajectory(), header_overwrites=par_dict)
     assert getattr(k.header, field) == value
+
+
+def test_KData_to_complex128(ismrmrd_cart):
+    """Change KData dtype complex128."""
+    k = KData.from_file(ismrmrd_cart.filename, DummyTrajectory())
+    k_complex128 = k.to(dtype=torch.complex128)
+    assert k_complex128.data.dtype == torch.complex128
+    assert k_complex128.traj.kx.dtype == torch.float64
+    assert k_complex128.traj.ky.dtype == torch.float64
+    assert k_complex128.traj.kz.dtype == torch.float64
+
+
+@pytest.mark.cuda
+def test_KData_to_cuda(ismrmrd_cart):
+    """Test KData.to to move data to CUDA memory."""
+    k = KData.from_file(ismrmrd_cart.filename, DummyTrajectory())
+    cuda_device = f'cuda:{torch.cuda.current_device()}'
+    kcuda = k.to(device=cuda_device)
+    assert kcuda.data.is_cuda
+    assert kcuda.traj.kz.is_cuda
+    assert kcuda.traj.ky.is_cuda
+    assert kcuda.traj.kx.is_cuda
+
+
+@pytest.mark.cuda
+def test_KData_cuda(ismrmrd_cart):
+    """Move KData object to CUDA memory."""
+    k = KData.from_file(ismrmrd_cart.filename, DummyTrajectory())
+    kcuda = k.cuda()
+    assert kcuda.data.is_cuda
+    assert kcuda.traj.kz.is_cuda
+    assert kcuda.traj.ky.is_cuda
+    assert kcuda.traj.kx.is_cuda
+
+
+@pytest.mark.cuda
+def test_KData_cpu(ismrmrd_cart):
+    """Move KData object to CUDA memory and back to CPU memory."""
+    k = KData.from_file(ismrmrd_cart.filename, DummyTrajectory())
+    kcpu = k.cuda().cpu()
+    assert kcpu.data.is_cpu
+    assert kcpu.traj.kz.is_cpu
+    assert kcpu.traj.ky.is_cpu
+    assert kcpu.traj.kx.is_cpu

--- a/tests/data/test_ktraj.py
+++ b/tests/data/test_ktraj.py
@@ -103,3 +103,47 @@ def test_ktraj_raise_wrong_dim():
     kx = ky = kz = torch.arange(1 * 2 * 3).reshape(1, 2, 3)
     with pytest.raises(ValueError):
         ktraj = KTrajectory(kz, ky, kx)
+
+
+def test_ktraj_to_float64(cartesian_grid):
+    """Change KTrajectory dtype to float64."""
+    nk0 = 10
+    nk1 = 20
+    nk2 = 30
+    kz_full, ky_full, kx_full = cartesian_grid(nk2, nk1, nk0, jitter=0.0)
+    ktraj = KTrajectory(kz_full, ky_full, kx_full)
+
+    ktraj_float64 = ktraj.to(dtype=torch.float64)
+    assert ktraj_float64.kz.dtype == torch.float64
+    assert ktraj_float64.ky.dtype == torch.float64
+    assert ktraj_float64.kx.dtype == torch.float64
+
+
+@pytest.mark.cuda
+def test_ktraj_cuda(cartesian_grid):
+    """Move KTrajectory object to CUDA memory."""
+    nk0 = 10
+    nk1 = 20
+    nk2 = 30
+    kz_full, ky_full, kx_full = cartesian_grid(nk2, nk1, nk0, jitter=0.0)
+    ktraj = KTrajectory(kz_full, ky_full, kx_full)
+
+    ktraj_cuda = ktraj.cuda()
+    assert ktraj_cuda.kz.is_cuda
+    assert ktraj_cuda.ky.is_cuda
+    assert ktraj_cuda.kx.is_cuda
+
+
+@pytest.mark.cuda
+def test_ktraj_cpu(cartesian_grid):
+    """Move KTrajectory object to CUDA memory and back to CPU memory."""
+    nk0 = 10
+    nk1 = 20
+    nk2 = 30
+    kz_full, ky_full, kx_full = cartesian_grid(nk2, nk1, nk0, jitter=0.0)
+    ktraj = KTrajectory(kz_full, ky_full, kx_full)
+
+    ktraj_cpu = ktraj.cuda().cpu()
+    assert ktraj_cpu.kz.is_cpu
+    assert ktraj_cpu.ky.is_cpu
+    assert ktraj_cpu.kx.is_cpu

--- a/tests/data/test_qdata.py
+++ b/tests/data/test_qdata.py
@@ -12,6 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import pytest
 import torch
 
 from mrpro.data import IHeader
@@ -40,3 +41,26 @@ def test_QData_from_dcm_file(dcm_2d):
     # QData uses complex values but dicom only supports real values
     im = torch.real(qdat.data[0, 0, 0, ...])
     torch.testing.assert_close(im, dcm_2d.imref)
+
+
+def test_QData_to_complex128(random_kheader, random_test_data):
+    """Change IData dtype complex128."""
+    qdat = QData(data=random_test_data, header=random_kheader)
+    qdat_complex128 = qdat.to(dtype=torch.complex128)
+    assert qdat_complex128.data.dtype == torch.complex128
+
+
+@pytest.mark.cuda
+def test_QData_cuda(random_kheader, random_test_data):
+    """Move IData object to CUDA memory."""
+    qdat = QData(data=random_test_data, header=random_kheader)
+    qdat_cuda = qdat.cuda()
+    assert qdat_cuda.data.is_cuda
+
+
+@pytest.mark.cuda
+def test_QData_cpu(random_kheader, random_test_data):
+    """Move IData object to CUDA memory and back to CPU memory."""
+    qdat = QData(data=random_test_data, header=random_kheader)
+    qdat_cpu = qdat.cuda().cpu()
+    assert qdat_cpu.data.is_cpu


### PR DESCRIPTION
I tested a simple reconstruction pipeline on a GPU. Only needed a few fixes for it to run. 

I have implemented a very basic .cuda() and .cpu() functionality for KTrajectory and KData. If we are more or less happy with this approach I would extend this to IData, CsmData...

I also added tests which are marked "cuda". In order to run only the cuda-tests `pytest -m cuda` can be used.

I added the pytest flag `-m "not cuda"` to pytest.yml such that these tests are excluded from CI. 