### PR TITLE
Cartesian FFT

### DIFF
--- a/src/mrpro/data/traj_calculators/_KTrajectoryIsmrmrd.py
+++ b/src/mrpro/data/traj_calculators/_KTrajectoryIsmrmrd.py
@@ -45,7 +45,7 @@ class KTrajectoryIsmrmrd:
 
         Returns
         -------
-            trajectory in the shape of the original raw data within [-pi, pi].
+            trajectory in the shape of the original raw data
         """
 
         # Read out the trajectory
@@ -53,9 +53,6 @@ class KTrajectoryIsmrmrd:
 
         if ktraj_mrd.numel() == 0:
             raise ValueError('No trajectory information available in the acquisitions.')
-
-        # Scale trajectory to be within [-pi, pi]. Not ideal, but the best we can do.
-        ktraj_mrd *= torch.pi / ktraj_mrd.abs().max()
 
         if ktraj_mrd.shape[2] == 2:
             ktraj = KTrajectoryRawShape(

--- a/src/mrpro/data/traj_calculators/_KTrajectoryRadial2D.py
+++ b/src/mrpro/data/traj_calculators/_KTrajectoryRadial2D.py
@@ -57,7 +57,6 @@ class KTrajectoryRadial2D(KTrajectoryCalculator):
         # Calculate points along readout
         nk0 = int(num_samples[0, 0, 0])
         k0 = torch.linspace(0, nk0 - 1, nk0, dtype=torch.float32) - center_sample[0, 0, 0]
-        k0 *= 2 * torch.pi / nk0
         return k0
 
     def __call__(self, kheader: KHeader) -> KTrajectory:

--- a/src/mrpro/data/traj_calculators/_KTrajectoryRpe.py
+++ b/src/mrpro/data/traj_calculators/_KTrajectoryRpe.py
@@ -50,8 +50,8 @@ class KTrajectoryRpe(KTrajectoryCalculator):
         """Shift radial phase encoding lines relative to each other.
 
         Example: shift_between_rpe_lines = [0, 0.5, 0.25, 0.75] leads to a shift of the 0th line by 0,
-        the 1st line by 0.5*delta_k, the 2nd line by 0.25*delta_k, the 3rd line by 0.75*delta_k, the 4th line
-        by 0, the 5th line by 0.5*delta_k and so on. Phase encoding points in k-space center are not shifted.
+        the 1st line by 0.5, the 2nd line by 0.25, the 3rd line by 0.75, the 4th line by 0, the 5th line
+        by 0.5 and so on. Phase encoding points in k-space center are not shifted.
 
         Line #          k-space points before shift             k-space points after shift
         0               +    +    +    +    +    +    +         +    +    +    +    +    +    +
@@ -113,7 +113,6 @@ class KTrajectoryRpe(KTrajectoryCalculator):
         # Calculate points along readout
         nk0 = int(num_samples[0, 0, 0])
         k0 = torch.linspace(0, nk0 - 1, nk0, dtype=torch.float32) - center_sample[0, 0, 0]
-        k0 *= 2 * torch.pi / nk0
         return k0
 
     def _kang(self, kheader: KHeader) -> torch.Tensor:
@@ -144,7 +143,6 @@ class KTrajectoryRpe(KTrajectoryCalculator):
         """
         krad = (kheader.acq_info.idx.k1 - kheader.encoding_limits.k1.center).to(torch.float32)
         krad = self._apply_shifts_between_rpe_lines(krad, kheader.acq_info.idx.k2)
-        krad *= 2 * torch.pi / kheader.encoding_limits.k1.max
         return krad
 
     def __call__(self, kheader: KHeader) -> KTrajectory:

--- a/src/mrpro/data/traj_calculators/_KTrajectorySunflowerGoldenRpe.py
+++ b/src/mrpro/data/traj_calculators/_KTrajectorySunflowerGoldenRpe.py
@@ -101,5 +101,4 @@ class KTrajectorySunflowerGoldenRpe(KTrajectoryRpe):
         kang = self._kang(kheader)
         krad = (kheader.acq_info.idx.k1 - kheader.encoding_limits.k1.center).to(torch.float32)
         krad = self._apply_sunflower_shift_between_rpe_lines(krad, kang, kheader)
-        krad *= 2 * torch.pi / kheader.encoding_limits.k1.max
         return krad

--- a/src/mrpro/operators/_FourierOp.py
+++ b/src/mrpro/operators/_FourierOp.py
@@ -22,28 +22,27 @@ from mrpro.operators import LinearOperator
 from mrpro.utils import fft
 
 
-def is_uniform(x: torch.Tensor, atol: float = 1e-6) -> torch.Tensor:
-    """Check if a tensor contains equidistant sampling points.
+def is_on_cartesian_grid(x: torch.Tensor, atol: float = 1e-6) -> torch.Tensor:
+    """Check if a tensor contains sampling points on a Cartesian grid.
 
     Parameters
     ----------
     x
         tensor to be checked
     atol
-        tolerance of how similar the values have to be
+        tolerance of how close the values have to be to the grid points
 
     Returns
     -------
-        boolean tensor if sampling points are equidistant.
+        boolean tensor if sampling points are on a Cartesian grid.
 
     If the tensor has batch-dimension>1, this is checked for all batches.
     """
-    # TODO: currrently, this function is never used here.
 
     if x.shape[1:].count(1) <= 1:
         raise ValueError('x is allowed to have at most one non-singleton dimension')
     all_close_list = [
-        torch.allclose(torch.diff(x[kb, ...].flatten()), torch.diff(x[kb, ...].flatten())[0], atol=atol)
+        torch.allclose(x[kb, ...].to(dtype=torch.int64).to(dtype=x.dtype), x[kb, ...], atol=atol)
         for kb in range(x.shape[0])
     ]
 
@@ -56,9 +55,7 @@ class FourierOp(LinearOperator):
         recon_shape: SpatialDimension[int],
         encoding_shape: SpatialDimension[int],
         traj: KTrajectory,
-        oversampling: SpatialDimension[float] = SpatialDimension(
-            2.0, 2.0, 2.0
-        ),  # TODO: maybe not the nicest, since only used for nuFFT
+        oversampling: SpatialDimension[float] = SpatialDimension(2.0, 2.0, 2.0),
         numpoints: int = 6,
         kbwidth: float = 2.34,
     ) -> None:
@@ -111,6 +108,7 @@ class FourierOp(LinearOperator):
                 fft_dims.append(i)
                 fft_recon_shape.append(int(rs))
                 fft_encoding_shape.append(int(es))
+
             else:
                 # dimension with nuFFT
                 grid_size.append(int(os * rs))
@@ -124,15 +122,55 @@ class FourierOp(LinearOperator):
 
             traj_shape.append(k.shape)
 
-        # if non-uniform directions were identified, create the trajectories
-        # to perform the nuFFT
-        if len(nufft_dims) != 0:
-            for k in (traj.kz, traj.ky, traj.kx):
+        # if uniform directions were identified, create index to perform FFT
+        if len(fft_dims) > 0:
+            ktraj_tensor = traj.as_tensor()
+            if -1 in fft_dims:
+                kx_idx = ktraj_tensor[-1, ...] + encoding_shape.x // 2
+            else:
+                encoding_shape.x = ktraj_tensor.shape[-1]
+                kx_idx = torch.ones_like(ktraj_tensor[0, ...]) * rearrange(
+                    torch.linspace(0, ktraj_tensor.shape[-1] - 1, ktraj_tensor.shape[-1]), 'kx->1 1 1 kx'
+                )
+            if -2 in fft_dims:
+                ky_idx = ktraj_tensor[-2, ...] + encoding_shape.y // 2
+            else:
+                encoding_shape.y = ktraj_tensor.shape[-2]
+                ky_idx = torch.ones_like(ktraj_tensor[0, ...]) * rearrange(
+                    torch.linspace(0, ktraj_tensor.shape[-2] - 1, ktraj_tensor.shape[-2]), 'ky->1 1 ky 1'
+                )
+            if -3 in fft_dims:
+                kz_idx = ktraj_tensor[-3, ...] + encoding_shape.z // 2
+            else:
+                encoding_shape.z = ktraj_tensor.shape[-3]
+                kz_idx = torch.ones_like(ktraj_tensor[0, ...]) * rearrange(
+                    torch.linspace(0, ktraj_tensor.shape[-3] - 1, ktraj_tensor.shape[-3]), 'kz->1 kz 1 1'
+                )
+            other_idx = torch.ones_like(ktraj_tensor[0, ...]) * rearrange(
+                torch.linspace(0, ktraj_tensor.shape[1] - 1, ktraj_tensor.shape[1]), 'other->other 1 1 1'
+            )
+            kidx = (
+                other_idx * encoding_shape.z * encoding_shape.y * encoding_shape.x
+                + kz_idx * encoding_shape.y * encoding_shape.x
+                + ky_idx * encoding_shape.x
+                + kx_idx
+            )
+            kidx = repeat(
+                kidx.to(dtype=torch.int64, device=traj.kx.device), 'other k2 k1 k0->other coil k2 k1 k0', coil=1
+            )
+
+            self._fft_idx = kidx
+            self._fft_idx_full = torch.zeros(0)  # not None to satisfy mypy
+
+        # if non-uniform directions were identified, create the trajectories to perform the nuFFT
+        if len(nufft_dims) > 0:
+            for k, ks in zip((traj.kz, traj.ky, traj.kx), (encoding_shape.z, encoding_shape.y, encoding_shape.x)):
                 # check number of singleton dimensions
                 n_singleton_dims = k.shape[1:].count(1)
                 if n_singleton_dims <= 1:
                     # if not is_uniform(k): #TODO: is_uniform maybe never needed?
-                    omega.append(k.flatten(start_dim=-3))
+                    # Scale trajectory to [-pi pi] required by torchkbnufft
+                    omega.append(k.flatten(start_dim=-3) * 2 * torch.pi / ks)
 
             self._omega = torch.stack(omega, dim=-2)
             self._fwd_nufft_op = KbNufft(
@@ -149,6 +187,7 @@ class FourierOp(LinearOperator):
         self._fft_encoding_shape = tuple(fft_encoding_shape)
         self._kshape = torch.broadcast_shapes(*traj_shape)
         self._recon_shape = recon_shape
+        self._encoding_shape = encoding_shape
         self._nufft_im_size = nufft_im_size
 
     @staticmethod
@@ -199,9 +238,6 @@ class FourierOp(LinearOperator):
         if self._recon_shape != SpatialDimension(*x.shape[-3:]):
             raise ValueError('image data shape missmatch')
 
-        if len(self._fft_dims) != 0:
-            x = fft.image_to_kspace(x, encoding_shape=self._fft_encoding_shape, dim=self._fft_dims)
-
         if len(self._nufft_dims) != 0:
             init_pattern = 'other coils dim2 dim1 dim0'
             target_pattern = self.get_target_pattern(self._fft_dims, self._nufft_dims, self._ignore_dims)
@@ -229,7 +265,35 @@ class FourierOp(LinearOperator):
 
             # bring to shape defined by k-space trajectories
             nk2, nk1, nk0 = self._kshape[1:]
+            if -1 in self._fft_dims:
+                nk0 = self._recon_shape.x
+            if -2 in self._fft_dims:
+                nk1 = self._recon_shape.y
+            if -3 in self._fft_dims:
+                nk2 = self._recon_shape.z
             x = rearrange(x, target_pattern + '->' + init_pattern, other=nb, coils=nc, dim1=nk1, dim2=nk2, dim0=nk0)
+
+        if len(self._fft_dims) != 0:
+            xfft = fft.image_to_kspace(x, encoding_shape=self._fft_encoding_shape, dim=self._fft_dims)
+
+            if len(self._fft_idx_full) == 0 or self._fft_idx_full.shape[1] != x.shape[1]:
+                coil_idx = torch.ones(
+                    *(x.shape[:2] + self._fft_idx.shape[2:]), dtype=torch.int64, device=x.device
+                ) * rearrange(
+                    torch.linspace(0, x.shape[1] - 1, x.shape[1], dtype=torch.int64, device=x.device),
+                    'coils->1 coils 1 1 1',
+                )
+                other_idx = torch.ones_like(self._fft_idx, dtype=torch.int64, device=x.device) * rearrange(
+                    torch.linspace(0, x.shape[0] - 1, x.shape[0], dtype=torch.int64, device=x.device),
+                    'other->other 1 1 1 1',
+                )
+                self._fft_idx_full = (
+                    self._fft_idx
+                    + other_idx * x.shape[1]
+                    + coil_idx * self._encoding_shape.z * self._encoding_shape.y * self._encoding_shape.x
+                )
+
+            x = torch.take(xfft, self._fft_idx_full)
 
         return x
 
@@ -251,7 +315,31 @@ class FourierOp(LinearOperator):
 
         # apply IFFT
         if len(self._fft_dims) != 0:
-            y = fft.kspace_to_image(y, recon_shape=self._fft_recon_shape, dim=self._fft_dims)
+            if len(self._fft_idx_full) == 0 or self._fft_idx_full.shape[1] != y.shape[1]:
+                coil_idx = torch.ones(
+                    *(y.shape[:2] + self._fft_idx.shape[2:]), dtype=torch.int64, device=y.device
+                ) * rearrange(
+                    torch.linspace(0, y.shape[1] - 1, y.shape[1], dtype=torch.int64, device=y.device),
+                    'coils->1 coils 1 1 1',
+                )
+                other_idx = torch.ones_like(self._fft_idx, dtype=torch.int64, device=y.device) * rearrange(
+                    torch.linspace(0, y.shape[0] - 1, y.shape[0], dtype=torch.int64, device=y.device),
+                    'other->other 1 1 1 1',
+                )
+                self._fft_idx_full = (
+                    self._fft_idx
+                    + other_idx * y.shape[1]
+                    + coil_idx * self._encoding_shape.z * self._encoding_shape.y * self._encoding_shape.x
+                )
+
+            yfft = torch.zeros(
+                *(y.shape[:2] + (self._encoding_shape.z, self._encoding_shape.y, self._encoding_shape.x)),
+                dtype=y.dtype,
+                device=y.device,
+            )
+            y = fft.kspace_to_image(
+                yfft.put_(self._fft_idx_full, y, accumulate=True), recon_shape=self._fft_recon_shape, dim=self._fft_dims
+            )
 
         # move dim where FFT was already performed such nuFFT can be performed
         if len(self._nufft_dims) != 0:

--- a/src/mrpro/operators/_FourierOp.py
+++ b/src/mrpro/operators/_FourierOp.py
@@ -11,7 +11,6 @@
 #   limitations under the License.
 
 import torch
-import torch.nn.functional as F
 from einops import rearrange
 from einops import repeat
 from torchkbnufft import KbNufft
@@ -20,6 +19,7 @@ from torchkbnufft import KbNufftAdjoint
 from mrpro.data import KTrajectory
 from mrpro.data import SpatialDimension
 from mrpro.operators import LinearOperator
+from mrpro.utils import fft
 
 
 def is_uniform(x: torch.Tensor, atol: float = 1e-6) -> torch.Tensor:
@@ -53,7 +53,8 @@ def is_uniform(x: torch.Tensor, atol: float = 1e-6) -> torch.Tensor:
 class FourierOp(LinearOperator):
     def __init__(
         self,
-        im_shape: SpatialDimension[int],
+        recon_shape: SpatialDimension[int],
+        encoding_shape: SpatialDimension[int],
         traj: KTrajectory,
         oversampling: SpatialDimension[float] = SpatialDimension(
             2.0, 2.0, 2.0
@@ -65,8 +66,10 @@ class FourierOp(LinearOperator):
 
         Parameters
         ----------
-        im_shape
-            dimension of the image to be Fourier-transformed
+        recon_shape
+            dimension of the reconstructed image
+        encoding_shape
+            dimension of the encoded k-space
         traj
             the k-space trajectories where the frequencies are sampled
         oversampling
@@ -82,7 +85,8 @@ class FourierOp(LinearOperator):
         nufft_dims = []
         fft_dims = []
         ignore_dims = []
-        fft_s = []
+        fft_recon_shape = []
+        fft_encoding_shape = []
         omega = []
         traj_shape = []
         super().__init__()
@@ -90,30 +94,27 @@ class FourierOp(LinearOperator):
         # create information about image shape, k-data shape etc
         # and identify which directions can be ignored, which ones require a nuFFT
         # and for which ones a simple FFT suffices
-        for n, os, k, i in zip(
-            (im_shape.z, im_shape.y, im_shape.x),
+        for rs, es, os, k, i in zip(
+            (recon_shape.z, recon_shape.y, recon_shape.x),
+            (encoding_shape.z, encoding_shape.y, encoding_shape.x),
             (oversampling.z, oversampling.y, oversampling.x),
             (traj.kz, traj.ky, traj.kx),
             (-3, -2, -1),
         ):
             nk_list = [traj.kz.shape[i], traj.ky.shape[i], traj.kx.shape[i]]
-            if n <= 1 and nk_list.count(1) == 3:
+            if rs <= 1 and nk_list.count(1) == 3:
                 # dimension with no Fourier transform
                 ignore_dims.append(i)
 
             elif nk_list.count(1) == 2:  # and is_uniform(k): #TODO: maybe is_uniform never needed?
-                # dimension with FFT
-                nk = torch.tensor(nk_list)
-                supp = torch.where(nk != 1, nk, 0)
-                s = supp.max().item()
-
                 # append dimension and output shape for oversampled FFT
                 fft_dims.append(i)
-                fft_s.append(s)
+                fft_recon_shape.append(int(rs))
+                fft_encoding_shape.append(int(es))
             else:
                 # dimension with nuFFT
-                grid_size.append(int(os * n))
-                nufft_im_size.append(n)
+                grid_size.append(int(os * rs))
+                nufft_im_size.append(rs)
                 nufft_dims.append(i)
 
                 # TODO: can omega be created here already?
@@ -144,9 +145,10 @@ class FourierOp(LinearOperator):
         self._ignore_dims = tuple(ignore_dims)
         self._nufft_dims = tuple(nufft_dims)
         self._fft_dims = tuple(fft_dims)
-        self._fft_s = tuple(fft_s)
+        self._fft_recon_shape = tuple(fft_recon_shape)
+        self._fft_encoding_shape = tuple(fft_encoding_shape)
         self._kshape = torch.broadcast_shapes(*traj_shape)
-        self._im_shape = im_shape
+        self._recon_shape = recon_shape
         self._nufft_im_size = nufft_im_size
 
     @staticmethod
@@ -194,11 +196,11 @@ class FourierOp(LinearOperator):
         -------
             coil k-space data with shape: (other coils k2 k1 k0)
         """
-        if self._im_shape != SpatialDimension(*x.shape[-3:]):
+        if self._recon_shape != SpatialDimension(*x.shape[-3:]):
             raise ValueError('image data shape missmatch')
 
         if len(self._fft_dims) != 0:
-            x = torch.fft.fftn(x, s=self._fft_s, dim=self._fft_dims, norm='ortho')
+            x = fft.image_to_kspace(x, encoding_shape=self._fft_encoding_shape, dim=self._fft_dims)
 
         if len(self._nufft_dims) != 0:
             init_pattern = 'other coils dim2 dim1 dim0'
@@ -249,22 +251,7 @@ class FourierOp(LinearOperator):
 
         # apply IFFT
         if len(self._fft_dims) != 0:
-            im_shape = [self._im_shape.z, self._im_shape.y, self._im_shape.x]
-            y = torch.fft.ifftn(y, s=self._fft_s, dim=self._fft_dims, norm='ortho')
-
-            # construct the paddings based on the FFT-directions
-            # TODO: can this be written more nicely?
-            diff_dim = torch.tensor(im_shape) - torch.tensor(y.shape[2:])
-            npad_tuple = tuple(
-                [
-                    int(diff_dim[i // 2].item()) if (i % 2 == 0 and dim in self._fft_dims) else 0
-                    for (i, dim) in zip(range(0, 6)[::-1], (-1, -1, -2, -2, -3, -3))
-                ]
-            )
-
-            # crop using (negative) padding;
-            if not torch.all(torch.tensor(npad_tuple) != 0):
-                y = F.pad(y, npad_tuple)
+            y = fft.kspace_to_image(y, recon_shape=self._fft_recon_shape, dim=self._fft_dims)
 
         # move dim where FFT was already performed such nuFFT can be performed
         if len(self._nufft_dims) != 0:
@@ -293,8 +280,8 @@ class FourierOp(LinearOperator):
             y = y.contiguous() if y.stride()[-1] != 1 else y
             y = self._adj_nufft_op(y, omega, norm='ortho')
 
-            # get back to orginal k-space shape
-            nz, ny, nx = self._im_shape.z, self._im_shape.y, self._im_shape.x
+            # get back to orginal image shape
+            nz, ny, nx = self._recon_shape.z, self._recon_shape.y, self._recon_shape.x
             y = rearrange(y, target_pattern + '->' + init_pattern, other=nb, coils=nc, dim2=nz, dim1=ny, dim0=nx)
 
         return y

--- a/src/mrpro/utils/fft.py
+++ b/src/mrpro/utils/fft.py
@@ -41,7 +41,7 @@ def change_image_shape(idat: torch.Tensor, idat_shape_new: tuple[int, ...]) -> t
 
     # Pad (positive npad) or crop  (negative npad)
     # Npad has to be reversed because pad expects it in reversed order
-    if not torch.all(torch.tensor(npad) != 0):
+    if not torch.all(torch.tensor(npad) == 0):
         idat = F.pad(idat, npad[::-1])
     return idat
 

--- a/src/mrpro/utils/fft.py
+++ b/src/mrpro/utils/fft.py
@@ -13,15 +13,50 @@
 #   limitations under the License.
 
 import torch
+import torch.nn.functional as F
 
 
-def kspace_to_image(kdat: torch.Tensor, dim: tuple[int, ...] = (-1, -2, -3)) -> torch.Tensor:
+def change_image_shape(idat: torch.Tensor, idat_shape_new: tuple[int, ...]) -> torch.Tensor:
+    """Change shape of image by cropping or zero-padding.
+
+    Parameters
+    ----------
+    idat
+        image data
+    idat_shape_new
+        desired shape of image
+
+    Returns
+    -------
+        image with shape idat_shape_new
+    """
+    s = list(idat.shape)
+    # Padding
+    npad = [0] * (2 * len(s))
+
+    for idx in range(len(s)):
+        if s[idx] != idat_shape_new[idx]:
+            npad[2 * idx] = (idat_shape_new[idx] - s[idx]) // 2
+            npad[2 * idx + 1] = idat_shape_new[idx] - (s[idx] + npad[2 * idx])
+
+    # Pad (positive npad) or crop  (negative npad)
+    # Npad has to be reversed because pad expects it in reversed order
+    if not torch.all(torch.tensor(npad) != 0):
+        idat = F.pad(idat, npad[::-1])
+    return idat
+
+
+def kspace_to_image(
+    kdat: torch.Tensor, recon_shape: tuple[int, ...] | None = None, dim: tuple[int, ...] = (-1, -2, -3)
+) -> torch.Tensor:
     """IFFT from k-space to image space.
 
     Parameters
     ----------
     kdat
         k-space data on Cartesian grid
+    recon_shape, optional
+        shape of reconstructed image
     dim, optional
         dim along which iFFT is applied, by default last three dimensions (-1, -2, -3)
 
@@ -29,16 +64,30 @@ def kspace_to_image(kdat: torch.Tensor, dim: tuple[int, ...] = (-1, -2, -3)) -> 
     -------
         iFFT of kdat
     """
-    return torch.fft.fftshift(torch.fft.ifftn(torch.fft.ifftshift(kdat, dim=dim), dim=dim, norm='ortho'), dim=dim)
+    # FFT
+    idat = torch.fft.fftshift(torch.fft.ifftn(torch.fft.ifftshift(kdat, dim=dim), dim=dim, norm='ortho'), dim=dim)
+
+    # Adapt image size
+    if recon_shape is not None:
+        s = list(idat.shape)
+        for idx, idim in enumerate(dim):
+            s[idim] = recon_shape[idx]
+        idat = change_image_shape(idat, tuple(s))
+
+    return idat
 
 
-def image_to_kspace(idat: torch.Tensor, dim: tuple[int, ...] = (-1, -2, -3)) -> torch.Tensor:
+def image_to_kspace(
+    idat: torch.Tensor, encoding_shape: tuple[int, ...] | None = None, dim: tuple[int, ...] = (-1, -2, -3)
+) -> torch.Tensor:
     """FFT from image space to k-space.
 
     Parameters
     ----------
     idat
         image data on Cartesian grid
+    encoding_shape, optional
+        shape of encoded image
     dim, optional
         dim along which FFT is applied, by default last three dimensions (-1, -2, -3)
 
@@ -46,4 +95,11 @@ def image_to_kspace(idat: torch.Tensor, dim: tuple[int, ...] = (-1, -2, -3)) -> 
     -------
         FFT of idat
     """
+    # Adapt image size
+    if encoding_shape is not None:
+        s = list(idat.shape)
+        for idx, idim in enumerate(dim):
+            s[idim] = encoding_shape[idx]
+        idat = change_image_shape(idat, tuple(s))
+
     return torch.fft.ifftshift(torch.fft.fftn(torch.fft.fftshift(idat, dim=dim), dim=dim, norm='ortho'), dim=dim)

--- a/tests/utils/test_fft.py
+++ b/tests/utils/test_fft.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 import torch
 
+from mrpro.utils.fft import change_image_shape
 from mrpro.utils.fft import image_to_kspace
 from mrpro.utils.fft import kspace_to_image
 
@@ -54,3 +55,14 @@ def test_image_to_kspace_as_inverse():
     # Transform to k-space and back along all three dimensions
     idat_transform = image_to_kspace(kspace_to_image(idat))
     torch.testing.assert_close(idat, idat_transform)
+
+
+def test_change_image_size():
+    """Test changing image size by cropping and padding."""
+    ishape_orig = (100, 200, 50)
+    ishape_new = (80, 100, 240)
+    iorig = torch.randn(*ishape_orig, dtype=torch.complex64)
+    inew = change_image_shape(iorig, ishape_new)
+
+    # Compare overlapping region
+    torch.testing.assert_close(iorig[10:90, 50:150, :], inew[:, :, 95:145])


### PR DESCRIPTION
Currently the `FourierOp` simply calls FFT on `KData.data` which only works if the data is correctly sorted and if the data is fully sampled. 

Here I have started to implement the code to also allow reconstruction of partial Fourier/echo and regular undersampled Cartesian data. 

Encoded space and recon space are now also correctly taken into consideration for the reco:

![encoded_recon_space](https://github.com/PTB-MR/mrpro/assets/17784338/43a76cb2-b32c-4046-8307-986e6913d16e)


Open issues:

- Should trajectory be within [-pi, pi] or in encoded space dimensions?
- How to correctly detect FFT dimensions? Maybe detect if trajectory is on Cartesian grid...
- How to deal with non-regular Cartesian undersampling?
- Lots of optimisation and pythonisation of code needed. Please add your suggestions/pseudo code and I will happily implement it. 