### PR TITLE
Hotfix for PyTorch 2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.23,<2.0",
-    "torch>=2.0,<3.0",
+    "torch>=2.2,<3.0",
     "torchio",
     "ismrmrd",
     "einops",

--- a/src/mrpro/data/_KData.py
+++ b/src/mrpro/data/_KData.py
@@ -212,7 +212,7 @@ class KData:
             header=self.header,
             data=self.data.to(
                 device=device, dtype=dtype, non_blocking=non_blocking, copy=copy, memory_format=memory_format
-            ),  # type: ignore [call-overload]
+            ),
             traj=self.traj.to(
                 device=device, dtype=dtype_traj, non_blocking=non_blocking, copy=copy, memory_format=memory_format
             ),


### PR DESCRIPTION
Pytorch 2.2 was released yesterday and it fixed some problems with mypy and `tensor.to()`. As our pre-commit framework always uses the latest pytorch version this now causes an error because our `KData.to()` implementation does not raise an error anymore and hence the exception `# type: ignore [call-overload]` is not needed anymore. 

This fixes this but now we also have to ensure that Pytorch version is at least 2.2.

@fzimmermann89 or @koflera can you see a problem with increasing the required pytorch version?