### PR TITLE
Enable data which does not allow for a reshape into k2 and k1

### DIFF
--- a/src/mrpro/data/_KData.py
+++ b/src/mrpro/data/_KData.py
@@ -115,8 +115,21 @@ class KData:
         # same as the product of all unique_idxs
         num_total_unique = torch.prod(torch.as_tensor([len(unique_idxs[label]) for label in KDIM_SORT_LABELS]))
 
-        # To find the dimensions of k2 and k1 we check a random other dimension
-        idx_matches = torch.nonzero(getattr(kheader.acq_info.idx, 'slice') == 0)
+        # At least one average, slice, contrast, phase, repetition and set must exist. We use this to find out the
+        # dimensions of k1 an k2.
+        def idx_label_combination(average_idx, slice_idx, contrast_idx, phase_idx, repetition_idx, set_idx):
+            return torch.nonzero(
+                (kheader.acq_info.idx.average == average_idx)
+                & (kheader.acq_info.idx.slice == slice_idx)
+                & (kheader.acq_info.idx.contrast == contrast_idx)
+                & (kheader.acq_info.idx.phase == phase_idx)
+                & (kheader.acq_info.idx.repetition == repetition_idx)
+                & (kheader.acq_info.idx.set == set_idx)
+            )
+
+        idx_matches = idx_label_combination(
+            *[unique_idxs[label][0] for label in KDIM_SORT_LABELS if label not in ('k1', 'k2')]
+        )
         if num_total_unique == kdata.shape[0]:
             # Data can be reshaped into (other coils k2 k1 k0))
             num_k1 = len(torch.unique(kheader.acq_info.idx.k1[idx_matches]))
@@ -126,22 +139,36 @@ class KData:
             num_k1 = len(idx_matches)
             num_k2 = 1
 
-        # Here we verify that the k2 and k1 contain the same number of k-space points for all other dimensions
-        for label, idxs in unique_idxs.items():
-            if label in ('k1', 'k2'):
-                continue
-            for idx in idxs:
-                idx_matches = torch.nonzero(getattr(kheader.acq_info.idx, label) == idx)
-                if num_total_unique == kdata.shape[0]:
-                    current_num_k1 = len(torch.unique(kheader.acq_info.idx.k1[idx_matches]))
-                    current_num_k2 = len(torch.unique(kheader.acq_info.idx.k2[idx_matches]))
-                    if current_num_k1 != num_k1:
-                        raise ValueError(f'Number of k1 points in {label}: {current_num_k1}. Expected: {num_k1}')
-                    if current_num_k2 != num_k2:
-                        raise ValueError(f'Number of k2 points in {label}: {current_num_k2}. Expected: {num_k2}')
-                else:
-                    if len(idx_matches) != num_k1:
-                        raise ValueError(f'Number of (k2 k1) points in {label}: {len(idx_matches)}. Expected: {num_k1}')
+        # Create all combinations of averages, slices, contrasts... to make the following loop easier to read
+        idx_combinations = [
+            [average_idx, slice_idx, contrast_idx, phase_idx, repetition_idx, set_idx]
+            for average_idx in unique_idxs['average']
+            for slice_idx in unique_idxs['slice']
+            for contrast_idx in unique_idxs['contrast']
+            for phase_idx in unique_idxs['phase']
+            for repetition_idx in unique_idxs['repetition']
+            for set_idx in unique_idxs['set']
+        ]
+
+        # Verify that k2 and k1 contain the same number of k-space points for all combinations of averages, slices...
+        for average_idx, slice_idx, contrast_idx, phase_idx, repetition_idx, set_idx in idx_combinations:
+            idx_matches = idx_label_combination(
+                average_idx, slice_idx, contrast_idx, phase_idx, repetition_idx, set_idx
+            )
+            label_str = (
+                f'[average {average_idx} | slice {slice_idx} | contrast {contrast_idx} | phase {phase_idx}'
+                + f'| repetition {repetition_idx} | set {set_idx}]'
+            )
+            if num_total_unique == kdata.shape[0]:
+                current_num_k1 = len(torch.unique(kheader.acq_info.idx.k1[idx_matches]))
+                current_num_k2 = len(torch.unique(kheader.acq_info.idx.k2[idx_matches]))
+                if current_num_k1 != num_k1:
+                    raise ValueError(f'Number of k1 points in {label_str}: {current_num_k1}. Expected: {num_k1}')
+                if current_num_k2 != num_k2:
+                    raise ValueError(f'Number of k2 points in {label_str}: {current_num_k2}. Expected: {num_k2}')
+            else:
+                if len(idx_matches) != num_k1:
+                    raise ValueError(f'Number of (k2 k1) points in {label_str}: {len(idx_matches)}. Expected: {num_k1}')
 
         # using np.lexsort as it looks a bit more familiar than looping and torch.argsort(..., stable=True)
         sort_ki = np.stack([getattr(kheader.acq_info.idx, label) for label in KDIM_SORT_LABELS], axis=0)

--- a/src/mrpro/data/_KData.py
+++ b/src/mrpro/data/_KData.py
@@ -66,11 +66,11 @@ class KData:
             filename
                 path to the ISMRMRD file
             ktrajectory
-                KTrajectory defining the trajectory to use # TODO: Maybe provide a default based on the header?
+                KTrajectoryCalculator to calculate the k-space trajectory or an already calculated KTrajectory
             header_overwrites
                 dictionary of key-value pairs to overwrite the header
             dataset_idx
-                index of the dataset to load (converter creates dataset, dataset_1, ...), default is -1 (last)
+                index of the ISMRMRD dataset to load (converter creates dataset, dataset_1, ...), default is -1 (last)
         """
 
         # Can raise FileNotFoundError
@@ -99,24 +99,22 @@ class KData:
             },
             overwrite=header_overwrites,
         )
+
+        # Create single kdata tensor from acquisition data
         kdata = torch.stack([torch.as_tensor(acq.data, dtype=torch.complex64) for acq in acquisitions])
 
         # Fill k0 limits if they were set to zero / not set in the header
         if kheader.encoding_limits.k0.length == 1:
             kheader.encoding_limits.k0 = Limits(0, kdata.shape[-1] - 1, kdata.shape[-1] // 2)
 
-        # TODO: Check for partial Fourier and reflected readouts
-
         # Sort kdata and acq_info into ("all other dim", coils, k2, k1, k0) / ("all other dim", k2, k1, acq_info_dims)
         # Fist, ensure each the non k1/k2 dimensions covers the same number of k1 and k2 points
         unique_idxs = {label: np.unique(getattr(kheader.acq_info.idx, label)) for label in KDIM_SORT_LABELS}
 
-        # In order to be able to reshape data into (other coils k2 k1 k0) the number of acquisitions has to be the
-        # same as the product of all unique_idxs
-        num_total_unique = torch.prod(torch.as_tensor([len(unique_idxs[label]) for label in KDIM_SORT_LABELS]))
+        # For reshaping into (other coils k2 k1 k0), the number of acqs must match the product of all unique_idxs
+        num_total_unique = torch.as_tensor([len(unique_idxs[label]) for label in KDIM_SORT_LABELS]).prod()
 
-        # At least one average, slice, contrast, phase, repetition and set must exist. We use this to find out the
-        # dimensions of k1 an k2.
+        # Define function to find index label combinations. This is used to determine the dimensions of k1 and k2.
         def idx_label_combination(average_idx, slice_idx, contrast_idx, phase_idx, repetition_idx, set_idx):
             return torch.nonzero(
                 (kheader.acq_info.idx.average == average_idx)
@@ -130,12 +128,14 @@ class KData:
         idx_matches = idx_label_combination(
             *[unique_idxs[label][0] for label in KDIM_SORT_LABELS if label not in ('k1', 'k2')]
         )
+
+        # Determine the number of k1 and k2 points
         if num_total_unique == kdata.shape[0]:
             # Data can be reshaped into (other coils k2 k1 k0))
             num_k1 = len(torch.unique(kheader.acq_info.idx.k1[idx_matches]))
             num_k2 = len(torch.unique(kheader.acq_info.idx.k2[idx_matches]))
         else:
-            # Data is reshaped as (other 1 (k2 k1) k0)
+            # Data is reshaped into (other 1 (k2 k1) k0)
             num_k1 = len(idx_matches)
             num_k2 = 1
 
@@ -170,12 +170,12 @@ class KData:
                 if len(idx_matches) != num_k1:
                     raise ValueError(f'Number of (k2 k1) points in {label_str}: {len(idx_matches)}. Expected: {num_k1}')
 
-        # using np.lexsort as it looks a bit more familiar than looping and torch.argsort(..., stable=True)
+        # Sort the data according to the sorted indices
         sort_ki = np.stack([getattr(kheader.acq_info.idx, label) for label in KDIM_SORT_LABELS], axis=0)
         sort_idx = np.lexsort(sort_ki)
-
         kdata = rearrange(kdata[sort_idx], '(other k2 k1) coils k0 -> other coils k2 k1 k0', k1=num_k1, k2=num_k2)
 
+        # Reshape the acquisition data and update the header acquisition infos accordingly
         def reshape_acq_data(data):
             return rearrange(data[sort_idx], '(other k2 k1) ... -> other k2 k1 ...', k1=num_k1, k2=num_k2)
 

--- a/tests/data/test_kdata.py
+++ b/tests/data/test_kdata.py
@@ -59,7 +59,7 @@ def test_KData_raise_wrong_ktraj_shape(ismrmrd_cart):
 def test_KData_from_file_diff_nky_for_rep(ismrmrd_cart_invalid_reps):
     """Multiple repetitions with different number of phase encoding lines is
     not supported."""
-    with pytest.raises(ValueError, match='Number of (k2 k1) points in repetition: 256. Expected: 512'):
+    with pytest.raises(ValueError, match=r'Number of \((k2 k1\)) points in repetition:'):
         KData.from_file(ismrmrd_cart_invalid_reps.filename, DummyTrajectory())
 
 

--- a/tests/data/test_kdata.py
+++ b/tests/data/test_kdata.py
@@ -64,10 +64,19 @@ def test_KData_from_file(ismrmrd_cart):
 
 
 def test_KData_random_cart_undersampling(ismrmrd_cart_random_us):
-    """Read in data with different random Cartesian undersampling in multiple
+    """Read data with different random Cartesian undersampling in multiple
     repetitions."""
     k = KData.from_file(ismrmrd_cart_random_us.filename, DummyTrajectory())
     assert k is not None
+
+
+def test_KData_random_cart_undersampling_shape(ismrmrd_cart_random_us):
+    """Check shape of KData with random Cartesian undersampling."""
+    k = KData.from_file(ismrmrd_cart_random_us.filename, DummyTrajectory())
+    # check if the number of repetitions is correct
+    assert k.data.shape[-5] == ismrmrd_cart_random_us.repetitions
+    # check if the number of phase encoding lines per repetition is correct
+    assert k.data.shape[-2] == ismrmrd_cart_random_us.matrix_size // ismrmrd_cart_random_us.acceleration
 
 
 def test_KData_raise_wrong_ktraj_shape(ismrmrd_cart):

--- a/tests/data/test_kdata.py
+++ b/tests/data/test_kdata.py
@@ -42,9 +42,31 @@ def ismrmrd_cart_invalid_reps(tmp_path_factory):
     return ismrmrd_kdat
 
 
+@pytest.fixture(scope='session')
+def ismrmrd_cart_random_us(ph_ellipse, tmp_path_factory):
+    """Randomly undersampled cartesian data set with repetitions."""
+    ismrmrd_filename = tmp_path_factory.mktemp('mrpro') / 'ismrmrd_cart.h5'
+    ismrmrd_kdat = IsmrmrdRawTestData(
+        filename=ismrmrd_filename,
+        noise_level=0.0,
+        repetitions=3,
+        acceleration=4,
+        sampling_order='random',
+        phantom=ph_ellipse.phantom,
+    )
+    return ismrmrd_kdat
+
+
 def test_KData_from_file(ismrmrd_cart):
     """Read in data from file."""
     k = KData.from_file(ismrmrd_cart.filename, DummyTrajectory())
+    assert k is not None
+
+
+def test_KData_random_cart_undersampling(ismrmrd_cart_random_us):
+    """Read in data with different random Cartesian undersampling in multiple
+    repetitions."""
+    k = KData.from_file(ismrmrd_cart_random_us.filename, DummyTrajectory())
     assert k is not None
 
 
@@ -59,7 +81,7 @@ def test_KData_raise_wrong_ktraj_shape(ismrmrd_cart):
 def test_KData_from_file_diff_nky_for_rep(ismrmrd_cart_invalid_reps):
     """Multiple repetitions with different number of phase encoding lines is
     not supported."""
-    with pytest.raises(ValueError, match=r'Number of \((k2 k1\)) points in repetition:'):
+    with pytest.raises(ValueError, match=r'Number of \((k2 k1\)) points in '):
         KData.from_file(ismrmrd_cart_invalid_reps.filename, DummyTrajectory())
 
 

--- a/tests/data/test_kdata.py
+++ b/tests/data/test_kdata.py
@@ -59,7 +59,7 @@ def test_KData_raise_wrong_ktraj_shape(ismrmrd_cart):
 def test_KData_from_file_diff_nky_for_rep(ismrmrd_cart_invalid_reps):
     """Multiple repetitions with different number of phase encoding lines is
     not supported."""
-    with pytest.raises(ValueError, match='Number of k1 points in repetition: 128. Expected: 256'):
+    with pytest.raises(ValueError, match='Number of (k2 k1) points in repetition: 256. Expected: 512'):
         KData.from_file(ismrmrd_cart_invalid_reps.filename, DummyTrajectory())
 
 


### PR DESCRIPTION
This allows to read in data which cannot be reshaped into a 2D matrix of k2 and k1. E.g. 2D Poisson-based Cartesian undersampling along the phase and slice encoding direction.