### PR TITLE
Fix ignore flags

### DIFF
--- a/src/mrpro/data/_KData.py
+++ b/src/mrpro/data/_KData.py
@@ -44,6 +44,18 @@ KDIM_SORT_LABELS = (
     'set',
 )
 
+# Same criteria as https://github.com/wtclarke/pymapvbvd/blob/master/mapvbvd/mapVBVD.py uses
+DEFAULT_IGNORE_FLAGS = (
+    AcqFlags.ACQ_IS_NOISE_MEASUREMENT
+    | AcqFlags.ACQ_IS_DUMMYSCAN_DATA
+    | AcqFlags.ACQ_IS_HPFEEDBACK_DATA
+    | AcqFlags.ACQ_IS_NAVIGATION_DATA
+    | AcqFlags.ACQ_IS_PHASECORR_DATA
+    | AcqFlags.ACQ_IS_PHASE_STABILIZATION
+    | AcqFlags.ACQ_IS_PHASE_STABILIZATION_REFERENCE
+    | AcqFlags.ACQ_IS_PARALLEL_CALIBRATION
+)
+
 
 @dataclasses.dataclass(slots=True, frozen=True)
 class KData:
@@ -58,7 +70,7 @@ class KData:
         ktrajectory: KTrajectoryCalculator | KTrajectory | KTrajectoryIsmrmrd,
         header_overwrites: dict[str, object] | None = None,
         dataset_idx: int = -1,
-        ignore_flags=None,
+        ignore_flags: AcqFlags = DEFAULT_IGNORE_FLAGS,
     ) -> KData:
         """Load k-space data from an ISMRMRD file.
 
@@ -73,8 +85,10 @@ class KData:
             dataset_idx
                 index of the ISMRMRD dataset to load (converter creates dataset, dataset_1, ...), default is -1 (last)
             ignore_flags
-                Acqisition flags to filter out. None defaults to all non-images as defined by pymapvbvd.
-                (Use ACQ_NO_FLAG to disable the filter)
+                Acqisition flags to filter out. Defaults to all non-images as defined by pymapvbvd.
+                Use ACQ_NO_FLAG to disable the filter.
+                Note: If ACQ_IS_PARALLEL_CALIBRATION is set without also setting ACQ_IS_PARALLEL_CALIBRATION_AND_IMAGING
+                      we interpret it as: Ignore if IS_PARALLEL_CALIBRATION and not PARALLEL_CALIBRATION_AND_IMAGING
         """
 
         # Can raise FileNotFoundError
@@ -88,19 +102,13 @@ class KData:
                 mtime = 0
             modification_time = datetime.datetime.fromtimestamp(mtime)
 
-        if ignore_flags is None:
-            # Same criteria as https://github.com/wtclarke/pymapvbvd/blob/master/mapvbvd/mapVBVD.py uses
-            ignore_flags = (
-                AcqFlags.ACQ_IS_NOISE_MEASUREMENT  # Noise data etc must be handled separately
-                | AcqFlags.ACQ_IS_DUMMYSCAN_DATA
-                | AcqFlags.ACQ_IS_HPFEEDBACK_DATA
-                | AcqFlags.ACQ_IS_NAVIGATION_DATA
-                | AcqFlags.ACQ_IS_PHASECORR_DATA
-                | AcqFlags.ACQ_IS_PHASE_STABILIZATION
-                | AcqFlags.ACQ_IS_PHASE_STABILIZATION_REFERENCE
-            )
-            # Unfortunatly, this cant be joined with those above
-            # as IS_PARALLEL_CALIBRATION_AND_IMAGING should pass
+        if (
+            AcqFlags.ACQ_IS_PARALLEL_CALIBRATION in ignore_flags
+            and AcqFlags.ACQ_IS_PARALLEL_CALIBRATION_AND_IMAGING not in ignore_flags
+        ):
+            # if only ACQ_IS_PARALLEL_CALIBRATION is set, reinterpret it as: ignore if
+            # ACQ_IS_PARALLEL_CALIBRATION is set and ACQ_IS_PARALLEL_CALIBRATION_AND_IMAGING is not set
+            ignore_flags = ignore_flags & ~AcqFlags.ACQ_IS_PARALLEL_CALIBRATION
             acquisitions = list(
                 filter(
                     lambda acq: (AcqFlags.ACQ_IS_PARALLEL_CALIBRATION_AND_IMAGING.value & acq.flags)


### PR DESCRIPTION
Should now on default ignore all Siemens non-image acquisitions, and flags are configurable.
 
Needs some testing on real data.

Fixes #119

