### PR TITLE
Allow more than one other dim in KTrajectory

### DIFF
--- a/src/mrpro/data/_KTrajectory.py
+++ b/src/mrpro/data/_KTrajectory.py
@@ -82,8 +82,8 @@ class KTrajectory:
             shape = self.broadcasted_shape
         except ValueError:
             raise ValueError('The k-space trajectory dimensions must be broadcastable.')
-        if len(shape) != 4:
-            raise ValueError('The k-space trajectory tensors should each have 4 dimensions.')
+        if len(shape) < 4:
+            raise ValueError('The k-space trajectory tensors should each have at least 4 dimensions.')
 
     @classmethod
     def from_tensor(


### PR DESCRIPTION
Just relaxes one of the checks: KTrajectory can now be created from tensors with more than 4 dimensions