### PR TITLE
HOTIFX: Binder to use main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This package supports ismrmrd-format for MR raw data. All data containers utiliz
 ![Coverage Bagde](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/ckolbPTB/48e334a10caf60e6708d7c712e56d241/raw/coverage.json)
 
 If you want to give MRpro a try you can use
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/PTB-MR/mrpro.git/example_framework?labpath=examples)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/PTB-MR/mrpro.git/main?labpath=examples)
 
 ## Installation for developers
 


### PR DESCRIPTION
Binder was still configured to start the old branch which implemented the binder functionality