### PR TITLE
Fix operator chaining

### DIFF
--- a/src/mrpro/operators/_LinearOperator.py
+++ b/src/mrpro/operators/_LinearOperator.py
@@ -69,7 +69,7 @@ class LinearOperatorComposition(LinearOperator, OperatorComposition[torch.Tensor
 
     def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
         """Adjoint operator composition."""
-        return self._operator2.adjoint(self._operator1.adjoint(x))
+        return self._operator2.adjoint(*self._operator1.adjoint(x))
 
 
 class LinearOperatorSum(LinearOperator, OperatorSum[torch.Tensor, tuple[torch.Tensor,]]):
@@ -77,7 +77,7 @@ class LinearOperatorSum(LinearOperator, OperatorSum[torch.Tensor, tuple[torch.Te
 
     def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
         """Adjoint operator addition."""
-        return self._operator1.adjoint(x) + self._operator2.adjoint(x)
+        return (self._operator1.adjoint(x)[0] + self._operator2.adjoint(x)[0],)
 
 
 class LinearOperatorElementwiseProduct(LinearOperator, OperatorElementwiseProduct[torch.Tensor, tuple[torch.Tensor,]]):
@@ -86,8 +86,8 @@ class LinearOperatorElementwiseProduct(LinearOperator, OperatorElementwiseProduc
     def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
         """Adjoint Operator elementwise multiplication with scalar/tensor."""
         if self._tensor.is_complex():
-            return self._operator.adjoint(x) * self._tensor.conj()
-        return self._operator.adjoint(x) * self._tensor
+            return (self._operator.adjoint(x)[0] * self._tensor.conj(),)
+        return (self._operator.adjoint(x)[0] * self._tensor,)
 
 
 class AdjointLinearOperator(LinearOperator):

--- a/src/mrpro/operators/_Operator.py
+++ b/src/mrpro/operators/_Operator.py
@@ -18,6 +18,7 @@ from abc import abstractmethod
 from typing import Generic
 from typing import TypeVar
 from typing import TypeVarTuple
+from typing import cast
 
 import torch
 
@@ -61,7 +62,7 @@ class OperatorComposition(Operator[*Tin, Tout]):
 
     def forward(self, *args: *Tin) -> Tout:
         """Operator composition."""
-        return self._operator1(self._operator2(*args))
+        return self._operator1(*self._operator2(*args))
 
 
 class OperatorSum(Operator[*Tin, Tout]):
@@ -74,7 +75,7 @@ class OperatorSum(Operator[*Tin, Tout]):
 
     def forward(self, *args: *Tin) -> Tout:
         """Operator addition."""
-        return self._operator1(*args) + self._operator2(*args)
+        return cast(Tout, tuple(a + b for a, b in zip(self._operator1(*args), self._operator2(*args), strict=True)))
 
 
 class OperatorElementwiseProduct(Operator[*Tin, Tout]):
@@ -87,4 +88,5 @@ class OperatorElementwiseProduct(Operator[*Tin, Tout]):
 
     def forward(self, *args: *Tin) -> Tout:
         """Operator elementwise multiplication."""
-        return self._tensor * self._operator(*args)
+        out = self._operator(*args)
+        return cast(Tout, tuple(a * self._tensor for a in out))


### PR DESCRIPTION
Two spots I missed when we switched to operators returning tuples:
In the @ chain, we need to unpack the return  of the inner operator when calling the outer operator.

Mypy did not catch that as the types on the general operator are not bound to Tensor. 

Edit: A couple more issues....
We should maybe consider running mypy on the tests as well...

(Maybe https://stackoverflow.com/questions/78013162/typehint-function-args-tupleargs-with-constrain-on-the-args could at some point help here)