### PR TITLE
Allow different total number of phase encode steps in KData

### DIFF
--- a/src/mrpro/data/_KTrajectoryRawShape.py
+++ b/src/mrpro/data/_KTrajectoryRawShape.py
@@ -47,7 +47,7 @@ class KTrajectoryRawShape:
     repeat_detection_tolerance: None | float = 1e-3
     """tolerance for repeat detection, by default 1e-3, None to disable."""
 
-    def reshape(
+    def sort_and_reshape(
         self,
         sort_idx: np.ndarray,
         n_k2: int,

--- a/tests/data/test_kdata.py
+++ b/tests/data/test_kdata.py
@@ -126,10 +126,11 @@ def test_KData_raise_wrong_trajectory_shape(ismrmrd_cart):
 
 
 def test_KData_from_file_diff_nky_for_rep(ismrmrd_cart_invalid_reps):
-    """Multiple repetitions with different number of phase encoding lines is
-    not supported."""
-    with pytest.raises(ValueError, match=r'Number of \((k2 k1\)) points in '):
-        KData.from_file(ismrmrd_cart_invalid_reps.filename, DummyTrajectory())
+    """Multiple repetitions with different number of phase encoding lines."""
+    with pytest.warns(UserWarning, match=r'different number'):
+        kdata = KData.from_file(ismrmrd_cart_invalid_reps.filename, DummyTrajectory())
+    assert kdata.data.shape[-2] == 1, 'k1 should be 1'
+    assert kdata.data.shape[-3] == 1, 'k2 should be 1'
 
 
 def test_KData_kspace(ismrmrd_cart):

--- a/tests/data/test_ktraj_raw_shape.py
+++ b/tests/data/test_ktraj_raw_shape.py
@@ -55,7 +55,7 @@ def test_trajectory_raw_reshape(cartesian_grid):
     trajectory_raw = KTrajectoryRawShape(kz_raw, ky_raw, kx_raw, repeat_detection_tolerance=None)
 
     # Reshape to original trajectory
-    trajectory = trajectory_raw.reshape(sort_idx, n_k2, n_k1)
+    trajectory = trajectory_raw.sort_and_reshape(sort_idx, n_k2, n_k1)
 
     # Compare trajectories
     torch.testing.assert_close(trajectory.kz, kz_full)


### PR DESCRIPTION
This simplifies the logic to determine `n_k2 `and `n_k1 `in `KData`. A lot of the complexity was due to the error message for the `NotImplementedError`.

Before, there were some edgecases that were not fully covered.  Now we also have a fallback for different numbers of phase encodes for different "other" labels, with shape (total_aquisitions, 1, 1, k0) with a warning instead of an exception.

(I would also be fine with removing the warning. I added it as I think it could  for us equally likely be a data/user error than the expected resullt.)

I also renamed` KTrajectoryRawShape.reshape` as this looked to close to `Tensor.reshape`: I was wondering why we would reshape with "sort_idx" as one of the sizes. Now it is `sort_and_reshape`


Note: This is currently vs the ruff PR, but will be rebased onto main and will be merged seperatly, either before or after #193
