### PR TITLE
move sensitivity operator tests to using  dotproduct_adjointness_test 

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -36,12 +36,49 @@ def relative_image_difference(img1, img2):
     return image_difference / image_mean
 
 
-def dotproduct_adjointness_test(operator, u, v):
-    """Test if <Operator(u),v> == <u, Operator^H(v)> for u ∈ domain and v ∈
-    range of Operator."""
+def dotproduct_adjointness_test(
+    operator, u: torch.Tensor, v: torch.Tensor, relative_tolerance: float = 1e-3, absolute_tolerance=1e-5
+):
+    """Test the adjointness of operator and operator.H
+
+    Test if
+         <Operator(u),v> == <u, Operator^H(v)>
+         for one u ∈ domain and one v ∈ range of Operator.
+    and if the shapes match.
+
+    Note: This property should hold for all u and v.
+    Commonly, this function is called with two random vectors u and v.
+
+
+    Parameters
+    ----------
+    operator
+        operator
+    u
+        element of the domain of the operator
+    v
+        element of the range of the operator
+    relative_tolerance
+        default is pytorch's default for float16
+    absolute_tolerance
+        default is pytorch's default for float16
+
+    Raises
+    ------
+    AssertionError
+        if the adjointness property does not hold
+    AssertionError
+        if the shape of operator(u) and v does not match
+        if the shape of u and operator.H(v) does not match
+
+    """
     (forward_u,) = operator(u)
     (adjoint_v,) = operator.adjoint(v)
+
+    # explicitly check the shapes, as flatten makes the dot product insensitive to wrong shapes
+    assert forward_u.shape == v.shape
+    assert adjoint_v.shape == u.shape
+
     dotproduct_range = torch.vdot(forward_u.flatten(), v.flatten())
     dotproduct_domain = torch.vdot(u.flatten().flatten(), adjoint_v.flatten())
-    # tolerances relaxed to torch.float16 defaults.
-    torch.testing.assert_close(dotproduct_range, dotproduct_domain, rtol=1e-3, atol=1e-5)
+    torch.testing.assert_close(dotproduct_range, dotproduct_domain, rtol=relative_tolerance, atol=absolute_tolerance)

--- a/tests/operators/test_sensitivity_op.py
+++ b/tests/operators/test_sensitivity_op.py
@@ -1,4 +1,4 @@
-"""Tests for Sensitivity operator."""
+"""Tests for sensitivity operator."""
 
 # Copyright 2023 Physikalisch-Technische Bundesanstalt
 #
@@ -20,72 +20,92 @@ from mrpro.data import SpatialDimension
 from mrpro.operators import SensitivityOp
 
 from tests import RandomGenerator
+from tests.helper import dotproduct_adjointness_test
 
 
 def test_sensitivity_op_adjointness():
-    """Sensitivity Operator adjoint property."""
+    """Test Sensitivity operator adjoint property."""
 
     random_generator = RandomGenerator(seed=0)
-    n_z, n_y, n_x = 100, 100, 100
+
+    ns_zyx = (2, 3, 4)
+    ns_other = (5, 6, 7)
     n_coils = 4
 
     # Generate sensitivity operator
-    random_tensor = random_generator.complex64_tensor(size=(1, n_coils, n_z, n_y, n_x))
+    random_tensor = random_generator.complex64_tensor(size=(*ns_other, n_coils, *ns_zyx))
     random_csmdata = CsmData(data=random_tensor, header=QHeader(fov=SpatialDimension(1.0, 1.0, 1.0)))
     sensitivity_op = SensitivityOp(random_csmdata)
 
     # Check adjoint property
-    u = random_generator.complex64_tensor(size=(1, 1, n_z, n_y, n_x))
-    v = random_generator.complex64_tensor(size=(1, n_coils, n_z, n_y, n_x))
-    (forward,) = sensitivity_op.forward(u)
-    (adjoint,) = sensitivity_op.adjoint(v)
-    torch.testing.assert_close(
-        torch.vdot(forward.ravel(), v.ravel()),
-        torch.vdot(u.ravel(), adjoint.ravel()),
-        rtol=1e-03,
-        atol=1e-03,
-    )
+    u = random_generator.complex64_tensor(size=(*ns_other, 1, *ns_zyx))
+    v = random_generator.complex64_tensor(size=(*ns_other, n_coils, *ns_zyx))
+    dotproduct_adjointness_test(sensitivity_op, u, v)
 
 
-@pytest.mark.parametrize(('csm_other_dim', 'img_other_dim'), [(1, 1), (1, 6), (6, 6)])
-def test_sensitivity_op_other_dim_compatibility_pass(csm_other_dim, img_other_dim):
+def test_sensitivity_op_csmdata_tensor():
+    """Test matching result after creation via tensor and CSMData."""
+
+    random_generator = RandomGenerator(seed=0)
+
+    ns_zyx = (2, 3, 4)
+    ns_other = (5, 6, 7)
+    n_coils = 4
+
+    # Generate sensitivity operators
+    random_tensor = random_generator.complex64_tensor(size=(*ns_other, n_coils, *ns_zyx))
+    random_csmdata = CsmData(data=random_tensor, header=QHeader(fov=SpatialDimension(1.0, 1.0, 1.0)))
+    sensitivity_op_csmdata = SensitivityOp(random_csmdata)
+    sensitivity_op_tensor = SensitivityOp(random_tensor)
+
+    # Check equality
+    u = random_generator.complex64_tensor(size=(*ns_other, 1, *ns_zyx))
+    v = random_generator.complex64_tensor(size=(*ns_other, n_coils, *ns_zyx))
+    assert torch.equal(*sensitivity_op_csmdata(u), *sensitivity_op_tensor(u))
+    assert torch.equal(*sensitivity_op_csmdata.H(v), *sensitivity_op_tensor.H(v))
+
+
+@pytest.mark.parametrize(('n_other_csm', 'n_other_img'), [(1, 1), (1, 6), (6, 6)])
+def test_sensitivity_op_other_dim_compatibility_pass(n_other_csm, n_other_img):
     """Test paired-dimensions that have to pass applying the sensitivity
     operator."""
 
     random_generator = RandomGenerator(seed=0)
-    n_z, n_y, n_x = 100, 100, 100
+
+    ns_zyx = (2, 3, 4)
     n_coils = 4
 
     # Generate sensitivity operator
-    random_tensor = random_generator.complex64_tensor(size=(csm_other_dim, n_coils, n_z, n_y, n_x))
+    random_tensor = random_generator.complex64_tensor(size=(n_other_csm, n_coils, *ns_zyx))
     random_csmdata = CsmData(data=random_tensor, header=QHeader(fov=SpatialDimension(1.0, 1.0, 1.0)))
     sensitivity_op = SensitivityOp(random_csmdata)
 
-    u = random_generator.complex64_tensor(size=(img_other_dim, 1, n_z, n_y, n_x))
-    v = random_generator.complex64_tensor(size=(img_other_dim, n_coils, n_z, n_y, n_x))
-    (forward,) = sensitivity_op.forward(u)
-    (adjoint,) = sensitivity_op.adjoint(v)
-    assert forward.shape == (img_other_dim, n_coils, n_z, n_y, n_x)
-    assert adjoint.shape == (img_other_dim, 1, n_z, n_y, n_x)
+    # Apply to n_other_img shape
+    u = random_generator.complex64_tensor(size=(n_other_img, 1, *ns_zyx))
+    v = random_generator.complex64_tensor(size=(n_other_img, n_coils, *ns_zyx))
+    dotproduct_adjointness_test(sensitivity_op, u, v)
 
 
-@pytest.mark.parametrize(('csm_other_dim', 'img_other_dim'), [(6, 3), (3, 6)])
-def test_sensitivity_op_other_dim_compatibility_fail(csm_other_dim, img_other_dim):
+@pytest.mark.parametrize(('n_other_csm', 'n_other_img'), [(6, 3), (3, 6)])
+def test_sensitivity_op_other_dim_compatibility_fail(n_other_csm, n_other_img):
     """Test paired-dimensions that have to raise error for the sensitivity
     operator."""
+
     random_generator = RandomGenerator(seed=0)
-    n_z, n_y, n_x = 100, 100, 100
+
+    ns_zyx = (2, 3, 4)
     n_coils = 4
 
-    # Generate sensitivity operator
-    random_tensor = random_generator.complex64_tensor(size=(csm_other_dim, n_coils, n_z, n_y, n_x))
+    # Generate sensitivity operator with n_other_csm shape
+    random_tensor = random_generator.complex64_tensor(size=(n_other_csm, n_coils, *ns_zyx))
     random_csmdata = CsmData(data=random_tensor, header=QHeader(fov=SpatialDimension(1.0, 1.0, 1.0)))
     sensitivity_op = SensitivityOp(random_csmdata)
 
-    u = random_generator.complex64_tensor(size=(img_other_dim, 1, n_z, n_y, n_x))
+    # Apply to n_other_img shape
+    u = random_generator.complex64_tensor(size=(n_other_img, 1, *ns_zyx))
     with pytest.raises(RuntimeError, match='The size of tensor'):
         sensitivity_op.forward(u)
 
-    v = random_generator.complex64_tensor(size=(img_other_dim, n_coils, n_z, n_y, n_x))
+    v = random_generator.complex64_tensor(size=(n_other_img, n_coils, *ns_zyx))
     with pytest.raises(RuntimeError, match='The size of tensor'):
         sensitivity_op.adjoint(v)


### PR DESCRIPTION
We forgot to move this one over in #193 
Also, it now tests for multiple other dimensions and if the result is the same if created with a tensor and with CSMData.

I added an explicit shape check to dotproduct_adjointness_test, as the flatten before the dotproduct made the test insensitive to an operator returning the wrong shape in the adjoint.

