### PR TITLE
Support bipolar readout

### DIFF
--- a/src/mrpro/data/traj_calculators/_KTrajectoryCalculator.py
+++ b/src/mrpro/data/traj_calculators/_KTrajectoryCalculator.py
@@ -58,21 +58,18 @@ class KTrajectoryCalculator(ABC):
         ValueError
             Center sample has to be the same for each readout
         """
-        n_samples = kheader.acq_info.number_of_samples.flatten()
-        center_sample = kheader.acq_info.center_sample.flatten()
-        if len(torch.unique(n_samples)) > 1:
+        n_samples = torch.unique(kheader.acq_info.number_of_samples)
+        center_sample = kheader.acq_info.center_sample
+        if len(n_samples) > 1:
             raise ValueError('Trajectory can only be calculated if each acquisition has the same number of samples')
-        n_k0 = int(n_samples[0])
+        n_k0 = int(n_samples.item())
 
         # Data can be obtained with standard or reversed readout (e.g. bipolar readout).
-        k0 = torch.linspace(0, n_k0 - 1, n_k0, dtype=torch.float32)[None, :] - center_sample[:, None]
-        reversed_readout_idx = torch.where(kheader.acq_info.flags.flatten() & AcqFlags.ACQ_IS_REVERSE.value)[0]
-        # pytorch does not yet allow for negative indexing. torch.flip makes a copy of the data. providing a reversed
-        # index should be fastest
-        reversed_index = torch.linspace(n_k0 - 1, 0, n_k0, dtype=torch.int64)
-        k0[reversed_readout_idx, :] = k0[reversed_readout_idx[:, None], reversed_index[None, :]]
-
-        return k0.reshape(kheader.acq_info.center_sample.shape[:-1] + (n_k0,))
+        k0 = torch.linspace(0, n_k0 - 1, n_k0, dtype=torch.float32) - center_sample
+        # Data can be obtained with standard or reversed readout (e.g. bipolar readout).
+        reversed_readout_mask = (kheader.acq_info.flags[..., 0] & AcqFlags.ACQ_IS_REVERSE.value).bool()
+        k0[reversed_readout_mask, :] = torch.flip(k0[reversed_readout_mask, :], (-1,))
+        return k0
 
 
 class DummyTrajectory(KTrajectoryCalculator):

--- a/src/mrpro/data/traj_calculators/_KTrajectoryCalculator.py
+++ b/src/mrpro/data/traj_calculators/_KTrajectoryCalculator.py
@@ -81,8 +81,8 @@ class DummyTrajectory(KTrajectoryCalculator):
     Shape will fit to all data. Only used as dummy for testing.
     """
 
-    def __call__(self, header: KHeader) -> KTrajectory:
-        """Calculate dummy trajectory for given KHeader."""
-        kx = torch.zeros(1, 1, 1, header.encoding_limits.k0.length)
+    def __call__(self, header: KHeader) -> KTrajectory:  # noqa: ARG002
+        """Calculate dummy trajectory."""
+        kx = torch.zeros(1, 1, 1, 1)
         ky = kz = torch.zeros(1, 1, 1, 1)
         return KTrajectory(kz, ky, kx)

--- a/src/mrpro/data/traj_calculators/_KTrajectoryCalculator.py
+++ b/src/mrpro/data/traj_calculators/_KTrajectoryCalculator.py
@@ -55,8 +55,6 @@ class KTrajectoryCalculator(ABC):
         ------
         ValueError
             Number of samples have to be the same for each readout
-        ValueError
-            Center sample has to be the same for each readout
         """
         n_samples = torch.unique(kheader.acq_info.number_of_samples)
         center_sample = kheader.acq_info.center_sample

--- a/src/mrpro/data/traj_calculators/_KTrajectoryCartesian.py
+++ b/src/mrpro/data/traj_calculators/_KTrajectoryCartesian.py
@@ -45,7 +45,6 @@ class KTrajectoryCartesian(KTrajectoryCalculator):
         kz = (kheader.acq_info.idx.k2 - kheader.encoding_limits.k2.center).to(torch.float32)
 
         # Bring to correct dimensions
-        kx = repeat(kx, 'k0-> other k2 k1 k0', other=1, k2=1, k1=1)
         ky = repeat(ky, 'other k2 k1-> other k2 k1 k0', k0=1)
         kz = repeat(kz, 'other k2 k1-> other k2 k1 k0', k0=1)
         return KTrajectory(kz, ky, kx)

--- a/src/mrpro/data/traj_calculators/_KTrajectoryRpe.py
+++ b/src/mrpro/data/traj_calculators/_KTrajectoryRpe.py
@@ -125,7 +125,7 @@ class KTrajectoryRpe(KTrajectoryCalculator):
             radial phase encoding trajectory for given KHeader
         """
         # Trajectory along readout
-        kfreq = self._kfreq(kheader)
+        kx = self._kfreq(kheader)
 
         # Angles of phase encoding lines
         kang = self._kang(kheader)
@@ -135,5 +135,4 @@ class KTrajectoryRpe(KTrajectoryCalculator):
 
         kz = (krad * torch.sin(kang))[..., None]
         ky = (krad * torch.cos(kang))[..., None]
-        kx = kfreq[None, None, None, :]
         return KTrajectory(kz, ky, kx)

--- a/tests/data/test_traj_calculators.py
+++ b/tests/data/test_traj_calculators.py
@@ -39,8 +39,9 @@ def valid_rad2d_kheader(monkeypatch, random_kheader):
     idx_k1 = torch.arange(n_k1, dtype=torch.int32)[None, None, ...]
 
     # Set parameters for radial 2D trajectory
-    monkeypatch.setattr(random_kheader.acq_info, 'number_of_samples', torch.zeros_like(idx_k1) + n_k0)
-    monkeypatch.setattr(random_kheader.acq_info, 'center_sample', torch.zeros_like(idx_k1) + n_k0 // 2)
+    monkeypatch.setattr(random_kheader.acq_info, 'number_of_samples', torch.zeros_like(idx_k1)[..., None] + n_k0)
+    monkeypatch.setattr(random_kheader.acq_info, 'center_sample', torch.zeros_like(idx_k1)[..., None] + n_k0 // 2)
+    monkeypatch.setattr(random_kheader.acq_info, 'flags', torch.zeros_like(idx_k1)[..., None])
     monkeypatch.setattr(random_kheader.acq_info.idx, 'k1', idx_k1)
 
     # This is only needed for Pulseq trajectory calculation
@@ -90,8 +91,9 @@ def valid_rpe_kheader(monkeypatch, random_kheader):
     idx_k2 = torch.reshape(idx_k2, (1, n_k2, n_k1))
 
     # Set parameters for RPE trajectory
-    monkeypatch.setattr(random_kheader.acq_info, 'number_of_samples', torch.zeros_like(idx_k1) + n_k0)
-    monkeypatch.setattr(random_kheader.acq_info, 'center_sample', torch.zeros_like(idx_k1) + n_k0 // 2)
+    monkeypatch.setattr(random_kheader.acq_info, 'number_of_samples', torch.zeros_like(idx_k1)[..., None] + n_k0)
+    monkeypatch.setattr(random_kheader.acq_info, 'center_sample', torch.zeros_like(idx_k1)[..., None] + n_k0 // 2)
+    monkeypatch.setattr(random_kheader.acq_info, 'flags', torch.zeros_like(idx_k1)[..., None])
     monkeypatch.setattr(random_kheader.acq_info.idx, 'k1', idx_k1)
     monkeypatch.setattr(random_kheader.acq_info.idx, 'k2', idx_k2)
     monkeypatch.setattr(random_kheader.encoding_limits.k1, 'center', int(n_k1 // 2))
@@ -174,8 +176,9 @@ def valid_cartesian_kheader(monkeypatch, random_kheader):
     idx_k2 = torch.reshape(idx_k2, (1, n_k2, n_k1))
 
     # Set parameters for Cartesian trajectory
-    monkeypatch.setattr(random_kheader.acq_info, 'number_of_samples', torch.zeros_like(idx_k1) + n_k0)
-    monkeypatch.setattr(random_kheader.acq_info, 'center_sample', torch.zeros_like(idx_k1) + n_k0 // 2)
+    monkeypatch.setattr(random_kheader.acq_info, 'number_of_samples', torch.zeros_like(idx_k1)[..., None] + n_k0)
+    monkeypatch.setattr(random_kheader.acq_info, 'center_sample', torch.zeros_like(idx_k1)[..., None] + n_k0 // 2)
+    monkeypatch.setattr(random_kheader.acq_info, 'flags', torch.zeros_like(idx_k1)[..., None])
     monkeypatch.setattr(random_kheader.acq_info.idx, 'k1', idx_k1)
     monkeypatch.setattr(random_kheader.acq_info.idx, 'k2', idx_k2)
     monkeypatch.setattr(random_kheader.encoding_limits.k1, 'center', int(n_k1 // 2))

--- a/tests/data/test_traj_calculators.py
+++ b/tests/data/test_traj_calculators.py
@@ -15,7 +15,9 @@
 import numpy as np
 import pytest
 import torch
+from einops import repeat
 from mrpro.data import KData
+from mrpro.data.enums import AcqFlags
 from mrpro.data.traj_calculators import KTrajectoryCartesian
 from mrpro.data.traj_calculators import KTrajectoryIsmrmrd
 from mrpro.data.traj_calculators import KTrajectoryPulseq
@@ -167,13 +169,14 @@ def valid_cartesian_kheader(monkeypatch, random_kheader):
     n_k0 = 200
     n_k1 = 20
     n_k2 = 10
+    n_other = 2
 
     # List of k1 and k2 indices in the shape (other, k2, k1)
     k1 = torch.linspace(0, n_k1 - 1, n_k1, dtype=torch.int32)
     k2 = torch.linspace(0, n_k2 - 1, n_k2, dtype=torch.int32)
     idx_k1, idx_k2 = torch.meshgrid(k1, k2, indexing='xy')
-    idx_k1 = torch.reshape(idx_k1, (1, n_k2, n_k1))
-    idx_k2 = torch.reshape(idx_k2, (1, n_k2, n_k1))
+    idx_k1 = repeat(torch.reshape(idx_k1, (n_k2, n_k1)), 'k2 k1->other k2 k1', other=n_other)
+    idx_k2 = repeat(torch.reshape(idx_k2, (n_k2, n_k1)), 'k2 k1->other k2 k1', other=n_other)
 
     # Set parameters for Cartesian trajectory
     monkeypatch.setattr(random_kheader.acq_info, 'number_of_samples', torch.zeros_like(idx_k1)[..., None] + n_k0)
@@ -193,7 +196,7 @@ def cartesian_traj_shape(valid_cartesian_kheader):
     n_k0 = valid_cartesian_kheader.acq_info.number_of_samples[0, 0, 0]
     n_k1 = valid_cartesian_kheader.acq_info.idx.k1.shape[2]
     n_k2 = valid_cartesian_kheader.acq_info.idx.k1.shape[1]
-    n_other = 1
+    n_other = 1  # trajectory along other is the same
     return (torch.Size([n_other, n_k2, 1, 1]), torch.Size([n_other, 1, n_k1, 1]), torch.Size([n_other, 1, 1, n_k0]))
 
 
@@ -205,6 +208,23 @@ def test_KTrajectoryCartesian(valid_cartesian_kheader):
     assert trajectory.kz.shape == valid_shape[0]
     assert trajectory.ky.shape == valid_shape[1]
     assert trajectory.kx.shape == valid_shape[2]
+
+
+@pytest.fixture()
+def valid_cartesian_kheader_bipolar(monkeypatch, valid_cartesian_kheader):
+    """Set readout of other==1 to reversed."""
+    acq_info_flags = valid_cartesian_kheader.acq_info.flags
+    acq_info_flags[1, ...] = AcqFlags.ACQ_IS_REVERSE.value
+    monkeypatch.setattr(valid_cartesian_kheader.acq_info, 'flags', acq_info_flags)
+    return valid_cartesian_kheader
+
+
+def test_KTrajectoryCartesian_bipolar(valid_cartesian_kheader_bipolar):
+    """Calculate Cartesian trajectory with bipolar readout."""
+    trajectory_calculator = KTrajectoryCartesian()
+    trajectory = trajectory_calculator(valid_cartesian_kheader_bipolar)
+    # Verify that the readout for the second part of the bipolar readout is reversed
+    torch.testing.assert_close(trajectory.kx[0, ...], torch.flip(trajectory.kx[1, ...], dims=(-1,)))
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
Correct trajectory calculation for bipolar (i.e. reversed) readout.

closes #184 
closes #50 

requires #221
Update: actually does not require #217

ToDo:
- [x] Fix encoding limits for readout in KData
- [x] Add tests for bipolar readout 