### PR TITLE
power iteration and operator-norm

### DIFF
--- a/src/mrpro/operators/LinearOperator.py
+++ b/src/mrpro/operators/LinearOperator.py
@@ -81,9 +81,21 @@ class LinearOperator(Operator[torch.Tensor, tuple[torch.Tensor]]):
         -------
             an estimaton of the operator norm
         """
-        # check if initial value is exactly zero; if yes, set it to a random value
-        vector = torch.randn_like(initial_value) if (initial_value == 0.0).all() else initial_value
+        norm_initial_value = torch.linalg.vector_norm(initial_value, dim=dim, keepdim=True)
+        if dim is None:
+            if norm_initial_value == 0:
+                raise Exception('The initial value for the iteration should be different from the zero-vector.')
+        else:
+            if not (norm_initial_value > 0).all():
+                raise Exception(
+                    'Found at least one zero-vector as starting point. \
+                    For each of the considered operators, the initial value for the iteration \
+                    should be different from the zero-vector.'
+                )
+        if max_iterations < 1:
+            raise Exception('The number of iterations should be larger than zero.')
 
+        vector = initial_value
         for _ in range(max_iterations):
             # apply the operator to the vector
             (vector,) = self.adjoint(*self(vector))

--- a/tests/operators/test_operator_norm.py
+++ b/tests/operators/test_operator_norm.py
@@ -1,0 +1,96 @@
+"""Tests for computing the operator norm for linear operators."""
+
+# Copyright 2024 Physikalisch-Technische Bundesanstalt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from math import cos
+from math import pi
+from math import prod
+
+import torch
+from mrpro.operators import EinsumOp
+from mrpro.operators import FastFourierOp
+
+from tests import RandomGenerator
+
+
+def test_correct_result():
+    """Test if the implementation yields the correct result for different choices
+    of operators with known operator-norm."""
+    random_generator = RandomGenerator(seed=0)
+
+    # test with a 3x3 matrix with known largest eigenvalue
+    matrix1 = torch.tensor([[2.0, 1, 0], [1.0, 2.0, 1.0], [0.0, 1.0, 2.0]])
+    operator1 = EinsumOp(matrix1, 'y x, x-> y')
+    random_vector1 = random_generator.float32_tensor(matrix1.shape[1])
+    operator1_norm_est = operator1.operator_norm(random_vector1, dim=None, max_iterations=32)
+    operator1_norm_true = 2 * (1 + cos(pi / 4))  # approximately 3.41421...
+    torch.testing.assert_close(operator1_norm_est.item(), operator1_norm_true, atol=1e-4, rtol=1e-4)
+
+    # test with Fast Fourier Operator (has norm 1 since norm="ortho" is used)
+    dim = (-3, -2, -1)
+    fouirer_op = FastFourierOp(dim=dim)
+
+    random_image = torch.zeros(
+        4, 4, 8, 16, dtype=torch.complex64
+    )  # also tests that the initial value is set to a random value
+    fouirer_op_norm_batched = fouirer_op.operator_norm(random_image, dim=dim, max_iterations=64)
+    fourier_op_norm_non_batched = fouirer_op.operator_norm(random_image, dim=None, max_iterations=64)
+    fourier_op_norm_true = 1.0
+
+    torch.testing.assert_close(fouirer_op_norm_batched, torch.ones(4, 1, 1, 1), atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(fourier_op_norm_non_batched.max().item(), fourier_op_norm_true, atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(fourier_op_norm_non_batched.item(), fourier_op_norm_true, atol=1e-4, rtol=1e-4)
+
+
+def test_batched_operator_norm():
+    """Test if the batched calculation of the operator-norm works on a simple
+    matrix-vector multiplication example."""
+    random_generator = RandomGenerator(seed=0)
+    input_shape = (2, 4, 8, 8)
+
+    # dimensions which define the dimensionality of the considered vector space
+    dim = (-1,)
+
+    # create a tensor to be identified as 2 * 4 (=8) 8x8 square matrices
+    matrix1 = torch.arange(prod(input_shape)).reshape(input_shape).to(torch.float32)
+
+    # construct a linear operator from the first matrix; the linear operator implements
+    # the batched matrix-vector multiplication
+    operator1 = EinsumOp(matrix1, 'other1 other2 y x, other1 other2 x-> other1 other2 y')
+
+    random_vector1 = random_generator.float32_tensor((input_shape[0], input_shape[1], input_shape[3]))
+
+    # compute batched and non batched operator norms
+    operator1_norm_batched = operator1.operator_norm(random_vector1, dim=dim, max_iterations=32)
+    operator1_norm_non_batched = operator1.operator_norm(random_vector1, dim=None, max_iterations=32)
+
+    # using the fact that for a block-diagonal matrix, the eigenvalues are the list of
+    # eigenvalues of the respective matrices, test whether the largest of the batched
+    # operator norms coincides with the non-batched operator norm
+    torch.testing.assert_close(
+        operator1_norm_batched.max().item(), operator1_norm_non_batched.item(), atol=1e-4, rtol=1e-4
+    )
+
+    # create a block diagonal matrix containing the 2*4=8 matrices in the diagonal
+    matrix2 = torch.block_diag(*[matrix1[kb, kt, ...] for kb in range(input_shape[0]) for kt in range(input_shape[1])])
+
+    # construct a linear operator from the second matrix; the linear operator implements
+    # the multiplication of the block-diagonal matrix with a 2*4*8*8 = 512-dimensional vector
+    operator2 = EinsumOp(matrix2, 'y x, x-> y')
+    random_vector2 = random_generator.float32_tensor(matrix2.shape[1])
+    operator2_norm_non_batched = operator2.operator_norm(random_vector2, dim=None, max_iterations=32)
+
+    # test whether the operator-norm calculated from the first operator and from the second
+    # one coincide
+    torch.testing.assert_close(
+        operator2_norm_non_batched.item(), operator1_norm_non_batched.item(), atol=1e-4, rtol=1e-4
+    )

--- a/tests/operators/test_operator_norm.py
+++ b/tests/operators/test_operator_norm.py
@@ -1,4 +1,4 @@
-"""Tests for computing the operator norm for linear operators."""
+"""Tests for computing the operator norm of linear operators."""
 
 # Copyright 2024 Physikalisch-Technische Bundesanstalt
 #
@@ -27,12 +27,12 @@ def test_operator_norm_result():
     random_generator = RandomGenerator(seed=0)
 
     # test with a 3x3 matrix with known largest eigenvalue
-    matrix1 = torch.tensor([[2.0, 1, 0], [1.0, 2.0, 1.0], [0.0, 1.0, 2.0]])
-    operator1 = EinsumOp(matrix1, 'y x, x-> y')
-    random_vector1 = random_generator.float32_tensor(matrix1.shape[1])
-    operator1_norm_est = operator1.operator_norm(random_vector1, dim=None, max_iterations=32)
-    operator1_norm_true = 2 + sqrt(2)  # approximately 3.41421...
-    torch.testing.assert_close(operator1_norm_est.item(), operator1_norm_true, atol=1e-4, rtol=1e-4)
+    matrix = torch.tensor([[2.0, 1, 0], [1.0, 2.0, 1.0], [0.0, 1.0, 2.0]])
+    operator = EinsumOp(matrix, 'y x, x-> y')
+    random_vector = random_generator.float32_tensor(matrix.shape[1])
+    operator_norm_est = operator.operator_norm(random_vector, dim=None, max_iterations=32)
+    operator_norm_true = 2 + sqrt(2)  # approximately 3.41421...
+    torch.testing.assert_close(operator_norm_est.item(), operator_norm_true, atol=1e-4, rtol=1e-4)
 
 
 def test_fourier_operator_norm():

--- a/tests/operators/test_operator_norm.py
+++ b/tests/operators/test_operator_norm.py
@@ -18,21 +18,47 @@ import pytest
 import torch
 from mrpro.operators import EinsumOp
 from mrpro.operators import FastFourierOp
+from mrpro.operators import FiniteDifferenceOp
 
 from tests import RandomGenerator
 
 
-def test_operator_norm_invalid_n_max_iterations():
+def test_power_iteration_uses_stopping_criterion():
+    """Test if the power iteration stops if the the absolute and relative tolerance are chosen high."""
+
+    # callback function that should not be called because the power iteration
+    # should stop if the tolerances are set high
+    def callback():
+        pytest.fail('The power iteration did not stop despite high atol and rtol!')
+
+    random_generator = RandomGenerator(seed=0)
+
+    # test with a 3x3 matrix
+    matrix = torch.tensor([[2.0, 1, 0], [1.0, 2.0, 1.0], [0.0, 1.0, 2.0]])
+    operator = EinsumOp(matrix, ' y x, x-> y')
+    random_vector = random_generator.float32_tensor(matrix.shape[1])
+    absolute_tolerance, relative_tolerance = 1e8, 1e8
+    _ = operator.operator_norm(
+        random_vector,
+        dim=None,
+        max_iterations=32,
+        absolute_tolerance=absolute_tolerance,
+        relative_tolerance=relative_tolerance,
+        callback=callback,
+    )
+
+
+def test_operator_norm_invalid_max_iterations():
     """Test if choosing a number of iterations < 1 throws an exception."""
     random_generator = RandomGenerator(seed=0)
 
     # test with a 3x3 matrix with known largest eigenvalue
     matrix = torch.tensor([[2.0, 1, 0], [1.0, 2.0, 1.0], [0.0, 1.0, 2.0]])
-    operator = EinsumOp(matrix, 'y x, x-> y')
+    operator = EinsumOp(matrix, 'y x, x -> y')
     random_vector = random_generator.float32_tensor(matrix.shape[1])
 
-    with pytest.raises(Exception, match='zero'):
-        operator.operator_norm(random_vector, dim=None, n_max_iterations=0)
+    with pytest.raises(ValueError, match='zero'):
+        operator.operator_norm(random_vector, dim=None, max_iterations=0)
 
 
 def test_operator_norm_invalid_initial_value():
@@ -46,7 +72,7 @@ def test_operator_norm_invalid_initial_value():
 
     # construct a linear operator from the first matrix; the linear operator implements
     # the batched matrix-vector multiplication
-    operator = EinsumOp(matrix, 'other1 other2 y x, other1 other2 x-> other1 other2 y')
+    operator = EinsumOp(matrix, '... y x, ... x-> ... y')
 
     # dimensions which define the dimensionality of the considered vector space
     dim1 = (-1,)
@@ -59,10 +85,10 @@ def test_operator_norm_invalid_initial_value():
     # zero-vector
     illegal_initial_value2 = torch.zeros(vector_shape)
 
-    with pytest.raises(Exception, match='least'):
-        operator.operator_norm(illegal_initial_value1, dim=dim1, n_max_iterations=8)
-    with pytest.raises(Exception, match='zero'):
-        operator.operator_norm(illegal_initial_value2, dim=dim2, n_max_iterations=8)
+    with pytest.raises(ValueError, match='least'):
+        operator.operator_norm(illegal_initial_value1, dim=dim1, max_iterations=8)
+    with pytest.raises(ValueError, match='zero'):
+        operator.operator_norm(illegal_initial_value2, dim=dim2, max_iterations=8)
 
 
 def test_operator_norm_result():
@@ -74,7 +100,7 @@ def test_operator_norm_result():
     matrix = torch.tensor([[2.0, 1, 0], [1.0, 2.0, 1.0], [0.0, 1.0, 2.0]])
     operator = EinsumOp(matrix, 'y x, x-> y')
     random_vector = random_generator.float32_tensor(matrix.shape[1])
-    operator_norm_est = operator.operator_norm(random_vector, dim=None, n_max_iterations=32)
+    operator_norm_est = operator.operator_norm(random_vector, dim=None, max_iterations=32)
     operator_norm_true = 2 + sqrt(2)  # approximately 3.41421...
     torch.testing.assert_close(operator_norm_est.item(), operator_norm_true, atol=1e-4, rtol=1e-4)
 
@@ -86,13 +112,38 @@ def test_fourier_operator_norm():
     dim = (-3, -2, -1)
     fourier_op = FastFourierOp(dim=dim)
     random_image = random_generator.complex64_tensor(size=(4, 4, 8, 16))
-    fourier_op_norm_batched = fourier_op.operator_norm(random_image, dim=dim, n_max_iterations=64)
-    fourier_op_norm_non_batched = fourier_op.operator_norm(random_image, dim=None, n_max_iterations=64)
+    fourier_op_norm_batched = fourier_op.operator_norm(random_image, dim=dim, max_iterations=128)
+    fourier_op_norm_non_batched = fourier_op.operator_norm(random_image, dim=None, max_iterations=128)
     fourier_op_norm_true = 1.0
 
     torch.testing.assert_close(fourier_op_norm_batched, torch.ones(4, 1, 1, 1), atol=1e-4, rtol=1e-4)
     torch.testing.assert_close(fourier_op_norm_non_batched.max().item(), fourier_op_norm_true, atol=1e-4, rtol=1e-4)
     torch.testing.assert_close(fourier_op_norm_non_batched.item(), fourier_op_norm_true, atol=1e-4, rtol=1e-4)
+
+
+@pytest.mark.parametrize(
+    'dim',
+    [(-1,), (-2, -1), (-3, -2, -1), (-4, -3, -2, -1)],
+)
+def test_finite_difference_operator_norm(dim):
+    """Test with the finite difference operator for which there exists a closed-form solution."""
+    random_generator = RandomGenerator(seed=0)
+
+    finite_difference_operator = FiniteDifferenceOp(dim=dim, mode='forward')
+
+    # initialize random image of appropriate shape depending on the dimensionality
+    image_shape = (1, *tuple([16 for _ in range(len(dim))]))
+    random_image = random_generator.complex64_tensor(size=image_shape)
+
+    # calculate the operator norm
+    finite_difference_operator_norm = finite_difference_operator.operator_norm(random_image, dim=dim, max_iterations=64)
+
+    # closed form solution of the operator norm
+    finite_difference_operator_norm_true = sqrt(len(dim) * 4)
+
+    torch.testing.assert_close(
+        finite_difference_operator_norm.item(), finite_difference_operator_norm_true, atol=1e-2, rtol=1e-2
+    )
 
 
 def test_batched_operator_norm():
@@ -114,13 +165,13 @@ def test_batched_operator_norm():
 
     # construct a linear operator from the first matrix; the linear operator implements
     # the batched matrix-vector multiplication
-    operator1 = EinsumOp(matrix1, 'other1 other2 y x, other1 other2 x-> other1 other2 y')
+    operator1 = EinsumOp(matrix1, '... y x, ... x-> ... y')
 
     random_vector1 = random_generator.float32_tensor((input_shape[0], input_shape[1], input_shape[3]))
 
     # compute batched and non batched operator norms
-    operator1_norm_batched = operator1.operator_norm(random_vector1, dim=dim, n_max_iterations=32)
-    operator1_norm_non_batched = operator1.operator_norm(random_vector1, dim=None, n_max_iterations=32)
+    operator1_norm_batched = operator1.operator_norm(random_vector1, dim=dim, max_iterations=32)
+    operator1_norm_non_batched = operator1.operator_norm(random_vector1, dim=None, max_iterations=32)
 
     torch.testing.assert_close(
         operator1_norm_batched.max().item(), operator1_norm_non_batched.item(), atol=1e-4, rtol=1e-4
@@ -135,7 +186,7 @@ def test_batched_operator_norm():
     # the multiplication of the block-diagonal matrix with a 2*4*8*8 = 512-dimensional vector
     operator2 = EinsumOp(matrix2, '... y x, x-> ... y')
     random_vector2 = random_generator.float32_tensor(matrix2.shape[1])
-    operator2_norm_non_batched = operator2.operator_norm(random_vector2, dim=None, n_max_iterations=32)
+    operator2_norm_non_batched = operator2.operator_norm(random_vector2, dim=None, max_iterations=32)
 
     # test whether the operator-norm calculated from the first operator and from the second
     # are equal

--- a/tests/operators/test_operator_norm.py
+++ b/tests/operators/test_operator_norm.py
@@ -22,7 +22,8 @@ from mrpro.operators import FastFourierOp
 from tests import RandomGenerator
 
 
-def test_operator_norm_illegal_max_iterations():
+def test_operator_norm_invalid_n_max_iterations():
+    """Test if choosing a number of iterations < 1 throws an exception."""
     random_generator = RandomGenerator(seed=0)
 
     # test with a 3x3 matrix with known largest eigenvalue
@@ -31,10 +32,11 @@ def test_operator_norm_illegal_max_iterations():
     random_vector = random_generator.float32_tensor(matrix.shape[1])
 
     with pytest.raises(Exception, match='zero'):
-        operator.operator_norm(random_vector, dim=None, max_iterations=0)
+        operator.operator_norm(random_vector, dim=None, n_max_iterations=0)
 
 
-def test_operator_norm_illegal_initial_value():
+def test_operator_norm_invalid_initial_value():
+    """Test if choosing zero-tensors throws an exception."""
     random_generator = RandomGenerator(seed=0)
     input_shape = (2, 4, 8, 8)
     vector_shape = (input_shape[0], input_shape[1], input_shape[3])
@@ -58,9 +60,9 @@ def test_operator_norm_illegal_initial_value():
     illegal_initial_value2 = torch.zeros(vector_shape)
 
     with pytest.raises(Exception, match='least'):
-        operator.operator_norm(illegal_initial_value1, dim=dim1, max_iterations=8)
+        operator.operator_norm(illegal_initial_value1, dim=dim1, n_max_iterations=8)
     with pytest.raises(Exception, match='zero'):
-        operator.operator_norm(illegal_initial_value2, dim=dim2, max_iterations=8)
+        operator.operator_norm(illegal_initial_value2, dim=dim2, n_max_iterations=8)
 
 
 def test_operator_norm_result():
@@ -72,7 +74,7 @@ def test_operator_norm_result():
     matrix = torch.tensor([[2.0, 1, 0], [1.0, 2.0, 1.0], [0.0, 1.0, 2.0]])
     operator = EinsumOp(matrix, 'y x, x-> y')
     random_vector = random_generator.float32_tensor(matrix.shape[1])
-    operator_norm_est = operator.operator_norm(random_vector, dim=None, max_iterations=32)
+    operator_norm_est = operator.operator_norm(random_vector, dim=None, n_max_iterations=32)
     operator_norm_true = 2 + sqrt(2)  # approximately 3.41421...
     torch.testing.assert_close(operator_norm_est.item(), operator_norm_true, atol=1e-4, rtol=1e-4)
 
@@ -84,8 +86,8 @@ def test_fourier_operator_norm():
     dim = (-3, -2, -1)
     fourier_op = FastFourierOp(dim=dim)
     random_image = random_generator.complex64_tensor(size=(4, 4, 8, 16))
-    fourier_op_norm_batched = fourier_op.operator_norm(random_image, dim=dim, max_iterations=64)
-    fourier_op_norm_non_batched = fourier_op.operator_norm(random_image, dim=None, max_iterations=64)
+    fourier_op_norm_batched = fourier_op.operator_norm(random_image, dim=dim, n_max_iterations=64)
+    fourier_op_norm_non_batched = fourier_op.operator_norm(random_image, dim=None, n_max_iterations=64)
     fourier_op_norm_true = 1.0
 
     torch.testing.assert_close(fourier_op_norm_batched, torch.ones(4, 1, 1, 1), atol=1e-4, rtol=1e-4)
@@ -117,8 +119,8 @@ def test_batched_operator_norm():
     random_vector1 = random_generator.float32_tensor((input_shape[0], input_shape[1], input_shape[3]))
 
     # compute batched and non batched operator norms
-    operator1_norm_batched = operator1.operator_norm(random_vector1, dim=dim, max_iterations=32)
-    operator1_norm_non_batched = operator1.operator_norm(random_vector1, dim=None, max_iterations=32)
+    operator1_norm_batched = operator1.operator_norm(random_vector1, dim=dim, n_max_iterations=32)
+    operator1_norm_non_batched = operator1.operator_norm(random_vector1, dim=None, n_max_iterations=32)
 
     torch.testing.assert_close(
         operator1_norm_batched.max().item(), operator1_norm_non_batched.item(), atol=1e-4, rtol=1e-4
@@ -133,7 +135,7 @@ def test_batched_operator_norm():
     # the multiplication of the block-diagonal matrix with a 2*4*8*8 = 512-dimensional vector
     operator2 = EinsumOp(matrix2, '... y x, x-> ... y')
     random_vector2 = random_generator.float32_tensor(matrix2.shape[1])
-    operator2_norm_non_batched = operator2.operator_norm(random_vector2, dim=None, max_iterations=32)
+    operator2_norm_non_batched = operator2.operator_norm(random_vector2, dim=None, n_max_iterations=32)
 
     # test whether the operator-norm calculated from the first operator and from the second
     # are equal


### PR DESCRIPTION
This implements a power iteration method to estimate the largest eigenvalue and largest eigenvector if a function. This can be further used to estimate the operator-norm of a LinearOperator.

Examples where this can be used are `iterative_walsh_inati` (see #210 and #97), the calculation of the operator norm for a simple Landweber method, the calculation of the upper bound for the step sizes to be used in pdhg, etc