### PR TITLE
allow batch dimension in signal models

### DIFF
--- a/src/mrpro/operators/models/_InversionRecovery.py
+++ b/src/mrpro/operators/models/_InversionRecovery.py
@@ -29,6 +29,7 @@ class InversionRecovery(SignalModel[torch.Tensor, torch.Tensor]):
             with shape (time, ...)
         """
         super().__init__()
+        ti = torch.as_tensor(ti)
         self.ti = torch.nn.Parameter(ti, requires_grad=ti.requires_grad)
 
     def forward(self, m0: torch.Tensor, t1: torch.Tensor) -> tuple[torch.Tensor,]:

--- a/src/mrpro/operators/models/_InversionRecovery.py
+++ b/src/mrpro/operators/models/_InversionRecovery.py
@@ -17,10 +17,10 @@ from mrpro.operators import SignalModel
 
 
 class InversionRecovery(SignalModel[torch.Tensor, torch.Tensor]):
-    """Inversion Recovery signal model."""
+    """Inversion recovery signal model."""
 
-    def __init__(self, ti: torch.Tensor):
-        """Initialize Inversion Recovery signal model for T1 mapping.
+    def __init__(self, ti: float | torch.Tensor):
+        """Initialize inversion recovery signal model for T1 mapping.
 
         Parameters
         ----------
@@ -33,7 +33,7 @@ class InversionRecovery(SignalModel[torch.Tensor, torch.Tensor]):
         self.ti = torch.nn.Parameter(ti, requires_grad=ti.requires_grad)
 
     def forward(self, m0: torch.Tensor, t1: torch.Tensor) -> tuple[torch.Tensor,]:
-        """Apply Inversion Recovery signal model.
+        """Apply inversion recovery signal model.
 
         Parameters
         ----------

--- a/src/mrpro/operators/models/_InversionRecovery.py
+++ b/src/mrpro/operators/models/_InversionRecovery.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import torch
-from einops import rearrange
 
 from mrpro.operators import SignalModel
 
@@ -26,7 +25,8 @@ class InversionRecovery(SignalModel[torch.Tensor, torch.Tensor]):
         Parameters
         ----------
         ti
-            inversion times [s]
+            inversion times
+            with shape (time, ...)
         """
         super().__init__()
         self.ti = torch.nn.Parameter(ti, requires_grad=ti.requires_grad)
@@ -38,19 +38,17 @@ class InversionRecovery(SignalModel[torch.Tensor, torch.Tensor]):
         ----------
         m0
             equilibrium signal / proton density
-            with shape ... other, coils, z, y, x)
+            with shape (... other, coils, z, y, x)
         t1
             longitudinal relaxation time T1
-            with shape ... other, coils, z, y, x)
+            with shape (... other, coils, z, y, x)
 
         Returns
         -------
             signal
-            with shape ... (other inv_times), coils, z, y, x)
+            with shape (time ... other, coils, z, y, x)
         """
-        ti = self.ti[..., None, :, None, None, None, None]  # *other t, c, z, y, x
-        m0 = m0.unsqueeze(-5)  # *other t, c, z, y, x
-        t1 = t1.unsqueeze(-5)  # *other t, c, z, y, x
+        delta_ndim = m0.ndim - (self.ti.ndim - 1)  # -1 for time
+        ti = self.ti[..., *[None] * (delta_ndim)] if delta_ndim > 0 else self.ti
         signal = m0 * (1 - 2 * torch.exp(-(ti / t1)))
-        signal = rearrange(signal, '... other t c z y x -> ... ( other t ) c z y x')
         return (signal,)

--- a/src/mrpro/operators/models/_InversionRecovery.py
+++ b/src/mrpro/operators/models/_InversionRecovery.py
@@ -38,15 +38,19 @@ class InversionRecovery(SignalModel[torch.Tensor, torch.Tensor]):
         ----------
         m0
             equilibrium signal / proton density
+            with shape ... other, coils, z, y, x)
         t1
             longitudinal relaxation time T1
+            with shape ... other, coils, z, y, x)
 
         Returns
         -------
-            signal with dimensions ((... inv_times), coils, z, y, x)
+            signal
+            with shape ... (other inv_times), coils, z, y, x)
         """
-        t1 = torch.where(t1 == 0, 1e-10, t1)
-        ti = self.ti[(...,) + (None,) * (m0.ndim)]
-        y = m0 * (1 - 2 * torch.exp(-ti / t1))
-        res = rearrange(y, 't ... c z y x -> (... t) c z y x')
-        return (res,)
+        ti = self.ti[..., None, :, None, None, None, None]  # *other t, c, z, y, x
+        m0 = m0.unsqueeze(-5)  # *other t, c, z, y, x
+        t1 = t1.unsqueeze(-5)  # *other t, c, z, y, x
+        signal = m0 * (1 - 2 * torch.exp(-(ti / t1)))
+        signal = rearrange(signal, '... other t c z y x -> ... ( other t ) c z y x')
+        return (signal,)

--- a/src/mrpro/operators/models/_MOLLI.py
+++ b/src/mrpro/operators/models/_MOLLI.py
@@ -19,7 +19,7 @@ from mrpro.operators import SignalModel
 class MOLLI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
     """Signal model for Modified Look-Locker inversion recovery (MOLLI)."""
 
-    def __init__(self, ti: torch.Tensor):
+    def __init__(self, ti: float | torch.Tensor):
         """Initialize MOLLI signal model for T1 mapping.
 
         Parameters

--- a/src/mrpro/operators/models/_MOLLI.py
+++ b/src/mrpro/operators/models/_MOLLI.py
@@ -29,6 +29,7 @@ class MOLLI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
             with shape (time, ...)
         """
         super().__init__()
+        ti = torch.as_tensor(ti)
         self.ti = torch.nn.Parameter(ti, requires_grad=ti.requires_grad)
 
     def forward(self, a: torch.Tensor, b: torch.Tensor, t1: torch.Tensor) -> tuple[torch.Tensor,]:

--- a/src/mrpro/operators/models/_MOLLI.py
+++ b/src/mrpro/operators/models/_MOLLI.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import torch
-from einops import rearrange
 
 from mrpro.operators import SignalModel
 
@@ -26,7 +25,8 @@ class MOLLI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
         Parameters
         ----------
         ti
-            inversion times [s]
+            inversion times
+            with shape (time, ...)
         """
         super().__init__()
         self.ti = torch.nn.Parameter(ti, requires_grad=ti.requires_grad)
@@ -37,22 +37,23 @@ class MOLLI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
         Parameters
         ----------
         a
-            Parameter a in MOLLI signal model
+            parameter a in MOLLI signal model
+            with shape (... other, coils, z, y, x)
         b
-            Parameter b in MOLLI signal model
+            parameter b in MOLLI signal model
+            with shape (... other, coils, z, y, x)
         t1
-            longitudinal relaxation time T1 [s]
+            longitudinal relaxation time T1
+            with shape (... other, coils, z, y, x)
 
         Returns
         -------
-            signal with dimensions ((... inv_times), coils, z, y, x)
+            signal
+            with shape (time ... other, coils, z, y, x)
         """
-        ti = self.ti[..., None, :, None, None, None, None]  # *other t=1, c, z, y, x
-        a = a.unsqueeze(-5)  # *other t=1, c, z, y, x
-        b = b.unsqueeze(-5)
-        t1 = t1.unsqueeze(-5)
+        delta_ndim = a.ndim - (self.ti.ndim - 1)  # -1 for time
+        ti = self.ti[..., *[None] * (delta_ndim)] if delta_ndim > 0 else self.ti
         c = b / torch.where(a == 0, 1e-10, a)
         t1 = torch.where(t1 == 0, t1 + 1e-10, t1)
-        signal = a * (1 - c * torch.exp(ti / t1 * (1 - c)))  # *other t=len(ti), c, z, y, x
-        signal = rearrange(signal, '... other t c z y x -> ... (other t) c z y x')
+        signal = a * (1 - c * torch.exp(ti / t1 * (1 - c)))
         return (signal,)

--- a/src/mrpro/operators/models/_SaturationRecovery.py
+++ b/src/mrpro/operators/models/_SaturationRecovery.py
@@ -29,6 +29,7 @@ class SaturationRecovery(SignalModel[torch.Tensor, torch.Tensor]):
             with shape (time, ...)
         """
         super().__init__()
+        ti = torch.as_tensor(ti)
         self.ti = torch.nn.Parameter(ti, requires_grad=ti.requires_grad)
 
     def forward(self, m0: torch.Tensor, t1: torch.Tensor) -> tuple[torch.Tensor,]:

--- a/src/mrpro/operators/models/_SaturationRecovery.py
+++ b/src/mrpro/operators/models/_SaturationRecovery.py
@@ -19,7 +19,7 @@ from mrpro.operators import SignalModel
 class SaturationRecovery(SignalModel[torch.Tensor, torch.Tensor]):
     """Signal model for saturation recovery."""
 
-    def __init__(self, ti: torch.Tensor):
+    def __init__(self, ti: float | torch.Tensor):
         """Initialize saturation recovery signal model for T1 mapping.
 
         Parameters
@@ -33,7 +33,7 @@ class SaturationRecovery(SignalModel[torch.Tensor, torch.Tensor]):
         self.ti = torch.nn.Parameter(ti, requires_grad=ti.requires_grad)
 
     def forward(self, m0: torch.Tensor, t1: torch.Tensor) -> tuple[torch.Tensor,]:
-        """Apply Saturation Recovery signal model.
+        """Apply saturation recovery signal model.
 
         Parameters
         ----------

--- a/tests/operators/models/test_shape_all_models.py
+++ b/tests/operators/models/test_shape_all_models.py
@@ -1,0 +1,65 @@
+from itertools import product
+
+import pytest
+import torch
+from mrpro.operators.models import MOLLI
+from mrpro.operators.models import WASABI
+from mrpro.operators.models import WASABITI
+from mrpro.operators.models import InversionRecovery
+from mrpro.operators.models import SaturationRecovery
+from tests import RandomGenerator
+
+# Signal model, number of tensor arguments in forward (i.e. quantitative parameters) and number of tensor arguments
+# in init (e.g. inversion time or CEST offsets)
+MODELS_AND_N_INPUT_PARAMETERS = [
+    (MOLLI, 3, 1),
+    (InversionRecovery, 2, 1),
+    (SaturationRecovery, 2, 1),
+    (WASABI, 4, 1),
+    (WASABITI, 3, 2),
+]
+
+# Shape combinations
+SHAPE_VARIATIONS_SIGNAL_MODELS = [
+    ((1, 1, 10, 20, 30), (5,), (5, 1, 1, 10, 20, 30)),  # single map with different inversion times
+    ((1, 1, 10, 20, 30), (5, 1), (5, 1, 1, 10, 20, 30)),
+    ((4, 1, 1, 10, 20, 30), (5, 1), (5, 4, 1, 1, 10, 20, 30)),  # multiple maps along additional batch dimension
+    ((4, 1, 1, 10, 20, 30), (5,), (5, 4, 1, 1, 10, 20, 30)),
+    ((4, 1, 1, 10, 20, 30), (5, 4), (5, 4, 1, 1, 10, 20, 30)),
+    ((3, 1, 10, 20, 30), (5,), (5, 3, 1, 10, 20, 30)),  # multiple maps along other dimension
+    ((3, 1, 10, 20, 30), (5, 1), (5, 3, 1, 10, 20, 30)),
+    ((3, 1, 10, 20, 30), (5, 3), (5, 3, 1, 10, 20, 30)),
+    ((4, 3, 1, 10, 20, 30), (5,), (5, 4, 3, 1, 10, 20, 30)),  # multiple maps along other and batch dimension
+    ((4, 3, 1, 10, 20, 30), (5, 4), (5, 4, 3, 1, 10, 20, 30)),
+    ((4, 3, 1, 10, 20, 30), (5, 4, 1), (5, 4, 3, 1, 10, 20, 30)),
+    ((4, 3, 1, 10, 20, 30), (5, 1, 3), (5, 4, 3, 1, 10, 20, 30)),
+    ((4, 3, 1, 10, 20, 30), (5, 4, 3), (5, 4, 3, 1, 10, 20, 30)),
+    ((1,), (5,), (5, 1)),  # single voxel
+    ((4, 3, 1), (5, 4, 3), (5, 4, 3, 1)),
+]
+
+# Combine models and shapes
+SHAPE_TESTS = pytest.mark.parametrize(
+    ('model', 'n_input_tensors', 'n_init_parameters', 'parameter_shape', 'contrast_dim_shape', 'signal_shape'),
+    [
+        (*model_shape[0], *model_shape[1])
+        for model_shape in product(MODELS_AND_N_INPUT_PARAMETERS, SHAPE_VARIATIONS_SIGNAL_MODELS)
+    ],
+)
+
+
+def create_parameter_tensors(parameter_shape=(10, 5, 100, 100, 100), number_of_tensors=2):
+    """Create list of tensors as input to signal models."""
+    random_generator = RandomGenerator(seed=0)
+    parameter_tensors = random_generator.float32_tensor(size=(number_of_tensors, *parameter_shape), low=1e-10)
+    return torch.unbind(parameter_tensors)
+
+
+@SHAPE_TESTS
+def test_model_shape(model, n_input_tensors, n_init_parameters, parameter_shape, contrast_dim_shape, signal_shape):
+    """Test correct signal shapes."""
+    input_parameters = create_parameter_tensors(contrast_dim_shape, number_of_tensors=n_init_parameters)
+    model_op = model(*input_parameters)
+    parameter_tensors = create_parameter_tensors(parameter_shape, number_of_tensors=n_input_tensors)
+    (signal,) = model_op.forward(*parameter_tensors)
+    assert signal.shape == signal_shape

--- a/tests/operators/models/test_t1_models.py
+++ b/tests/operators/models/test_t1_models.py
@@ -3,45 +3,7 @@ import torch
 from mrpro.operators.models import MOLLI
 from mrpro.operators.models import InversionRecovery
 from mrpro.operators.models import SaturationRecovery
-from tests import RandomGenerator
-
-SHAPE_VARIATIONS = pytest.mark.parametrize(
-    ('parameter_shape', 'ti_shape', 'signal_shape'),
-    [
-        ((1, 1, 10, 20, 30), (5), (5, 1, 1, 10, 20, 30)),  # single map with different inversion times
-        ((1, 1, 10, 20, 30), (5, 1), (5, 1, 1, 10, 20, 30)),
-        ((4, 1, 1, 10, 20, 30), (5, 1), (5, 4, 1, 1, 10, 20, 30)),  # multiple maps along additional batch dimension
-        ((4, 1, 1, 10, 20, 30), (5), (5, 4, 1, 1, 10, 20, 30)),
-        ((4, 1, 1, 10, 20, 30), (5, 4), (5, 4, 1, 1, 10, 20, 30)),
-        ((3, 1, 10, 20, 30), (5), (5, 3, 1, 10, 20, 30)),  # multiple maps along other dimension
-        ((3, 1, 10, 20, 30), (5, 1), (5, 3, 1, 10, 20, 30)),
-        ((3, 1, 10, 20, 30), (5, 3), (5, 3, 1, 10, 20, 30)),
-        ((4, 3, 1, 10, 20, 30), (5), (5, 4, 3, 1, 10, 20, 30)),  # multiple maps along other and batch dimension
-        ((4, 3, 1, 10, 20, 30), (5, 4), (5, 4, 3, 1, 10, 20, 30)),
-        ((4, 3, 1, 10, 20, 30), (5, 4, 1), (5, 4, 3, 1, 10, 20, 30)),
-        ((4, 3, 1, 10, 20, 30), (5, 1, 3), (5, 4, 3, 1, 10, 20, 30)),
-        ((4, 3, 1, 10, 20, 30), (5, 4, 3), (5, 4, 3, 1, 10, 20, 30)),
-        ((1,), (5), (5, 1)),  # single voxel
-        ((4, 3, 1), (5, 4, 3), (5, 4, 3, 1)),
-    ],
-)
-
-
-def create_parameter_tensors(data_shape=(10, 5, 100, 100, 100), number_of_tensors=2):
-    random_generator = RandomGenerator(seed=0)
-    parameter_tensors = random_generator.float32_tensor(size=(number_of_tensors, *data_shape), low=1e-10)
-    return torch.unbind(parameter_tensors)
-
-
-@SHAPE_VARIATIONS
-def test_saturation_recovery_shape(parameter_shape, ti_shape, signal_shape):
-    """Test correct signal shapes."""
-    random_generator = RandomGenerator(seed=0)
-    ti = random_generator.float32_tensor(size=ti_shape, low=0)
-    model = SaturationRecovery(ti)
-    m0, t1 = create_parameter_tensors(parameter_shape)
-    (signal,) = model.forward(m0, t1)
-    assert signal.shape == signal_shape
+from tests.operators.models.test_shape_all_models import create_parameter_tensors
 
 
 @pytest.mark.parametrize(
@@ -71,17 +33,6 @@ def test_saturation_recovery(ti, result):
         torch.testing.assert_close(image[0, ...], m0)
 
 
-@SHAPE_VARIATIONS
-def test_inversion_recovery_shape(parameter_shape, ti_shape, signal_shape):
-    """Test correct signal shapes."""
-    random_generator = RandomGenerator(seed=0)
-    ti = random_generator.float32_tensor(size=ti_shape, low=0)
-    model = InversionRecovery(ti)
-    m0, t1 = create_parameter_tensors(parameter_shape)
-    (signal,) = model.forward(m0, t1)
-    assert signal.shape == signal_shape
-
-
 @pytest.mark.parametrize(
     ('ti', 'result'),
     [
@@ -105,17 +56,6 @@ def test_inversion_recovery(ti, result):
     # Assert closeness to m0 for large ti
     elif result == 'm0':
         torch.testing.assert_close(image[0, ...], m0)
-
-
-@SHAPE_VARIATIONS
-def test_molli_shape(parameter_shape, ti_shape, signal_shape):
-    """Test correct signal shapes."""
-    random_generator = RandomGenerator(seed=0)
-    ti = random_generator.float32_tensor(size=ti_shape, low=0)
-    model = MOLLI(ti)
-    a, b, t1 = create_parameter_tensors(parameter_shape, number_of_tensors=3)
-    (signal,) = model.forward(a, b, t1)
-    assert signal.shape == signal_shape
 
 
 @pytest.mark.parametrize(

--- a/tests/operators/models/test_t1_models.py
+++ b/tests/operators/models/test_t1_models.py
@@ -45,32 +45,28 @@ def test_saturation_recovery_shape(parameter_shape, ti_shape, signal_shape):
 
 
 @pytest.mark.parametrize(
-    ('t', 'result'),
+    ('ti', 'result'),
     [
         (0, '0'),  # short ti
         (20, 'm0'),  # long ti
     ],
 )
-def test_saturation_recovery(t, result):
+def test_saturation_recovery(ti, result):
     """Test for saturation recovery.
 
-    Checking that idata output tensor at t=0 is close to 0. Checking
-    that idata output tensor at large t is close to m0.
+    Checking that idata output tensor at ti=0 is close to 0. Checking
+    that idata output tensor at large ti is close to m0.
     """
-    # Tensor of TI
-    ti = torch.tensor([t])
-
-    # Generate signal model and torch tensor for comparison
     model = SaturationRecovery(ti)
     m0, t1 = create_parameter_tensors()
     (image,) = model.forward(m0, t1)
 
     zeros = torch.zeros_like(m0)
 
-    # Assert closeness to zero for t=0
+    # Assert closeness to zero for ti=0
     if result == '0':
         torch.testing.assert_close(image[0, ...], zeros)
-    # Assert closeness to m0 for large t
+    # Assert closeness to m0 for large ti
     elif result == 'm0':
         torch.testing.assert_close(image[0, ...], m0)
 
@@ -87,31 +83,26 @@ def test_inversion_recovery_shape(parameter_shape, ti_shape, signal_shape):
 
 
 @pytest.mark.parametrize(
-    ('t', 'result'),
+    ('ti', 'result'),
     [
         (0, '-m0'),  # short ti
         (20, 'm0'),  # long ti
     ],
 )
-def test_inversion_recovery(t, result):
+def test_inversion_recovery(ti, result):
     """Test for inversion recovery.
 
-    Checking that idata output tensor at t=0 is close to -m0. Checking
-    that idata output tensor at large t is close to m0.
+    Checking that idata output tensor at ti=0 is close to -m0. Checking
+    that idata output tensor at large ti is close to m0.
     """
-
-    # Tensor of TI
-    ti = torch.tensor([t])
-
-    # Generate signal model and torch tensor for comparison
     model = InversionRecovery(ti)
     m0, t1 = create_parameter_tensors()
     (image,) = model.forward(m0, t1)
 
-    # Assert closeness to -m0 for t=0
+    # Assert closeness to -m0 for ti=0
     if result == '-m0':
         torch.testing.assert_close(image[0, ...], -m0)
-    # Assert closeness to m0 for large t
+    # Assert closeness to m0 for large ti
     elif result == 'm0':
         torch.testing.assert_close(image[0, ...], m0)
 
@@ -128,17 +119,17 @@ def test_molli_shape(parameter_shape, ti_shape, signal_shape):
 
 
 @pytest.mark.parametrize(
-    ('t', 'result'),
+    ('ti', 'result'),
     [
         (0, 'a-b'),  # short ti
         (20, 'a'),  # long ti
     ],
 )
-def test_molli(t, result):
+def test_molli(ti, result):
     """Test for MOLLI.
 
-    Checking that idata output tensor at t=0 is close to a. Checking
-    that idata output tensor at large t is close to a-b.
+    Checking that idata output tensor at ti=0 is close to a. Checking
+    that idata output tensor at large ti is close to a-b.
     """
     # Generate qdata tensor, not random as a<b is necessary for t1_star to be >= 0
     other, coils, z, y, x = 10, 5, 100, 100, 100
@@ -146,16 +137,13 @@ def test_molli(t, result):
     b = torch.ones((other, coils, z, y, x)) * 5
     t1 = torch.ones((other, coils, z, y, x)) * 2
 
-    # Tensor of TI
-    ti = torch.tensor([t])
-
     # Generate signal model and torch tensor for comparison
     model = MOLLI(ti)
     (image,) = model.forward(a, b, t1)
 
-    # Assert closeness to a-b for large t
+    # Assert closeness to a-b for large ti
     if result == 'a-b':
         torch.testing.assert_close(image[0, ...], a - b)
-    # Assert closeness to a for t=0
+    # Assert closeness to a for ti=0
     elif result == 'a':
         torch.testing.assert_close(image[0, ...], a)

--- a/tests/operators/models/test_t1_models.py
+++ b/tests/operators/models/test_t1_models.py
@@ -5,12 +5,43 @@ from mrpro.operators.models import InversionRecovery
 from mrpro.operators.models import SaturationRecovery
 from tests import RandomGenerator
 
+SHAPE_VARIATIONS = pytest.mark.parametrize(
+    ('parameter_shape', 'ti_shape', 'signal_shape'),
+    [
+        ((1, 1, 10, 20, 30), (5), (5, 1, 1, 10, 20, 30)),  # single map with different inversion times
+        ((1, 1, 10, 20, 30), (5, 1), (5, 1, 1, 10, 20, 30)),
+        ((4, 1, 1, 10, 20, 30), (5, 1), (5, 4, 1, 1, 10, 20, 30)),  # multiple maps along additional batch dimension
+        ((4, 1, 1, 10, 20, 30), (5), (5, 4, 1, 1, 10, 20, 30)),
+        ((4, 1, 1, 10, 20, 30), (5, 4), (5, 4, 1, 1, 10, 20, 30)),
+        ((3, 1, 10, 20, 30), (5), (5, 3, 1, 10, 20, 30)),  # multiple maps along other dimension
+        ((3, 1, 10, 20, 30), (5, 1), (5, 3, 1, 10, 20, 30)),
+        ((3, 1, 10, 20, 30), (5, 3), (5, 3, 1, 10, 20, 30)),
+        ((4, 3, 1, 10, 20, 30), (5), (5, 4, 3, 1, 10, 20, 30)),  # multiple maps along other and batch dimension
+        ((4, 3, 1, 10, 20, 30), (5, 4), (5, 4, 3, 1, 10, 20, 30)),
+        ((4, 3, 1, 10, 20, 30), (5, 4, 1), (5, 4, 3, 1, 10, 20, 30)),
+        ((4, 3, 1, 10, 20, 30), (5, 1, 3), (5, 4, 3, 1, 10, 20, 30)),
+        ((4, 3, 1, 10, 20, 30), (5, 4, 3), (5, 4, 3, 1, 10, 20, 30)),
+        ((1,), (5), (5, 1)),  # single voxel
+        ((4, 3, 1), (5, 4, 3), (5, 4, 3, 1)),
+    ],
+)
 
-def create_data(other=10, coils=5, z=100, y=100, x=100):
+
+def create_parameter_tensors(data_shape=(10, 5, 100, 100, 100), number_of_tensors=2):
     random_generator = RandomGenerator(seed=0)
-    m0 = random_generator.float32_tensor(size=(other, coils, z, y, x), low=1e-10)
-    t1 = random_generator.float32_tensor(size=(other, coils, z, y, x), low=1e-10)
-    return m0, t1
+    parameter_tensors = random_generator.float32_tensor(size=(number_of_tensors, *data_shape), low=1e-10)
+    return torch.unbind(parameter_tensors)
+
+
+@SHAPE_VARIATIONS
+def test_saturation_recovery_shape(parameter_shape, ti_shape, signal_shape):
+    """Test correct signal shapes."""
+    random_generator = RandomGenerator(seed=0)
+    ti = random_generator.float32_tensor(size=ti_shape, low=0)
+    model = SaturationRecovery(ti)
+    m0, t1 = create_parameter_tensors(parameter_shape)
+    (signal,) = model.forward(m0, t1)
+    assert signal.shape == signal_shape
 
 
 @pytest.mark.parametrize(
@@ -31,17 +62,28 @@ def test_saturation_recovery(t, result):
 
     # Generate signal model and torch tensor for comparison
     model = SaturationRecovery(ti)
-    m0, t1 = create_data()
+    m0, t1 = create_parameter_tensors()
     (image,) = model.forward(m0, t1)
 
     zeros = torch.zeros_like(m0)
 
     # Assert closeness to zero for t=0
     if result == '0':
-        torch.testing.assert_close(image, zeros)
+        torch.testing.assert_close(image[0, ...], zeros)
     # Assert closeness to m0 for large t
     elif result == 'm0':
-        torch.testing.assert_close(image, m0)
+        torch.testing.assert_close(image[0, ...], m0)
+
+
+@SHAPE_VARIATIONS
+def test_inversion_recovery_shape(parameter_shape, ti_shape, signal_shape):
+    """Test correct signal shapes."""
+    random_generator = RandomGenerator(seed=0)
+    ti = random_generator.float32_tensor(size=ti_shape, low=0)
+    model = InversionRecovery(ti)
+    m0, t1 = create_parameter_tensors(parameter_shape)
+    (signal,) = model.forward(m0, t1)
+    assert signal.shape == signal_shape
 
 
 @pytest.mark.parametrize(
@@ -63,15 +105,26 @@ def test_inversion_recovery(t, result):
 
     # Generate signal model and torch tensor for comparison
     model = InversionRecovery(ti)
-    m0, t1 = create_data()
+    m0, t1 = create_parameter_tensors()
     (image,) = model.forward(m0, t1)
 
     # Assert closeness to -m0 for t=0
     if result == '-m0':
-        torch.testing.assert_close(image, -m0)
+        torch.testing.assert_close(image[0, ...], -m0)
     # Assert closeness to m0 for large t
     elif result == 'm0':
-        torch.testing.assert_close(image, m0)
+        torch.testing.assert_close(image[0, ...], m0)
+
+
+@SHAPE_VARIATIONS
+def test_molli_shape(parameter_shape, ti_shape, signal_shape):
+    """Test correct signal shapes."""
+    random_generator = RandomGenerator(seed=0)
+    ti = random_generator.float32_tensor(size=ti_shape, low=0)
+    model = MOLLI(ti)
+    a, b, t1 = create_parameter_tensors(parameter_shape, number_of_tensors=3)
+    (signal,) = model.forward(a, b, t1)
+    assert signal.shape == signal_shape
 
 
 @pytest.mark.parametrize(
@@ -102,7 +155,7 @@ def test_molli(t, result):
 
     # Assert closeness to a-b for large t
     if result == 'a-b':
-        torch.testing.assert_close(image, a - b)
+        torch.testing.assert_close(image[0, ...], a - b)
     # Assert closeness to a for t=0
     elif result == 'a':
-        torch.testing.assert_close(image, a)
+        torch.testing.assert_close(image[0, ...], a)

--- a/tests/operators/models/test_wasabi.py
+++ b/tests/operators/models/test_wasabi.py
@@ -2,28 +2,18 @@ import torch
 from mrpro.operators.models import WASABI
 
 
-def create_data(offset_max=250, offset_nr=101, b0_shift_in=0, rb1=1.0, c=1.0, d=2.0):
-    offsets = torch.linspace(-offset_max, offset_max, offset_nr)
-    b0_shift = torch.zeros([1, 1, 1, 1, 1])
-    b0_shift[0] = b0_shift_in
-    rb1 = torch.Tensor([rb1])
-    c = torch.Tensor([c])
-    d = torch.Tensor([d])
-
-    return offsets, b0_shift, rb1, c, d
+def create_data(offset_max=500, n_offsets=101, b0_shift=0, rb1=1.0, c=1.0, d=2.0):
+    offsets = torch.linspace(-offset_max, offset_max, n_offsets)
+    return offsets, torch.Tensor([b0_shift]), torch.Tensor([rb1]), torch.Tensor([c]), torch.Tensor([d])
 
 
 def test_WASABI_shift():
     """Test symmetry property of shifted and unshifted WASABI spectra."""
-    offsets_unshifted, b0_shift_unshifted, rb1_unshifted, c_unshifted, d_unshifted = create_data(
-        offset_max=500,
-        offset_nr=100,
-        b0_shift_in=0,
-    )
+    offsets_unshifted, b0_shift, rb1, c, d = create_data()
     wasabi_model = WASABI(offsets=offsets_unshifted)
-    (signal,) = wasabi_model.forward(b0_shift_unshifted, rb1_unshifted, c_unshifted, d_unshifted)
+    (signal,) = wasabi_model.forward(b0_shift, rb1, c, d)
 
-    offsets_shifted, b0_shift, rb1, c, d = create_data(offset_max=500, offset_nr=101, b0_shift_in=100)
+    offsets_shifted, b0_shift, rb1, c, d = create_data(b0_shift=100)
     wasabi_model = WASABI(offsets=offsets_shifted)
     (signal_shifted,) = wasabi_model.forward(b0_shift, rb1, c, d)
 
@@ -35,7 +25,7 @@ def test_WASABI_shift():
 
 
 def test_WASABI_extreme_offset():
-    offset, b0_shift, rb1, c, d = create_data(offset_max=30000, offset_nr=1, b0_shift_in=0)
+    offset, b0_shift, rb1, c, d = create_data(offset_max=30000, n_offsets=1)
     wasabi_model = WASABI(offsets=offset)
     (signal,) = wasabi_model.forward(b0_shift, rb1, c, d)
 

--- a/tests/operators/models/test_wasabi.py
+++ b/tests/operators/models/test_wasabi.py
@@ -1,4 +1,3 @@
-import pytest
 import torch
 from mrpro.operators.models import WASABI
 
@@ -12,23 +11,6 @@ def create_data(offset_max=250, offset_nr=101, b0_shift_in=0, rb1=1.0, c=1.0, d=
     d = torch.Tensor([d])
 
     return offsets, b0_shift, rb1, c, d
-
-
-@pytest.mark.parametrize(
-    ('offset_max', 'offset_nr', 'b0_shift', 'rb1', 'c', 'd', 'coils', 'z', 'y', 'x'),
-    [
-        (250, 101, 0, 1.0, 1.0, 2.0, 1, 1, 1, 1),
-        (200, 101, 0, 0, 1.0, 2.0, 1, 1, 1, 1),
-        (10, 101, 10, 10, 1.0, 2.0, 1, 1, 1, 1),
-    ],
-)
-def test_WASABI_signal_model_shape(offset_max, offset_nr, b0_shift, rb1, c, d, coils, z, y, x):
-    """Test for correct output shape."""
-    offsets, b0_shift, rb1, c, d = create_data(offset_max, offset_nr, b0_shift, rb1, c, d)
-    wasabi_model = WASABI(offsets=offsets)
-    (signal,) = wasabi_model.forward(b0_shift, rb1, c, d)
-
-    assert signal.shape == (offset_nr, coils, z, y, x)
 
 
 def test_WASABI_shift():

--- a/tests/operators/models/test_wasabiti.py
+++ b/tests/operators/models/test_wasabiti.py
@@ -3,24 +3,20 @@ import torch
 from mrpro.operators.models import WASABITI
 
 
-def create_data(offset_max=250, offset_nr=101, b0_shift_in=0, rb1=1.0, t1=1.0):
-    offsets = torch.linspace(-offset_max, offset_max, offset_nr)
-    b0_shift = torch.zeros([1, 1, 1, 1, 1])
-    b0_shift[0] = b0_shift_in
-    rb1 = torch.Tensor([rb1])
-    t1 = torch.Tensor([t1])
-
-    return offsets, b0_shift, rb1, t1
+def create_data(offset_max=500, n_offsets=101, b0_shift=0, rb1=1.0, t1=1.0):
+    offsets = torch.linspace(-offset_max, offset_max, n_offsets)
+    return offsets, torch.Tensor([b0_shift]), torch.Tensor([rb1]), torch.Tensor([t1])
 
 
 def test_WASABITI_shift_and_symmetry():
     """Test symmetry property of shifted and unshifted WASABITI spectra."""
-    offsets_unshifted, b0_shift, rb1, t1 = create_data(offset_max=500, offset_nr=100, b0_shift_in=0)
+    offsets_unshifted, b0_shift, rb1, t1 = create_data()
+    # note that the symmetry is only guaranteed for identical trec values
     trec = torch.ones_like(offsets_unshifted)
     wasabiti_model = WASABITI(offsets=offsets_unshifted, trec=trec)
     (signal,) = wasabiti_model.forward(b0_shift, rb1, t1)
 
-    offsets_shifted, b0_shift, rb1, t1 = create_data(offset_max=500, offset_nr=101, b0_shift_in=100)
+    offsets_shifted, b0_shift, rb1, t1 = create_data(b0_shift=100)
     trec = torch.ones_like(offsets_shifted)
     wasabiti_model = WASABITI(offsets=offsets_shifted, trec=trec)
     (signal_shifted,) = wasabiti_model.forward(b0_shift, rb1, t1)
@@ -35,10 +31,9 @@ def test_WASABITI_shift_and_symmetry():
 @pytest.mark.parametrize('t1', [(1), (2), (3)])
 def test_WASABITI_relaxation_term(t1):
     """Test relaxation term (Mzi) of WASABITI model."""
-    _, b0_shift, rb1, t1 = create_data(offset_max=300, offset_nr=3, b0_shift_in=0, t1=t1)
-    offsets_new = torch.FloatTensor([30000])
-    trec = torch.ones_like(offsets_new) * t1
-    wasabiti_model = WASABITI(offsets=offsets_new, trec=trec)
+    offset, b0_shift, rb1, t1 = create_data(offset_max=50000, n_offsets=1, t1=t1)
+    trec = torch.ones_like(offset) * t1
+    wasabiti_model = WASABITI(offsets=offset, trec=trec)
     sig = wasabiti_model.forward(b0_shift, rb1, t1)
 
     assert torch.isclose(sig[0], torch.FloatTensor([1 - torch.exp(torch.FloatTensor([-1]))]), rtol=1e-8)


### PR DESCRIPTION
Modifies the signal models for T1 mapping and wasabi, such that leading dimensions before the 'other' dimension are considered as batch dimension and not flattened.
Wasabiti is a todo.
Also removes some edgecases from molli resulting in nan-gradients, should result in same signal (needs to be checked)