### PR TITLE
shape for all models verified

### DIFF
--- a/src/mrpro/operators/models/_WASABITI.py
+++ b/src/mrpro/operators/models/_WASABITI.py
@@ -95,7 +95,7 @@ class WASABITI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
 
         b1 = self.b1_nom * rb1
         da = offsets - b0_shift
-        mz_initial = 1.0 - torch.exp(torch.multiply(-1.0 / t1, trec))
+        mz_initial = 1.0 - torch.exp(-trec / t1)
 
         signal = mz_initial * (
             1

--- a/src/mrpro/operators/models/_WASABITI.py
+++ b/src/mrpro/operators/models/_WASABITI.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import torch
-from einops import rearrange
 from torch import nn
 
 from mrpro.operators import SignalModel
@@ -39,8 +38,10 @@ class WASABITI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
         ----------
         offsets
             frequency offsets [Hz]
+            with shape (offsets, ...)
         trec
             recovery time between offsets [s]
+            with shape (offsets, ...)
         tp
             RF pulse duration [s], by default 0.005
         b1_nom
@@ -57,6 +58,9 @@ class WASABITI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
         gamma = torch.as_tensor(gamma)
         freq = torch.as_tensor(freq)
 
+        if trec.shape != offsets.shape:
+            raise ValueError(f'Shape of trec ({trec.shape}) and offsets ({offsets.shape}) needs to be the same.')
+
         # nn.Parameters allow for grad calculation
         self.offsets = nn.Parameter(offsets, requires_grad=offsets.requires_grad)
         self.trec = nn.Parameter(trec, requires_grad=trec.requires_grad)
@@ -72,21 +76,24 @@ class WASABITI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
         ----------
         b0_shift
             B0 shift [Hz]
+            with shape (... other, coils, z, y, x)
         rb1
             relative B1 amplitude
+            with shape (... other, coils, z, y, x)
         t1
             longitudinal relaxation time T1 [s]
+            with shape (... other, coils, z, y, x)
 
         Returns
         -------
-            signal with dimensions ((... offsets), coils, z, y, x)
+            signal
+            with shape (offsets ... other, coils, z, y, x)
         """
+        delta_ndim = b0_shift.ndim - (self.offsets.ndim - 1)  # -1 for offset
+        offsets = self.offsets[..., *[None] * (delta_ndim)] if delta_ndim > 0 else self.offsets
+        trec = self.trec[..., *[None] * (delta_ndim)] if delta_ndim > 0 else self.trec
+
         b1 = self.b1_nom * rb1
-
-        # ensure correct dimensionality
-        offsets = self.offsets[(...,) + (None,) * b0_shift.ndim]
-        trec = self.trec[(...,) + (None,) * b0_shift.ndim]
-
         da = offsets - b0_shift
         mz_initial = 1.0 - torch.exp(torch.multiply(-1.0 / t1, trec))
 
@@ -96,6 +103,4 @@ class WASABITI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
             * (torch.pi * b1 * self.gamma * self.tp) ** 2
             * torch.sinc(self.tp * torch.sqrt((b1 * self.gamma) ** 2 + da**2)) ** 2
         )
-
-        signal = rearrange(signal, 'offset ... c z y x -> (... offset) c z y x')
         return (signal,)

--- a/tests/operators/models/test_shape_all_models.py
+++ b/tests/operators/models/test_shape_all_models.py
@@ -9,8 +9,9 @@ from mrpro.operators.models import InversionRecovery
 from mrpro.operators.models import SaturationRecovery
 from tests import RandomGenerator
 
-# Signal model, number of input tensors and number of contrast parameters (e.g. inversion time or CEST offsets)
-MODELS_AND_NUM_INPUT_PARAMETERS = [
+# Signal model, number of tensor arguments in forward (i.e. quantitative parameters) , number of tensor arguments
+# in init (e.g. inversion time or CEST offsets)
+MODELS_AND_N_INPUT_PARAMETERS = [
     (MOLLI, 3, 1),
     (InversionRecovery, 2, 1),
     (SaturationRecovery, 2, 1),
@@ -39,10 +40,10 @@ SHAPE_VARIATIONS_SIGNAL_MODELS = [
 
 # Combine models and shapes
 SHAPE_TESTS = pytest.mark.parametrize(
-    ('model', 'num_input_tensors', 'num_init_parameters', 'parameter_shape', 'contrast_dim_shape', 'signal_shape'),
+    ('model', 'n_input_tensors', 'n_init_parameters', 'parameter_shape', 'contrast_dim_shape', 'signal_shape'),
     [
         (*model_shape[0], *model_shape[1])
-        for model_shape in product(MODELS_AND_NUM_INPUT_PARAMETERS, SHAPE_VARIATIONS_SIGNAL_MODELS)
+        for model_shape in product(MODELS_AND_N_INPUT_PARAMETERS, SHAPE_VARIATIONS_SIGNAL_MODELS)
     ],
 )
 
@@ -55,10 +56,10 @@ def create_parameter_tensors(parameter_shape=(10, 5, 100, 100, 100), number_of_t
 
 
 @SHAPE_TESTS
-def test_model_shape(model, num_input_tensors, num_init_parameters, parameter_shape, contrast_dim_shape, signal_shape):
+def test_model_shape(model, n_input_tensors, n_init_parameters, parameter_shape, contrast_dim_shape, signal_shape):
     """Test correct signal shapes."""
-    input_parameters = create_parameter_tensors(contrast_dim_shape, number_of_tensors=num_init_parameters)
+    input_parameters = create_parameter_tensors(contrast_dim_shape, number_of_tensors=n_init_parameters)
     model_op = model(*input_parameters)
-    parameter_tensors = create_parameter_tensors(parameter_shape, number_of_tensors=num_input_tensors)
+    parameter_tensors = create_parameter_tensors(parameter_shape, number_of_tensors=n_input_tensors)
     (signal,) = model_op.forward(*parameter_tensors)
     assert signal.shape == signal_shape

--- a/tests/operators/models/test_shape_all_models.py
+++ b/tests/operators/models/test_shape_all_models.py
@@ -9,7 +9,7 @@ from mrpro.operators.models import InversionRecovery
 from mrpro.operators.models import SaturationRecovery
 from tests import RandomGenerator
 
-# Signal model, number of tensor arguments in forward (i.e. quantitative parameters) , number of tensor arguments
+# Signal model, number of tensor arguments in forward (i.e. quantitative parameters) and number of tensor arguments
 # in init (e.g. inversion time or CEST offsets)
 MODELS_AND_N_INPUT_PARAMETERS = [
     (MOLLI, 3, 1),

--- a/tests/operators/models/test_shape_all_models.py
+++ b/tests/operators/models/test_shape_all_models.py
@@ -1,0 +1,64 @@
+from itertools import product
+
+import pytest
+import torch
+from mrpro.operators.models import MOLLI
+from mrpro.operators.models import WASABI
+from mrpro.operators.models import WASABITI
+from mrpro.operators.models import InversionRecovery
+from mrpro.operators.models import SaturationRecovery
+from tests import RandomGenerator
+
+# Signal model, number of input tensors and number of contrast parameters (e.g. inversion time or CEST offsets)
+MODELS_AND_NUM_INPUT_PARAMETERS = [
+    (MOLLI, 3, 1),
+    (InversionRecovery, 2, 1),
+    (SaturationRecovery, 2, 1),
+    (WASABI, 4, 1),
+    (WASABITI, 3, 2),
+]
+
+# Shape combinations
+SHAPE_VARIATIONS_SIGNAL_MODELS = [
+    ((1, 1, 10, 20, 30), (5,), (5, 1, 1, 10, 20, 30)),  # single map with different inversion times
+    ((1, 1, 10, 20, 30), (5, 1), (5, 1, 1, 10, 20, 30)),
+    ((4, 1, 1, 10, 20, 30), (5, 1), (5, 4, 1, 1, 10, 20, 30)),  # multiple maps along additional batch dimension
+    ((4, 1, 1, 10, 20, 30), (5,), (5, 4, 1, 1, 10, 20, 30)),
+    ((4, 1, 1, 10, 20, 30), (5, 4), (5, 4, 1, 1, 10, 20, 30)),
+    ((3, 1, 10, 20, 30), (5,), (5, 3, 1, 10, 20, 30)),  # multiple maps along other dimension
+    ((3, 1, 10, 20, 30), (5, 1), (5, 3, 1, 10, 20, 30)),
+    ((3, 1, 10, 20, 30), (5, 3), (5, 3, 1, 10, 20, 30)),
+    ((4, 3, 1, 10, 20, 30), (5,), (5, 4, 3, 1, 10, 20, 30)),  # multiple maps along other and batch dimension
+    ((4, 3, 1, 10, 20, 30), (5, 4), (5, 4, 3, 1, 10, 20, 30)),
+    ((4, 3, 1, 10, 20, 30), (5, 4, 1), (5, 4, 3, 1, 10, 20, 30)),
+    ((4, 3, 1, 10, 20, 30), (5, 1, 3), (5, 4, 3, 1, 10, 20, 30)),
+    ((4, 3, 1, 10, 20, 30), (5, 4, 3), (5, 4, 3, 1, 10, 20, 30)),
+    ((1,), (5,), (5, 1)),  # single voxel
+    ((4, 3, 1), (5, 4, 3), (5, 4, 3, 1)),
+]
+
+# Combine models and shapes
+SHAPE_TESTS = pytest.mark.parametrize(
+    ('model', 'num_input_tensors', 'num_init_parameters', 'parameter_shape', 'contrast_dim_shape', 'signal_shape'),
+    [
+        (*model_shape[0], *model_shape[1])
+        for model_shape in product(MODELS_AND_NUM_INPUT_PARAMETERS, SHAPE_VARIATIONS_SIGNAL_MODELS)
+    ],
+)
+
+
+def create_parameter_tensors(parameter_shape=(10, 5, 100, 100, 100), number_of_tensors=2):
+    """Create list of tensors as input to signal models."""
+    random_generator = RandomGenerator(seed=0)
+    parameter_tensors = random_generator.float32_tensor(size=(number_of_tensors, *parameter_shape), low=1e-10)
+    return torch.unbind(parameter_tensors)
+
+
+@SHAPE_TESTS
+def test_model_shape(model, num_input_tensors, num_init_parameters, parameter_shape, contrast_dim_shape, signal_shape):
+    """Test correct signal shapes."""
+    input_parameters = create_parameter_tensors(contrast_dim_shape, number_of_tensors=num_init_parameters)
+    model_op = model(*input_parameters)
+    parameter_tensors = create_parameter_tensors(parameter_shape, number_of_tensors=num_input_tensors)
+    (signal,) = model_op.forward(*parameter_tensors)
+    assert signal.shape == signal_shape

--- a/tests/operators/models/test_t1_models.py
+++ b/tests/operators/models/test_t1_models.py
@@ -3,45 +3,7 @@ import torch
 from mrpro.operators.models import MOLLI
 from mrpro.operators.models import InversionRecovery
 from mrpro.operators.models import SaturationRecovery
-from tests import RandomGenerator
-
-SHAPE_VARIATIONS = pytest.mark.parametrize(
-    ('parameter_shape', 'ti_shape', 'signal_shape'),
-    [
-        ((1, 1, 10, 20, 30), (5), (5, 1, 1, 10, 20, 30)),  # single map with different inversion times
-        ((1, 1, 10, 20, 30), (5, 1), (5, 1, 1, 10, 20, 30)),
-        ((4, 1, 1, 10, 20, 30), (5, 1), (5, 4, 1, 1, 10, 20, 30)),  # multiple maps along additional batch dimension
-        ((4, 1, 1, 10, 20, 30), (5), (5, 4, 1, 1, 10, 20, 30)),
-        ((4, 1, 1, 10, 20, 30), (5, 4), (5, 4, 1, 1, 10, 20, 30)),
-        ((3, 1, 10, 20, 30), (5), (5, 3, 1, 10, 20, 30)),  # multiple maps along other dimension
-        ((3, 1, 10, 20, 30), (5, 1), (5, 3, 1, 10, 20, 30)),
-        ((3, 1, 10, 20, 30), (5, 3), (5, 3, 1, 10, 20, 30)),
-        ((4, 3, 1, 10, 20, 30), (5), (5, 4, 3, 1, 10, 20, 30)),  # multiple maps along other and batch dimension
-        ((4, 3, 1, 10, 20, 30), (5, 4), (5, 4, 3, 1, 10, 20, 30)),
-        ((4, 3, 1, 10, 20, 30), (5, 4, 1), (5, 4, 3, 1, 10, 20, 30)),
-        ((4, 3, 1, 10, 20, 30), (5, 1, 3), (5, 4, 3, 1, 10, 20, 30)),
-        ((4, 3, 1, 10, 20, 30), (5, 4, 3), (5, 4, 3, 1, 10, 20, 30)),
-        ((1,), (5), (5, 1)),  # single voxel
-        ((4, 3, 1), (5, 4, 3), (5, 4, 3, 1)),
-    ],
-)
-
-
-def create_parameter_tensors(data_shape=(10, 5, 100, 100, 100), number_of_tensors=2):
-    random_generator = RandomGenerator(seed=0)
-    parameter_tensors = random_generator.float32_tensor(size=(number_of_tensors, *data_shape), low=1e-10)
-    return torch.unbind(parameter_tensors)
-
-
-@SHAPE_VARIATIONS
-def test_saturation_recovery_shape(parameter_shape, ti_shape, signal_shape):
-    """Test correct signal shapes."""
-    random_generator = RandomGenerator(seed=0)
-    ti = random_generator.float32_tensor(size=ti_shape, low=0)
-    model = SaturationRecovery(ti)
-    m0, t1 = create_parameter_tensors(parameter_shape)
-    (signal,) = model.forward(m0, t1)
-    assert signal.shape == signal_shape
+from tests.operators.models.test_shape_all_models import create_parameter_tensors
 
 
 @pytest.mark.parametrize(
@@ -71,17 +33,6 @@ def test_saturation_recovery(ti, result):
         torch.testing.assert_close(image[0, ...], m0)
 
 
-@SHAPE_VARIATIONS
-def test_inversion_recovery_shape(parameter_shape, ti_shape, signal_shape):
-    """Test correct signal shapes."""
-    random_generator = RandomGenerator(seed=0)
-    ti = random_generator.float32_tensor(size=ti_shape, low=0)
-    model = InversionRecovery(ti)
-    m0, t1 = create_parameter_tensors(parameter_shape)
-    (signal,) = model.forward(m0, t1)
-    assert signal.shape == signal_shape
-
-
 @pytest.mark.parametrize(
     ('ti', 'result'),
     [
@@ -105,17 +56,6 @@ def test_inversion_recovery(ti, result):
     # Assert closeness to m0 for large ti
     elif result == 'm0':
         torch.testing.assert_close(image[0, ...], m0)
-
-
-@SHAPE_VARIATIONS
-def test_molli_shape(parameter_shape, ti_shape, signal_shape):
-    """Test correct signal shapes."""
-    random_generator = RandomGenerator(seed=0)
-    ti = random_generator.float32_tensor(size=ti_shape, low=0)
-    model = MOLLI(ti)
-    a, b, t1 = create_parameter_tensors(parameter_shape, number_of_tensors=3)
-    (signal,) = model.forward(a, b, t1)
-    assert signal.shape == signal_shape
 
 
 @pytest.mark.parametrize(

--- a/tests/operators/models/test_wasabi.py
+++ b/tests/operators/models/test_wasabi.py
@@ -1,4 +1,3 @@
-import pytest
 import torch
 from mrpro.operators.models import WASABI
 
@@ -12,23 +11,6 @@ def create_data(offset_max=250, offset_nr=101, b0_shift_in=0, rb1=1.0, c=1.0, d=
     d = torch.Tensor([d])
 
     return offsets, b0_shift, rb1, c, d
-
-
-@pytest.mark.parametrize(
-    ('offset_max', 'offset_nr', 'b0_shift', 'rb1', 'c', 'd', 'coils', 'z', 'y', 'x'),
-    [
-        (250, 101, 0, 1.0, 1.0, 2.0, 1, 1, 1, 1),
-        (200, 101, 0, 0, 1.0, 2.0, 1, 1, 1, 1),
-        (10, 101, 10, 10, 1.0, 2.0, 1, 1, 1, 1),
-    ],
-)
-def test_WASABI_signal_model_shape(offset_max, offset_nr, b0_shift, rb1, c, d, coils, z, y, x):
-    """Test for correct output shape."""
-    offsets, b0_shift, rb1, c, d = create_data(offset_max, offset_nr, b0_shift, rb1, c, d)
-    wasabi_model = WASABI(offsets=offsets)
-    (signal,) = wasabi_model.forward(b0_shift, rb1, c, d)
-
-    assert signal.shape == (offset_nr, coils, z, y, x)
 
 
 def test_WASABI_shift():


### PR DESCRIPTION
Wasabi and Wasabiti now also compatible with new signal model dimensions.

I need help with the variable names here: https://github.com/PTB-MR/mrpro/blob/f8b056248c6705817e0daf81f37eda3199d10511/tests/operators/models/test_shape_all_models.py#L13

The first is the model name (easy), the second is the number of input tensors of `forward` and the third number is the number of tensors required for the `init`. Any good suggestions of how to name them?