### PR TITLE
Detection tolerance for KTrajectoryPulseq

### DIFF
--- a/src/mrpro/data/_KTrajectory.py
+++ b/src/mrpro/data/_KTrajectory.py
@@ -25,7 +25,7 @@ from mrpro.data.enums import TrajType
 from mrpro.utils import remove_repeat
 
 
-@dataclass(slots=True, init=False, frozen=True)
+@dataclass(slots=True, frozen=True)
 class KTrajectory:
     """K-space trajectory.
 
@@ -39,122 +39,31 @@ class KTrajectory:
     """
 
     kz: torch.Tensor
-    """(other,k2,k1,k0), phase encoding direction k2 if Cartesian."""
+    """Trajectory in z direction / phase encoding direction k2 if Cartesian. Shape (other,k2,k1,k0)"""
 
     ky: torch.Tensor
-    """(other,k2,k1,k0), phase encoding direction k1 if Cartesian."""
+    """Trajectory in y direction / phase encoding direction k1 if Cartesian. Shape (other,k2,k1,k0)"""
 
     kx: torch.Tensor
-    """(other,k2,k1,k0), frequency encoding direction k0 if Cartesian."""
+    """Trajectory in x direction / phase encoding direction k0 if Cartesian. Shape (other,k2,k1,k0)"""
 
     grid_detection_tolerance: float = 1e-3
     """tolerance of how close trajectory positions have to be to integer grid points."""
 
-    @property
-    def broadcasted_shape(self) -> tuple[int, ...]:
-        """The broadcasted shape of the trajectory.
+    repeat_detection_tolerance: float | None = 1e-3
+    """tolerance for repeat detection, by default 1e-3. Set None to disable."""
 
-        Returns
-        -------
-            broadcasted shape of trajectory
-        """
-        shape = np.broadcast_shapes(self.kx.shape, self.ky.shape, self.kz.shape)
-        return tuple(shape)
+    def __post_init__(self) -> None:
+        """Reduce repeated dimensions to singletons."""
+        if self.repeat_detection_tolerance is not None:
+            kz, ky, kx = (
+                remove_repeat(tensor, self.repeat_detection_tolerance) for tensor in (self.kz, self.ky, self.kx)
+            )
 
-    def _traj_types(
-        self,
-        tolerance: float,
-    ) -> tuple[tuple[TrajType, TrajType, TrajType], tuple[TrajType, TrajType, TrajType]]:
-        """Calculate the trajectory type along kzkykx and k2k1k0.
-
-        Checks if the entries of the trajectory along certain dimensions
-            - are of shape 1 -> TrajType.SINGLEVALUE
-            - lie on a Cartesian grid -> TrajType.ONGRID
-
-        Parameters
-        ----------
-        tolerance:
-            absolute tolerance in checking if points are on integer grid positions
-
-        Returns
-        -------
-            ((types along kz,ky,kx),(types along k2,k1,k0))
-
-        # TODO: consider non-integer positions that are on a grid, e.g. (0.5, 1, 1.5, ....)
-        """
-        # Matrix describing trajectory-type [(kz, ky, kx), (k2, k1, k0)]
-        # Start with everything not on a grid (arbitrary k-space locations).
-        # We use the value of the enum-type to make it easier to do array operations.
-        traj_type_matrix = torch.zeros(3, 3, dtype=torch.int)
-        for ind, ks in enumerate((self.kz, self.ky, self.kx)):
-            values_on_grid = not ks.is_floating_point() or torch.all(ks.frac() <= tolerance)
-            for dim in (-3, -2, -1):
-                if ks.shape[dim] == 1:
-                    traj_type_matrix[ind, dim] |= TrajType.SINGLEVALUE.value | TrajType.ONGRID.value
-                if values_on_grid:
-                    traj_type_matrix[ind, dim] |= TrajType.ONGRID.value
-
-        # kz should only have flags that are enabled in all columns
-        # k2 only flags enabled in all rows, etc
-        type_zyx = [TrajType(i.item()) for i in np.bitwise_and.reduce(traj_type_matrix, axis=1)]
-        type_210 = [TrajType(i.item()) for i in np.bitwise_and.reduce(traj_type_matrix, axis=0)]
-
-        # make mypy recognize return  will always have len=3
-        return (type_zyx[0], type_zyx[1], type_zyx[2]), (type_210[0], type_210[1], type_210[2])
-
-    @property
-    def type_along_kzyx(self) -> tuple[TrajType, TrajType, TrajType]:
-        """Type of trajectory along kz-ky-kx."""
-        return self._traj_types(self.grid_detection_tolerance)[0]
-
-    @property
-    def type_along_k210(self) -> tuple[TrajType, TrajType, TrajType]:
-        """Type of trajectory along k2-k1-k0."""
-        return self._traj_types(self.grid_detection_tolerance)[1]
-
-    def as_tensor(self, stack_dim: int = 0) -> torch.Tensor:
-        """Tensor representation of the trajectory.
-
-        Parameters
-        ----------
-        stack_dim
-            The dimension to stack the tensor along.
-        """
-        shape = self.broadcasted_shape
-        return torch.stack([traj.expand(*shape) for traj in (self.kz, self.ky, self.kx)], dim=stack_dim)
-
-    def __init__(
-        self,
-        kz: torch.Tensor,
-        ky: torch.Tensor,
-        kx: torch.Tensor,
-        repeat_detection_tolerance: float | None = 1e-8,
-        grid_detection_tolerance: float = 1e-3,
-    ) -> None:
-        """K-Space Trajectory dataclass.
-
-        Reduces repeated dimensions to singletons if repeat_detection_tolerance
-        is not set to None.
-
-        Parameters
-        ----------
-        kz, ky, kx
-            trajectory coordinates to set
-        repeat_detection_tolerance
-            Tolerance for repeat detection. Set to None to disable.
-        grid_detection_tolerance
-            tolerance to detect if trajectory points are on integer grid positions
-        """
-        if repeat_detection_tolerance is not None:
-            kz, ky, kx = (remove_repeat(tensor, repeat_detection_tolerance) for tensor in (kz, ky, kx))
-
-        # use of setattr due to frozen dataclass
-        object.__setattr__(self, 'kz', kz)
-        object.__setattr__(self, 'ky', ky)
-        object.__setattr__(self, 'kx', kx)
-
-        # use of setattr due to frozen dataclass
-        object.__setattr__(self, 'grid_detection_tolerance', grid_detection_tolerance)
+            # use of setattr due to frozen dataclass
+            object.__setattr__(self, 'kz', kz)
+            object.__setattr__(self, 'ky', ky)
+            object.__setattr__(self, 'kx', kx)
 
         try:
             shape = self.broadcasted_shape
@@ -199,6 +108,79 @@ class KTrajectory:
             repeat_detection_tolerance=repeat_detection_tolerance,
             grid_detection_tolerance=grid_detection_tolerance,
         )
+
+    @property
+    def broadcasted_shape(self) -> tuple[int, ...]:
+        """The broadcasted shape of the trajectory.
+
+        Returns
+        -------
+            broadcasted shape of trajectory
+        """
+        shape = np.broadcast_shapes(self.kx.shape, self.ky.shape, self.kz.shape)
+        return tuple(shape)
+
+    @property
+    def type_along_kzyx(self) -> tuple[TrajType, TrajType, TrajType]:
+        """Type of trajectory along kz-ky-kx."""
+        return self._traj_types(self.grid_detection_tolerance)[0]
+
+    @property
+    def type_along_k210(self) -> tuple[TrajType, TrajType, TrajType]:
+        """Type of trajectory along k2-k1-k0."""
+        return self._traj_types(self.grid_detection_tolerance)[1]
+
+    def _traj_types(
+        self,
+        tolerance: float,
+    ) -> tuple[tuple[TrajType, TrajType, TrajType], tuple[TrajType, TrajType, TrajType]]:
+        """Calculate the trajectory type along kzkykx and k2k1k0.
+
+        Checks if the entries of the trajectory along certain dimensions
+            - are of shape 1 -> TrajType.SINGLEVALUE
+            - lie on a Cartesian grid -> TrajType.ONGRID
+
+        Parameters
+        ----------
+        tolerance:
+            absolute tolerance in checking if points are on integer grid positions
+
+        Returns
+        -------
+            ((types along kz,ky,kx),(types along k2,k1,k0))
+
+        # TODO: consider non-integer positions that are on a grid, e.g. (0.5, 1, 1.5, ....)
+        """
+        # Matrix describing trajectory-type [(kz, ky, kx), (k2, k1, k0)]
+        # Start with everything not on a grid (arbitrary k-space locations).
+        # We use the value of the enum-type to make it easier to do array operations.
+        traj_type_matrix = torch.zeros(3, 3, dtype=torch.int)
+        for ind, ks in enumerate((self.kz, self.ky, self.kx)):
+            values_on_grid = not ks.is_floating_point() or torch.all(ks.frac() <= tolerance)
+            for dim in (-3, -2, -1):
+                if ks.shape[dim] == 1:
+                    traj_type_matrix[ind, dim] |= TrajType.SINGLEVALUE.value | TrajType.ONGRID.value
+                if values_on_grid:
+                    traj_type_matrix[ind, dim] |= TrajType.ONGRID.value
+
+        # kz should only have flags that are enabled in all columns
+        # k2 only flags enabled in all rows, etc
+        type_zyx = [TrajType(i.item()) for i in np.bitwise_and.reduce(traj_type_matrix, axis=1)]
+        type_210 = [TrajType(i.item()) for i in np.bitwise_and.reduce(traj_type_matrix, axis=0)]
+
+        # make mypy recognize return  will always have len=3
+        return (type_zyx[0], type_zyx[1], type_zyx[2]), (type_210[0], type_210[1], type_210[2])
+
+    def as_tensor(self, stack_dim: int = 0) -> torch.Tensor:
+        """Tensor representation of the trajectory.
+
+        Parameters
+        ----------
+        stack_dim
+            The dimension to stack the tensor along.
+        """
+        shape = self.broadcasted_shape
+        return torch.stack([traj.expand(*shape) for traj in (self.kz, self.ky, self.kx)], dim=stack_dim)
 
     def to(self, *args, **kwargs) -> KTrajectory:
         """Perform dtype and/or device conversion of trajectory.

--- a/src/mrpro/data/_KTrajectory.py
+++ b/src/mrpro/data/_KTrajectory.py
@@ -47,8 +47,8 @@ class KTrajectory:
     kx: torch.Tensor
     """(other,k2,k1,k0), frequency encoding direction k0 if Cartesian."""
 
-    # Tolerance of how close trajectory positions have to be to integer grid points
-    grid_detection_tolerance: float
+    grid_detection_tolerance: float = 1e-3
+    """tolerance of how close trajectory positions have to be to integer grid points."""
 
     @property
     def broadcasted_shape(self) -> tuple[int, ...]:

--- a/src/mrpro/data/_KTrajectoryRawShape.py
+++ b/src/mrpro/data/_KTrajectoryRawShape.py
@@ -44,8 +44,8 @@ class KTrajectoryRawShape:
     kx: torch.Tensor
     """(other,k2,k1,k0), frequency encoding direction k0 if Cartesian."""
 
-    repeat_detection_tolerance: float = 1e-3
-    """tolerance for repeat detection which is used in reshape()."""
+    repeat_detection_tolerance: None | float = 1e-3
+    """tolerance for repeat detection, by default 1e-3, None to disable."""
 
     def reshape(
         self,
@@ -75,4 +75,4 @@ class KTrajectoryRawShape:
         ky = rearrange(self.ky[sort_idx, ...], '(other k2 k1) k0 -> other k2 k1 k0', k1=n_k1, k2=n_k2)
         kx = rearrange(self.kx[sort_idx, ...], '(other k2 k1) k0 -> other k2 k1 k0', k1=n_k1, k2=n_k2)
 
-        return KTrajectory(kz, ky, kx, self.repeat_detection_tolerance)
+        return KTrajectory(kz, ky, kx, repeat_detection_tolerance=self.repeat_detection_tolerance)

--- a/src/mrpro/data/_KTrajectoryRawShape.py
+++ b/src/mrpro/data/_KTrajectoryRawShape.py
@@ -35,16 +35,23 @@ class KTrajectoryRawShape:
     raw data file.
     """
 
-    kz: torch.Tensor  # ((other,k2,k1),k0) #phase encoding direction, k2 if Cartesian
-    ky: torch.Tensor  # ((other,k2,k1),k0) #phase encoding direction, k1 if Cartesian
-    kx: torch.Tensor  # ((other,k2,k1),k0) #frequency encoding direction, k0 if Cartesian
+    kz: torch.Tensor
+    """(other,k2,k1,k0), phase encoding direction k2 if Cartesian."""
+
+    ky: torch.Tensor
+    """(other,k2,k1,k0), phase encoding direction k1 if Cartesian."""
+
+    kx: torch.Tensor
+    """(other,k2,k1,k0), frequency encoding direction k0 if Cartesian."""
+
+    repeat_detection_tolerance: float = 1e-3
+    """tolerance for repeat detection which is used in reshape()."""
 
     def reshape(
         self,
         sort_idx: np.ndarray,
         n_k2: int,
         n_k1: int,
-        repeat_detection_tolerance: float | None = 1e-8,
     ) -> KTrajectory:
         """Resort and reshape the raw trajectory to KTrajectory.
 
@@ -58,8 +65,6 @@ class KTrajectoryRawShape:
             number of k2 points.
         n_k1
             number of k1 points.
-        repeat_detection_tolerance:
-            tolerance for repeat detection which is passed on to create KTrajectory. Set to None to disable.
 
         Returns
         -------
@@ -70,4 +75,4 @@ class KTrajectoryRawShape:
         ky = rearrange(self.ky[sort_idx, ...], '(other k2 k1) k0 -> other k2 k1 k0', k1=n_k1, k2=n_k2)
         kx = rearrange(self.kx[sort_idx, ...], '(other k2 k1) k0 -> other k2 k1 k0', k1=n_k1, k2=n_k2)
 
-        return KTrajectory(kz, ky, kx, repeat_detection_tolerance)
+        return KTrajectory(kz, ky, kx, self.repeat_detection_tolerance)

--- a/src/mrpro/data/traj_calculators/_KTrajectoryPulseq.py
+++ b/src/mrpro/data/traj_calculators/_KTrajectoryPulseq.py
@@ -34,9 +34,11 @@ class KTrajectoryPulseq(KTrajectoryCalculator):
     ----------
     seq_path
         absolute path to .seq file
+    repeat_detection_tolerance
+        tolerance for repeat detection when creating KTrajectory, by default 1e-3
     """
 
-    def __init__(self, seq_path: str | Path, repeat_detection_tolerance: float = 1e-3) -> None:
+    def __init__(self, seq_path: str | Path, repeat_detection_tolerance: None | float = 1e-3) -> None:
         super().__init__()
         self.seq_path = seq_path
         self.repeat_detection_tolerance = repeat_detection_tolerance

--- a/src/mrpro/data/traj_calculators/_KTrajectoryPulseq.py
+++ b/src/mrpro/data/traj_calculators/_KTrajectoryPulseq.py
@@ -36,9 +36,10 @@ class KTrajectoryPulseq(KTrajectoryCalculator):
         absolute path to .seq file
     """
 
-    def __init__(self, seq_path: str | Path) -> None:
+    def __init__(self, seq_path: str | Path, repeat_detection_tolerance: float = 1e-3) -> None:
         super().__init__()
         self.seq_path = seq_path
+        self.repeat_detection_tolerance = repeat_detection_tolerance
 
     def __call__(self, kheader: KHeader) -> KTrajectoryRawShape:
         """Calculate trajectory from given .seq file and header information.
@@ -89,4 +90,4 @@ class KTrajectoryPulseq(KTrajectoryCalculator):
         ky = reshape_pulseq_traj(k_traj_adc[1], kheader.encoding_matrix.y)
         kz = reshape_pulseq_traj(k_traj_adc[2], kheader.encoding_matrix.z)
 
-        return KTrajectoryRawShape(kz, ky, kx)
+        return KTrajectoryRawShape(kz, ky, kx, self.repeat_detection_tolerance)

--- a/src/mrpro/data/traj_calculators/_KTrajectoryPulseq.py
+++ b/src/mrpro/data/traj_calculators/_KTrajectoryPulseq.py
@@ -63,29 +63,15 @@ class KTrajectoryPulseq(KTrajectoryCalculator):
         k_traj_adc_numpy, _, _, _, _ = seq.calculate_kspace()
         k_traj_adc = torch.tensor(k_traj_adc_numpy, dtype=torch.float32)
 
-        unique_idxs = {label: torch.unique(getattr(kheader.acq_info.idx, label)) for label in ['k1', 'k2']}
-
-        n_k1 = len(unique_idxs['k1'])
-        n_k2 = len(unique_idxs['k2'])
-
         n_samples = kheader.acq_info.number_of_samples
         n_samples = torch.unique(n_samples)
         if len(n_samples) > 1:
             raise ValueError('We currently only support constant number of samples')
         n_k0 = int(n_samples.item())
 
-        sample_size = n_samples.shape[0]
-
         def reshape_pulseq_traj(k_traj: torch.Tensor, encoding_size: int):
             k_traj *= encoding_size / (2 * torch.max(torch.abs(k_traj)))
-            return rearrange(
-                k_traj,
-                '(other k2 k1 k0) -> (other k2 k1) k0',
-                k0=n_k0,
-                k2=n_k2,
-                k1=n_k1,
-                other=sample_size,
-            )
+            return rearrange(k_traj, '(other k0) -> other k0', k0=n_k0)
 
         # rearrange k-space trajectory to match MRpro convention
         kx = reshape_pulseq_traj(k_traj_adc[0], kheader.encoding_matrix.x)

--- a/tests/data/test_ktraj_raw_shape.py
+++ b/tests/data/test_ktraj_raw_shape.py
@@ -52,10 +52,10 @@ def test_trajectory_raw_reshape(cartesian_grid):
     kx_raw = make_trajectory_raw_shape(kx_full, sort_idx)
 
     # Create raw trajectory
-    trajectory_raw = KTrajectoryRawShape(kz_raw, ky_raw, kx_raw)
+    trajectory_raw = KTrajectoryRawShape(kz_raw, ky_raw, kx_raw, repeat_detection_tolerance=None)
 
     # Reshape to original trajectory
-    trajectory = trajectory_raw.reshape(sort_idx, n_k2, n_k1, repeat_detection_tolerance=None)
+    trajectory = trajectory_raw.reshape(sort_idx, n_k2, n_k1)
 
     # Compare trajectories
     torch.testing.assert_close(trajectory.kz, kz_full)


### PR DESCRIPTION
Before, it was not possible to set the `repeat_detection_tolerance`, which is used when creating a `KTrajectory` from a `KTrajectoryRawShape` if using the `KTrajectoryPulseq` trajectory calculator. 

The old default would result in kz not beeing added as a ignore_dimension, leading to an error when applying the fourier operator. 

We decided that `repeat_detection_tolerance` is (for now) only required for `KTrajectoryPulseq` as all other should use correct analytical trajectory values anyway. 