### PR TITLE
Operators: elementwise multiplication with non-scalar tensors and typing

### DIFF
--- a/src/mrpro/operators/_EinsumOp.py
+++ b/src/mrpro/operators/_EinsumOp.py
@@ -16,7 +16,7 @@ import re
 
 import torch
 
-from mrpro.operators import LinearOperator
+from mrpro.operators._LinearOperator import LinearOperator
 
 
 class EinsumOp(LinearOperator):

--- a/src/mrpro/operators/_LinearOperator.py
+++ b/src/mrpro/operators/_LinearOperator.py
@@ -86,10 +86,10 @@ class LinearOperatorSum(LinearOperator, OperatorSum[torch.Tensor, tuple[torch.Te
 class LinearOperatorElementwiseProductRight(
     LinearOperator, OperatorElementwiseProductRight[torch.Tensor, tuple[torch.Tensor,]]
 ):
-    """Operator elementwise right multiplication with scalar/tensor."""
+    """Operator elementwise right multiplication with a tensor."""
 
     def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
-        """Adjoint Operator elementwise multiplication with scalar/tensor."""
+        """Adjoint Operator elementwise multiplication with a tensor."""
         if self._tensor.is_complex():
             return self._operator.adjoint(x * self._tensor.conj())
         return self._operator.adjoint(x * self._tensor)
@@ -98,10 +98,10 @@ class LinearOperatorElementwiseProductRight(
 class LinearOperatorElementwiseProductLeft(
     LinearOperator, OperatorElementwiseProductLeft[torch.Tensor, tuple[torch.Tensor,]]
 ):
-    """Operator elementwise left multiplication with scalar/tensor."""
+    """Operator elementwise left multiplication with a tensor."""
 
     def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
-        """Adjoint Operator elementwise multiplication with scalar/tensor."""
+        """Adjoint Operator elementwise multiplication with a tensor."""
         if self._tensor.is_complex():
             return (self._operator.adjoint(x)[0] * self._tensor.conj(),)
         return (self._operator.adjoint(x)[0] * self._tensor,)

--- a/src/mrpro/operators/_LinearOperator.py
+++ b/src/mrpro/operators/_LinearOperator.py
@@ -22,7 +22,8 @@ import torch
 
 from mrpro.operators._Operator import Operator
 from mrpro.operators._Operator import OperatorComposition
-from mrpro.operators._Operator import OperatorElementwiseProduct
+from mrpro.operators._Operator import OperatorElementwiseProductLeft
+from mrpro.operators._Operator import OperatorElementwiseProductRight
 from mrpro.operators._Operator import OperatorSum
 from mrpro.operators._Operator import Tin2
 
@@ -59,11 +60,11 @@ class LinearOperator(Operator[torch.Tensor, tuple[torch.Tensor,]]):
 
     def __mul__(self, other: torch.Tensor):
         """Operator multiplication with tensor."""
-        return LinearOperatorElementwiseProduct(self, other)
+        return LinearOperatorElementwiseProductLeft(self, other)
 
     def __rmul__(self, other: torch.Tensor):
         """Operator multiplication with tensor."""
-        return LinearOperatorElementwiseProduct(self, other)
+        return LinearOperatorElementwiseProductRight(self, other)
 
 
 class LinearOperatorComposition(LinearOperator, OperatorComposition[torch.Tensor, tuple[torch.Tensor,]]):
@@ -82,8 +83,22 @@ class LinearOperatorSum(LinearOperator, OperatorSum[torch.Tensor, tuple[torch.Te
         return (self._operator1.adjoint(x)[0] + self._operator2.adjoint(x)[0],)
 
 
-class LinearOperatorElementwiseProduct(LinearOperator, OperatorElementwiseProduct[torch.Tensor, tuple[torch.Tensor,]]):
-    """Operator elementwise multiplication with scalar/tensor."""
+class LinearOperatorElementwiseProductRight(
+    LinearOperator, OperatorElementwiseProductRight[torch.Tensor, tuple[torch.Tensor,]]
+):
+    """Operator elementwise right multiplication with scalar/tensor."""
+
+    def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
+        """Adjoint Operator elementwise multiplication with scalar/tensor."""
+        if self._tensor.is_complex():
+            return self._operator.adjoint(x * self._tensor.conj())
+        return self._operator.adjoint(x * self._tensor)
+
+
+class LinearOperatorElementwiseProductLeft(
+    LinearOperator, OperatorElementwiseProductLeft[torch.Tensor, tuple[torch.Tensor,]]
+):
+    """Operator elementwise left multiplication with scalar/tensor."""
 
     def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
         """Adjoint Operator elementwise multiplication with scalar/tensor."""

--- a/src/mrpro/operators/_Operator.py
+++ b/src/mrpro/operators/_Operator.py
@@ -47,11 +47,11 @@ class Operator(Generic[*Tin, Tout], ABC, torch.nn.Module):
 
     def __mul__(self, other: torch.Tensor):
         """Operator multiplication with tensor."""
-        return OperatorElementwiseProduct(self, other)
+        return OperatorElementwiseProductLeft(self, other)
 
     def __rmul__(self, other: torch.Tensor):
         """Operator multiplication with tensor."""
-        return OperatorElementwiseProduct(self, other)
+        return OperatorElementwiseProductRight(self, other)
 
 
 class OperatorComposition(Operator[*Tin, Tout]):
@@ -80,8 +80,8 @@ class OperatorSum(Operator[*Tin, Tout]):
         return cast(Tout, tuple(a + b for a, b in zip(self._operator1(*args), self._operator2(*args), strict=True)))
 
 
-class OperatorElementwiseProduct(Operator[*Tin, Tout]):
-    """Operator elementwise multiplication with scalar/tensor."""
+class OperatorElementwiseProductRight(Operator[*Tin, Tout]):
+    """Operator elementwise right multiplication with scalar/tensor."""
 
     def __init__(self, operator: Operator[*Tin, Tout], tensor: torch.Tensor):
         super().__init__()
@@ -92,3 +92,17 @@ class OperatorElementwiseProduct(Operator[*Tin, Tout]):
         """Operator elementwise multiplication."""
         out = self._operator(*args)
         return cast(Tout, tuple(a * self._tensor for a in out))
+
+
+class OperatorElementwiseProductLeft(Operator[*Tin, Tout]):
+    """Operator elementwise left multiplication  with scalar/tensor."""
+
+    def __init__(self, operator: Operator[*Tin, Tout], tensor: torch.Tensor):
+        super().__init__()
+        self._operator = operator
+        self._tensor = tensor
+
+    def forward(self, *args: *Tin) -> Tout:
+        """Operator elementwise multiplication."""
+        out = self._operator(*(a * self._tensor for a in args))
+        return cast(Tout, out)

--- a/src/mrpro/operators/_Operator.py
+++ b/src/mrpro/operators/_Operator.py
@@ -81,7 +81,7 @@ class OperatorSum(Operator[*Tin, Tout]):
 
 
 class OperatorElementwiseProductRight(Operator[*Tin, Tout]):
-    """Operator elementwise right multiplication with scalar/tensor."""
+    """Operator elementwise right multiplication with a tensor."""
 
     def __init__(self, operator: Operator[*Tin, Tout], tensor: torch.Tensor):
         super().__init__()
@@ -89,13 +89,13 @@ class OperatorElementwiseProductRight(Operator[*Tin, Tout]):
         self._tensor = tensor
 
     def forward(self, *args: *Tin) -> Tout:
-        """Operator elementwise multiplication."""
+        """Operator elementwise right multiplication."""
         out = self._operator(*args)
         return cast(Tout, tuple(a * self._tensor for a in out))
 
 
 class OperatorElementwiseProductLeft(Operator[*Tin, Tout]):
-    """Operator elementwise left multiplication  with scalar/tensor."""
+    """Operator elementwise left multiplication  with a tensor."""
 
     def __init__(self, operator: Operator[*Tin, Tout], tensor: torch.Tensor):
         super().__init__()
@@ -103,6 +103,6 @@ class OperatorElementwiseProductLeft(Operator[*Tin, Tout]):
         self._tensor = tensor
 
     def forward(self, *args: *Tin) -> Tout:
-        """Operator elementwise multiplication."""
+        """Operator left elementwise multiplication."""
         out = self._operator(*(a * self._tensor for a in args))
         return cast(Tout, out)

--- a/tests/operators/test_operators.py
+++ b/tests/operators/test_operators.py
@@ -143,8 +143,8 @@ def test_elementwise_product_operator(value):
     (y2,) = a(b * x)
 
     torch.testing.assert_close(y1, y2)
-    assert isinstance(c, Operator), 'Operator * scalar should be an Operator'
-    assert not isinstance(c, LinearOperator), 'Operator * scalar should not be a LinearOperator'
+    assert isinstance(c, Operator), 'Operator * tensor should be an Operator'
+    assert not isinstance(c, LinearOperator), 'Operator * tensor should not be a LinearOperator'
 
 
 @pytest.mark.parametrize('value', [2, 3j])
@@ -157,8 +157,8 @@ def test_elementwise_rproduct_operator(value):
     y2 = b * a(x)[0]
 
     torch.testing.assert_close(y1, y2)
-    assert isinstance(c, Operator), 'Operator * scalar should be an Operator'
-    assert not isinstance(c, LinearOperator), 'Operator * scalar should not be a LinearOperator'
+    assert isinstance(c, Operator), 'tensor * Operator should be an Operator'
+    assert not isinstance(c, LinearOperator), 'tensor * Operator should not be a LinearOperator'
 
 
 @pytest.mark.parametrize('value', [2, 3j])
@@ -167,8 +167,8 @@ def test_elementwise_product_linearoperator(value):
     a = DummyLinearOperator(rng.complex64_tensor((3, 10)))
     b = torch.ones(10) * value
     c = a * b
-    assert isinstance(c, Operator), 'LinearOperator * scalar should be an Operator'
-    assert isinstance(c, LinearOperator), 'LinearOperator * scalar should be a LinearOperator'
+    assert isinstance(c, Operator), 'LinearOperator * tensor should be an Operator'
+    assert isinstance(c, LinearOperator), 'LinearOperator * tensor should be a LinearOperator'
 
     x = rng.complex64_tensor(10)
     (y1,) = c(x)
@@ -187,8 +187,8 @@ def test_elementwise_rproduct_linearoperator(value):
     a = DummyLinearOperator(rng.complex64_tensor((3, 10)))
     b = torch.ones(3) * value
     c = b * a
-    assert isinstance(c, Operator), 'LinearOperator * scalar should be an Operator'
-    assert isinstance(c, LinearOperator), 'LinearOperator * scalar should be a LinearOperator'
+    assert isinstance(c, Operator), 'tensor * LinearOperator should be an Operator'
+    assert isinstance(c, LinearOperator), 'tensor * LinearOperator should be a LinearOperator'
 
     x = RandomGenerator(0).complex64_tensor(10)
     (y1,) = c(x)

--- a/tests/operators/test_operators.py
+++ b/tests/operators/test_operators.py
@@ -1,14 +1,16 @@
 """Tests for the operators module."""
 
+import pytest
 import torch
 from mrpro.operators import LinearOperator
 from mrpro.operators import Operator
 
+from tests import RandomGenerator
 from tests.helper import dotproduct_adjointness_test
 
 
 class DummyOperator(Operator[torch.Tensor, torch.Tensor]):
-    """Dummy operator for testing, raises input to the power of value."""
+    """Dummy operator for testing, raises input to the power of value and sums."""
 
     def __init__(self, value: torch.Tensor):
         super().__init__()
@@ -16,7 +18,7 @@ class DummyOperator(Operator[torch.Tensor, torch.Tensor]):
 
     def forward(self, x: torch.Tensor):
         """Dummy operator."""
-        return (x**self._value,)
+        return ((x**self._value).sum().unsqueeze(0),)
 
 
 class DummyLinearOperator(LinearOperator):
@@ -28,20 +30,18 @@ class DummyLinearOperator(LinearOperator):
 
     def forward(self, x: torch.Tensor):
         """Dummy linear operator."""
-        return (x * self._value,)
+        return (self._value @ x,)
 
     def adjoint(self, x: torch.Tensor):
         """Dummy adjoint linear operator."""
-        if self._value.is_complex():
-            return (x * self._value.conj(),)
-        return (x * self._value,)
+        return (self._value.mH @ x,)
 
 
 def test_composition_operator():
     a = DummyOperator(torch.tensor(2.0))
     b = DummyOperator(torch.tensor(3.0))
     c = a @ b
-    x = torch.arange(10)
+    x = RandomGenerator(0).complex64_tensor(10)
     (y1,) = c(x)
     (y2,) = a(*b(x))
 
@@ -51,10 +51,11 @@ def test_composition_operator():
 
 
 def test_composition_linearoperator():
-    a = DummyLinearOperator(torch.tensor(2.0))
-    b = DummyLinearOperator(torch.tensor(3.0))
+    rng = RandomGenerator(2)
+    a = DummyLinearOperator(rng.complex64_tensor((2, 3)))
+    b = DummyLinearOperator(rng.complex64_tensor((3, 10)))
     c = a @ b
-    x = torch.arange(10)
+    x = RandomGenerator(0).complex64_tensor(10)
     (y1,) = c(x)
     (y2,) = a(*b(x))
 
@@ -64,10 +65,11 @@ def test_composition_linearoperator():
 
 
 def test_composition_linearoperator_operator():
-    a = DummyLinearOperator(torch.tensor(2.0))
+    rng = RandomGenerator(2)
+    a = DummyLinearOperator(rng.complex64_tensor((3, 1)))
     b = DummyOperator(torch.tensor(3.0))
     c = a @ b
-    x = torch.arange(10)
+    x = RandomGenerator(0).complex64_tensor(10)
     (y1,) = c(x)
     (y2,) = a(*b(x))
 
@@ -80,7 +82,7 @@ def test_sum_operator():
     a = DummyOperator(torch.tensor(2.0))
     b = DummyOperator(torch.tensor(3.0))
     c = a + b
-    x = torch.arange(10)
+    x = RandomGenerator(0).complex64_tensor(10)
     (y1,) = c(x)
     y2 = a(x)[0] + b(x)[0]
 
@@ -90,10 +92,11 @@ def test_sum_operator():
 
 
 def test_sum_linearoperator():
-    a = DummyLinearOperator(torch.tensor(2.0))
-    b = DummyLinearOperator(torch.tensor(3.0))
+    rng = RandomGenerator(2)
+    a = DummyLinearOperator(rng.complex64_tensor((3, 10)))
+    b = DummyLinearOperator(rng.complex64_tensor((3, 10)))
     c = a + b
-    x = torch.arange(10)
+    x = RandomGenerator(0).complex64_tensor(10)
     (y1,) = c(x)
     y2 = a(x)[0] + b(x)[0]
 
@@ -103,10 +106,11 @@ def test_sum_linearoperator():
 
 
 def test_sum_linearoperator_operator():
-    a = DummyLinearOperator(torch.tensor(2.0))
+    rng = RandomGenerator(0)
+    a = DummyLinearOperator(rng.complex64_tensor((3, 10)))
     b = DummyOperator(torch.tensor(3.0))
     c = a + b
-    x = torch.arange(10)
+    x = rng.complex64_tensor(10)
     (y1,) = c(x)
     y2 = a(x)[0] + b(x)[0]
 
@@ -116,10 +120,11 @@ def test_sum_linearoperator_operator():
 
 
 def test_sum_operator_linearoperator():
+    rng = RandomGenerator(0)
     a = DummyOperator(torch.tensor(3.0))
-    b = DummyLinearOperator(torch.tensor(2.0))
+    b = DummyLinearOperator(rng.complex64_tensor((3, 10)))
     c = a + b
-    x = torch.arange(10)
+    x = rng.complex64_tensor(10)
     (y1,) = c(x)
     y2 = a(x)[0] + b(x)[0]
 
@@ -128,80 +133,114 @@ def test_sum_operator_linearoperator():
     assert not isinstance(c, LinearOperator), 'Operator + LinearOperator should not be a LinearOperator'
 
 
-def test_elementwise_product_operator():
+@pytest.mark.parametrize('value', [2, 3j])
+def test_elementwise_product_operator(value):
     a = DummyOperator(torch.tensor(2.0))
-    b = torch.tensor(3.0)
+    b = torch.ones(10) * value
     c = a * b
-    x = torch.arange(10)
+    x = RandomGenerator(0).complex64_tensor(10)
     (y1,) = c(x)
-    y2 = a(x)[0] * b
+    (y2,) = a(b * x)
 
     torch.testing.assert_close(y1, y2)
     assert isinstance(c, Operator), 'Operator * scalar should be an Operator'
     assert not isinstance(c, LinearOperator), 'Operator * scalar should not be a LinearOperator'
 
 
-def test_elementwise_rproduct_operator():
+@pytest.mark.parametrize('value', [2, 3j])
+def test_elementwise_rproduct_operator(value):
     a = DummyOperator(torch.tensor(2.0))
-    b = torch.tensor(3.0)
+    b = torch.tensor(value)
     c = b * a
-    x = torch.arange(10)
+    x = RandomGenerator(0).complex64_tensor(10)
     (y1,) = c(x)
-    y2 = a(x)[0] * b
+    y2 = b * a(x)[0]
 
     torch.testing.assert_close(y1, y2)
     assert isinstance(c, Operator), 'Operator * scalar should be an Operator'
     assert not isinstance(c, LinearOperator), 'Operator * scalar should not be a LinearOperator'
 
 
-def test_elementwise_product_linearoperator():
-    a = DummyLinearOperator(torch.tensor(2.0))
-    b = torch.tensor(3.0)
+@pytest.mark.parametrize('value', [2, 3j])
+def test_elementwise_product_linearoperator(value):
+    rng = RandomGenerator(0)
+    a = DummyLinearOperator(rng.complex64_tensor((3, 10)))
+    b = torch.ones(10) * value
     c = a * b
-    x = torch.arange(10)
-    (y1,) = c(x)
-    y2 = a(x)[0] * b
-
-    torch.testing.assert_close(y1, y2)
     assert isinstance(c, Operator), 'LinearOperator * scalar should be an Operator'
     assert isinstance(c, LinearOperator), 'LinearOperator * scalar should be a LinearOperator'
 
+    x = rng.complex64_tensor(10)
+    (y1,) = c(x)
+    (y2,) = a(x * b)
+    torch.testing.assert_close(y1, y2)
 
-def test_elementwise_rproduct_linearoperator():
-    a = DummyLinearOperator(torch.tensor(2.0))
-    b = torch.tensor(3.0)
+    y = rng.complex64_tensor(3)
+    (x1,) = c.H(y)
+    x2 = b.conj() * a.H(y)[0]
+    torch.testing.assert_close(x1, x2)
+
+
+@pytest.mark.parametrize('value', [2, 3j])
+def test_elementwise_rproduct_linearoperator(value):
+    rng = RandomGenerator(2)
+    a = DummyLinearOperator(rng.complex64_tensor((3, 10)))
+    b = torch.ones(3) * value
     c = b * a
-    x = torch.arange(10)
-    (y1,) = c(x)
-    y2 = a(x)[0] * b
-
-    torch.testing.assert_close(y1, y2)
     assert isinstance(c, Operator), 'LinearOperator * scalar should be an Operator'
     assert isinstance(c, LinearOperator), 'LinearOperator * scalar should be a LinearOperator'
+
+    x = RandomGenerator(0).complex64_tensor(10)
+    (y1,) = c(x)
+    y2 = a(x)[0] * b
+    torch.testing.assert_close(y1, y2)
+
+    y = RandomGenerator(0).complex64_tensor(10)
+    (y1,) = c(x)
+    y2 = a(x)[0] * b
+    torch.testing.assert_close(y1, y2)
+
+    y = rng.complex64_tensor(3)
+    (x1,) = c.H(y)
+    (x2,) = a.H(b.conj() * y)
+    torch.testing.assert_close(x1, x2)
 
 
 def test_adjoint_composition_operators():
-    a = DummyLinearOperator(torch.tensor(2.0 + 1j))
-    b = DummyLinearOperator(torch.tensor(3.0 + 2j))
-    u = torch.tensor(4 + 5j)
-    v = torch.tensor(7 + 8j)
+    rng = RandomGenerator(2)
+    a = DummyLinearOperator(rng.complex64_tensor((2, 3)))
+    b = DummyLinearOperator(rng.complex64_tensor((3, 10)))
+    u = rng.complex64_tensor(10)
+    v = rng.complex64_tensor(2)
     linear_op_composition = a @ b
     dotproduct_adjointness_test(linear_op_composition, u, v)
 
 
-def test_adjoint_product():
-    a = DummyLinearOperator(torch.tensor(2.0 + 1j))
-    b = torch.tensor(3.0 + 2j)
-    u = torch.tensor(4 + 5j)
-    v = torch.tensor(7 + 8j)
+def test_adjoint_product_left():
+    rng = RandomGenerator(0)
+    a = DummyLinearOperator(rng.complex64_tensor((3, 10)))
+    b = rng.float32_tensor(10)
+    u = rng.complex64_tensor(10)
+    v = rng.complex64_tensor(3)
     linear_op_product = a * b
     dotproduct_adjointness_test(linear_op_product, u, v)
 
 
+def test_adjoint_product_right():
+    rng = RandomGenerator(1)
+    a = DummyLinearOperator(rng.complex64_tensor((3, 10)))
+    b = rng.float32_tensor(3)
+    u = rng.complex64_tensor(10)
+    v = rng.complex64_tensor(3)
+    linear_op_product = b * a
+    dotproduct_adjointness_test(linear_op_product, u, v)
+
+
 def test_adjoint_sum():
-    a = DummyLinearOperator(torch.tensor(2.0 + 1j))
-    b = DummyLinearOperator(torch.tensor(3.0 + 2j))
-    u = torch.tensor(4 + 5j)
-    v = torch.tensor(7 + 8j)
+    rng = RandomGenerator(2)
+    a = DummyLinearOperator(rng.complex64_tensor((3, 10)))
+    b = DummyLinearOperator(rng.complex64_tensor((3, 10)))
+    u = rng.complex64_tensor(10)
+    v = rng.complex64_tensor(3)
     linear_op_sum = a + b
     dotproduct_adjointness_test(linear_op_sum, u, v)


### PR DESCRIPTION
We only supported (i.e. tested) for multiplication with a scalar tensor.

This adds tests and logic for elementwise multiplication with nd-tensors.

Related #247 

and adds missing type hints.