### PR TITLE
Bump pytorch and ismrmrd version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,8 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.23,<2.0",
-    "torch>=2.2,<3.0",
-    "ismrmrd",
-    "xsdata>=22.2,<23",
+    "torch>=2.3,<3.0",
+    "ismrmrd>=1.14.1,<2.0",
     "einops",
     "pydicom",
     "pypulseq@git+https://github.com/imr-framework/pypulseq",

--- a/src/mrpro/algorithms/optimizers/_lbfgs.py
+++ b/src/mrpro/algorithms/optimizers/_lbfgs.py
@@ -66,12 +66,6 @@ def lbfgs(
     -------
         list of optimized parameters
     """
-    # TODO: remove after new pytorch release;
-    if torch.tensor([torch.is_complex(p) for p in initial_parameters]).any():
-        raise ValueError(
-            "at least one tensor in 'params' is complex-valued; \
-            \ncomplex-valued tensors will be allowed for lbfgs in future torch versions",
-        )
 
     parameters = [p.detach().clone().requires_grad_(True) for p in initial_parameters]
     optim = LBFGS(

--- a/src/mrpro/algorithms/optimizers/_lbfgs.py
+++ b/src/mrpro/algorithms/optimizers/_lbfgs.py
@@ -66,7 +66,6 @@ def lbfgs(
     -------
         list of optimized parameters
     """
-
     parameters = [p.detach().clone().requires_grad_(True) for p in initial_parameters]
     optim = LBFGS(
         params=parameters,

--- a/src/mrpro/data/_Data.py
+++ b/src/mrpro/data/_Data.py
@@ -59,7 +59,7 @@ class Data(ABC):
         """
         return Data(
             header=self.header,
-            data=self.data.cuda(device=device, non_blocking=non_blocking, memory_format=memory_format),  # type: ignore [call-arg]
+            data=self.data.cuda(device=device, non_blocking=non_blocking, memory_format=memory_format),
         )
 
     def cpu(self, memory_format: torch.memory_format = torch.preserve_format) -> Data:
@@ -70,4 +70,4 @@ class Data(ABC):
         memory_format
             The desired memory format of returned tensor.
         """
-        return Data(header=self.header, data=self.data.cpu(memory_format=memory_format))  # type: ignore [call-arg]
+        return Data(header=self.header, data=self.data.cpu(memory_format=memory_format))

--- a/src/mrpro/data/_KNoise.py
+++ b/src/mrpro/data/_KNoise.py
@@ -120,7 +120,7 @@ class KNoise:
             The desired memory format of returned Tensor.
         """
         return type(self)(
-            data=self.data.cuda(device=device, non_blocking=non_blocking, memory_format=memory_format),  # type: ignore [call-arg]
+            data=self.data.cuda(device=device, non_blocking=non_blocking, memory_format=memory_format),
         )
 
     def cpu(self, memory_format: torch.memory_format = torch.preserve_format) -> Self:
@@ -132,5 +132,5 @@ class KNoise:
             The desired memory format of returned Tensor.
         """
         return type(self)(
-            data=self.data.cpu(memory_format=memory_format),  # type: ignore [call-arg]
+            data=self.data.cpu(memory_format=memory_format),
         )

--- a/src/mrpro/data/_KTrajectory.py
+++ b/src/mrpro/data/_KTrajectory.py
@@ -214,9 +214,9 @@ class KTrajectory:
             The desired memory format of returned Tensor.
         """
         return KTrajectory(
-            kz=self.kz.cuda(device=device, non_blocking=non_blocking, memory_format=memory_format),  # type: ignore [call-arg]
-            ky=self.ky.cuda(device=device, non_blocking=non_blocking, memory_format=memory_format),  # type: ignore [call-arg]
-            kx=self.kx.cuda(device=device, non_blocking=non_blocking, memory_format=memory_format),  # type: ignore [call-arg]
+            kz=self.kz.cuda(device=device, non_blocking=non_blocking, memory_format=memory_format),
+            ky=self.ky.cuda(device=device, non_blocking=non_blocking, memory_format=memory_format),
+            kx=self.kx.cuda(device=device, non_blocking=non_blocking, memory_format=memory_format),
         )
 
     def cpu(self, memory_format: torch.memory_format = torch.preserve_format) -> KTrajectory:
@@ -228,7 +228,7 @@ class KTrajectory:
             The desired memory format of returned Tensor.
         """
         return KTrajectory(
-            kz=self.kz.cpu(memory_format=memory_format),  # type: ignore [call-arg]
-            ky=self.ky.cpu(memory_format=memory_format),  # type: ignore [call-arg]
-            kx=self.kx.cpu(memory_format=memory_format),  # type: ignore [call-arg]
+            kz=self.kz.cpu(memory_format=memory_format),
+            ky=self.ky.cpu(memory_format=memory_format),
+            kx=self.kx.cpu(memory_format=memory_format),
         )

--- a/src/mrpro/data/_kdata/_KData.py
+++ b/src/mrpro/data/_kdata/_KData.py
@@ -332,7 +332,7 @@ class KData(KDataSplitMixin, KDataRearrangeMixin, KDataSelectMixin, KDataRemoveO
         """
         return KData(
             header=self.header,
-            data=self.data.cuda(device=device, non_blocking=non_blocking, memory_format=memory_format),  # type: ignore [call-arg]
+            data=self.data.cuda(device=device, non_blocking=non_blocking, memory_format=memory_format),
             traj=self.traj.cuda(device=device, non_blocking=non_blocking, memory_format=memory_format),
         )
 
@@ -346,7 +346,7 @@ class KData(KDataSplitMixin, KDataRearrangeMixin, KDataSelectMixin, KDataRemoveO
         """
         return KData(
             header=self.header,
-            data=self.data.cpu(memory_format=memory_format),  # type: ignore [call-arg]
+            data=self.data.cpu(memory_format=memory_format),
             traj=self.traj.cpu(memory_format=memory_format),
         )
 


### PR DESCRIPTION
This fixes a ismrmrd / xsdata incompatibility issue  (Ref. #177) and sets the min. pytorch version to 2.3.
This version includes my fix for https://github.com/pytorch/pytorch/issues/118501, so we can remove a lot of type-ignore comments
 