### PR TITLE
Adjoint as gradient for linear operator

### DIFF
--- a/src/mrpro/operators/EinsumOp.py
+++ b/src/mrpro/operators/EinsumOp.py
@@ -75,7 +75,7 @@ class EinsumOp(LinearOperator):
         self._forward_rule = einsum_rule
         self.matrix = torch.nn.Parameter(matrix, matrix.requires_grad)
 
-    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor]:
+    def _forward_implementation(self, x: torch.Tensor) -> torch.Tensor:
         """Sum-Multiplication of input `x` with `A`.
 
         `A` and the rule used to perform the sum-product is set at initialization.
@@ -90,9 +90,9 @@ class EinsumOp(LinearOperator):
             result of matrix-vector multiplication
         """
         y = einsum(self.matrix, x, self._forward_rule)
-        return (y,)
+        return y
 
-    def adjoint(self, y: torch.Tensor) -> tuple[torch.Tensor]:
+    def _adjoint_implementation(self, y: torch.Tensor) -> torch.Tensor:
         """Multiplication of input with the adjoint of `A`.
 
         Parameters
@@ -105,4 +105,4 @@ class EinsumOp(LinearOperator):
             result of adjoint sum product
         """
         x = einsum(self.matrix.conj(), y, self._adjoint_rule)
-        return (x,)
+        return x

--- a/src/mrpro/operators/FastFourierOp.py
+++ b/src/mrpro/operators/FastFourierOp.py
@@ -110,7 +110,7 @@ class FastFourierOp(LinearOperator):
                 f'{encoding_matrix=} and {recon_matrix=}'
             )
 
-    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
+    def _forward_implementation(self, x: torch.Tensor) -> torch.Tensor:
         """FFT from image space to k-space.
 
         Parameters
@@ -126,9 +126,9 @@ class FastFourierOp(LinearOperator):
             torch.fft.fftn(torch.fft.ifftshift(*self._pad_op.forward(x), dim=self._dim), dim=self._dim, norm='ortho'),
             dim=self._dim,
         )
-        return (y,)
+        return y
 
-    def adjoint(self, y: torch.Tensor) -> tuple[torch.Tensor,]:
+    def _adjoint_implementation(self, y: torch.Tensor) -> torch.Tensor:
         """IFFT from k-space to image space.
 
         Parameters
@@ -146,4 +146,4 @@ class FastFourierOp(LinearOperator):
                 torch.fft.ifftn(torch.fft.ifftshift(y, dim=self._dim), dim=self._dim, norm='ortho'),
                 dim=self._dim,
             ),
-        )
+        )[0]

--- a/src/mrpro/operators/FourierOp.py
+++ b/src/mrpro/operators/FourierOp.py
@@ -150,7 +150,7 @@ class FourierOp(LinearOperator):
             traj=kdata.traj,
         )
 
-    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
+    def _forward_implementation(self, x: torch.Tensor) -> torch.Tensor:
         """Forward operator mapping the coil-images to the coil k-space data.
 
         Parameters
@@ -189,9 +189,9 @@ class FourierOp(LinearOperator):
             shape_nufft_dims = [self._kshape[i] for i in self._nufft_dims]
             x = x.reshape(*permuted_x_shape[: -len(keep_dims)], -1, *shape_nufft_dims)  # -1 is coils
             x = x.permute(*unpermute)
-        return (x,)
+        return x
 
-    def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
+    def _adjoint_implementation(self, x: torch.Tensor) -> torch.Tensor:
         """Adjoint operator mapping the coil k-space data to the coil images.
 
         Parameters
@@ -227,4 +227,4 @@ class FourierOp(LinearOperator):
             x = x.reshape(*permuted_x_shape[: -len(keep_dims)], *x.shape[-len(keep_dims) :])
             x = x.permute(*unpermute)
 
-        return (x,)
+        return x

--- a/src/mrpro/operators/LinearOperator.py
+++ b/src/mrpro/operators/LinearOperator.py
@@ -59,6 +59,10 @@ class _AutogradWrapper(torch.autograd.Function):
     def backward(ctx: Any, *grad_output: torch.Tensor) -> tuple[None, None, Any | None]:  # noqa: ANN401
         return None, None, _AutogradWrapper.apply(ctx.bw, ctx.fw, grad_output[0])
 
+    @staticmethod
+    def jvp(ctx: Any, *grad_inputs: Any) -> Any:  # noqa: ANN401
+        return _AutogradWrapper.apply(ctx.fw, ctx.bw, grad_inputs[-1])
+
 
 class LinearOperator(Operator[torch.Tensor, tuple[torch.Tensor]]):
     """General Linear Operator.

--- a/src/mrpro/operators/LinearOperator.py
+++ b/src/mrpro/operators/LinearOperator.py
@@ -43,7 +43,7 @@ class _AutogradWrapper(torch.autograd.Function):
         fw: Callable[[torch.Tensor], torch.Tensor],
         bw: Callable[[torch.Tensor], torch.Tensor],  # noqa: ARG004
         x: torch.Tensor,
-    ) -> Any:  # noqa: ANN401
+    ) -> torch.Tensor:
         return fw(x)
 
     @staticmethod
@@ -56,11 +56,11 @@ class _AutogradWrapper(torch.autograd.Function):
         return output
 
     @staticmethod
-    def backward(ctx: Any, *grad_output: torch.Tensor) -> tuple[None, None, Any | None]:  # noqa: ANN401
+    def backward(ctx: Any, *grad_output: torch.Tensor) -> tuple[None, None, torch.Tensor]:  # noqa: ANN401
         return None, None, _AutogradWrapper.apply(ctx.bw, ctx.fw, grad_output[0])
 
     @staticmethod
-    def jvp(ctx: Any, *grad_inputs: Any) -> Any:  # noqa: ANN401
+    def jvp(ctx: Any, *grad_inputs: Any) -> torch.Tensor:  # noqa: ANN401
         return _AutogradWrapper.apply(ctx.fw, ctx.bw, grad_inputs[-1])
 
 
@@ -77,7 +77,7 @@ class LinearOperator(Operator[torch.Tensor, tuple[torch.Tensor]]):
         return (_AutogradWrapper.apply(self._forward_implementation, self._adjoint_implementation, x),)
 
     def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor]:
-        """Apply the adjoint of the Operator to x."""
+        """Apply the adjoint of the operator to x."""
         return (_AutogradWrapper.apply(self._adjoint_implementation, self._forward_implementation, x),)
 
     @property

--- a/src/mrpro/operators/LinearOperator.py
+++ b/src/mrpro/operators/LinearOperator.py
@@ -39,14 +39,16 @@ class _AutogradWrapper(torch.autograd.Function):
     generate_vmap_rule = True
 
     @staticmethod
-    def forward(
-        fw: Callable[[torch.Tensor], torch.Tensor], bw: Callable[[torch.Tensor], torch.Tensor], x: torch.Tensor
-    ) -> Any:
+    def forward(  # type: ignore [override]
+        fw: Callable[[torch.Tensor], torch.Tensor],
+        bw: Callable[[torch.Tensor], torch.Tensor],  # noqa: ARG004
+        x: torch.Tensor,
+    ) -> Any:  # noqa: ANN401
         return fw(x)
 
     @staticmethod
     def setup_context(
-        ctx: Any,
+        ctx: Any,  # noqa: ANN401
         inputs: tuple[Callable[[torch.Tensor], torch.Tensor], Callable[[torch.Tensor], torch.Tensor], torch.Tensor],
         output: torch.Tensor,
     ) -> torch.Tensor:
@@ -54,7 +56,7 @@ class _AutogradWrapper(torch.autograd.Function):
         return output
 
     @staticmethod
-    def backward(ctx, *grad_output: torch.Tensor):
+    def backward(ctx: Any, *grad_output: torch.Tensor) -> tuple[None, None, Any | None]:  # noqa: ANN401
         return None, None, _AutogradWrapper.apply(ctx.bw, ctx.fw, grad_output[0])
 
 

--- a/src/mrpro/operators/SensitivityOp.py
+++ b/src/mrpro/operators/SensitivityOp.py
@@ -39,7 +39,7 @@ class SensitivityOp(LinearOperator):
             csm = csm.data
         self.register_buffer('csm_tensor', csm)
 
-    def forward(self, img: torch.Tensor) -> tuple[torch.Tensor,]:
+    def _forward_implementation(self, img: torch.Tensor) -> torch.Tensor:
         """Apply the forward operator, thus expand the coils dimension.
 
         Parameters
@@ -51,9 +51,9 @@ class SensitivityOp(LinearOperator):
         -------
             image data tensor with dimensions (other coils z y x).
         """
-        return (self.csm_tensor * img,)
+        return self.csm_tensor * img
 
-    def adjoint(self, img: torch.Tensor) -> tuple[torch.Tensor,]:
+    def _adjoint_implementation(self, img: torch.Tensor) -> torch.Tensor:
         """Apply the adjoint operator, thus reduce the coils dimension.
 
         Parameters
@@ -65,4 +65,4 @@ class SensitivityOp(LinearOperator):
         -------
             image data tensor with dimensions (other 1 z y x).
         """
-        return ((self.csm_tensor.conj() * img).sum(-4, keepdim=True),)
+        return (self.csm_tensor.conj() * img).sum(-4, keepdim=True)

--- a/src/mrpro/operators/SliceProjectionOp.py
+++ b/src/mrpro/operators/SliceProjectionOp.py
@@ -209,7 +209,7 @@ class SliceProjectionOp(LinearOperator):
         self._range_shape: tuple[int] = (*batch_shapes, 1, max_shape, max_shape)
         self._domain_shape = input_shape.zyx
 
-    def forward(self, x: Tensor) -> tuple[Tensor]:
+    def _forward_implementation(self, x: Tensor) -> Tensor:
         """Transform from a 3D Volume to a 2D Slice.
 
         Parameters
@@ -239,9 +239,9 @@ class SliceProjectionOp(LinearOperator):
             [_MatrixMultiplication.apply(x, matrix, matrix_adjoint).reshape(self._range_shape) for x in xflat], -4
         )
         y = y.reshape(*y.shape[:-4], *x.shape[:-3], *y.shape[-3:])
-        return (y,)
+        return y
 
-    def adjoint(self, x: Tensor) -> tuple[Tensor,]:
+    def _adjoint_implementation(self, x: Tensor) -> Tensor:
         """Transform from a 2D slice to a 3D Volume.
 
         Parameters
@@ -282,7 +282,7 @@ class SliceProjectionOp(LinearOperator):
             ]
         )
         y = y_flatdomainbatch.reshape(*x.shape[n_batchdim:-3], *y_flatdomainbatch.shape[1:])
-        return (y,)
+        return y
 
     @staticmethod
     def join_matrices(matrices: Sequence[Tensor]) -> Tensor:

--- a/src/mrpro/operators/ZeroPadOp.py
+++ b/src/mrpro/operators/ZeroPadOp.py
@@ -48,7 +48,7 @@ class ZeroPadOp(LinearOperator):
         self.original_shape = original_shape
         self.padded_shape = padded_shape
 
-    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
+    def _forward_implementation(self, x: torch.Tensor) -> torch.Tensor:
         """Pad or crop data.
 
         Parameters
@@ -60,9 +60,9 @@ class ZeroPadOp(LinearOperator):
         -------
             data with shape padded_shape
         """
-        return (zero_pad_or_crop(x, self.padded_shape, self.dim),)
+        return zero_pad_or_crop(x, self.padded_shape, self.dim)
 
-    def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
+    def _adjoint_implementation(self, x: torch.Tensor) -> torch.Tensor:
         """Crop or pad data.
 
         Parameters
@@ -74,4 +74,4 @@ class ZeroPadOp(LinearOperator):
         -------
             data with shape orig_shape
         """
-        return (zero_pad_or_crop(x, self.original_shape, self.dim),)
+        return zero_pad_or_crop(x, self.original_shape, self.dim)

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -178,7 +178,7 @@ def forward_mode_autodiff_of_linear_operator_test(
     """
     # jvp of the forward
     assert torch.allclose(
-        torch.func.jvp(linear_operator.forward, (u,), (u,))[0],
+        torch.func.jvp(linear_operator.forward, (u,), (u,))[0][0],
         linear_operator.forward(u)[0],
         rtol=relative_tolerance,
         atol=absolute_tolerance,
@@ -186,7 +186,7 @@ def forward_mode_autodiff_of_linear_operator_test(
 
     # jvp of the adjoint
     assert torch.allclose(
-        torch.func.jvp(linear_operator.adjoint, (v,), (v,))[0],
+        torch.func.jvp(linear_operator.adjoint, (v,), (v,))[0][0],
         linear_operator.adjoint(v)[0],
         rtol=relative_tolerance,
         atol=absolute_tolerance,

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -201,6 +201,12 @@ def autodiff_of_operator_test(
 
     This test does not check that the gradient is correct but simply that it can be calculated using autodiff.
 
+    torch.autograd.detect_anomaly will raise the Warning:
+    Anomaly Detection has been enabled. This mode will increase the runtime and should only be enabled for debugging.
+
+    If you want to add this function in a test, use the decorator:
+    @pytest.mark.filterwarnings("ignore:Anomaly Detection has been enabled")
+
     Parameters
     ----------
     operator
@@ -216,7 +222,10 @@ def autodiff_of_operator_test(
 
     """
     # Forward-mode autodiff using jvp
-    assert torch.func.jvp(operator.forward, u, u)
+    with torch.autograd.detect_anomaly():
+        v_range, _ = torch.func.jvp(operator.forward, u, u)
 
     # Backward-mode autodiff using vjp
-    assert torch.func.vjp(operator.forward, *u)
+    with torch.autograd.detect_anomaly():
+        (_, vjpfunc) = torch.func.vjp(operator.forward, *u)
+        vjpfunc(v_range)

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -130,12 +130,66 @@ def gradient_of_linear_operator_test(
     """
     # Gradient of the forward via vjp
     (_, vjpfunc) = torch.func.vjp(linear_operator.forward, u)
-    assert torch.allclose(vjpfunc((v,))[0], linear_operator.adjoint(v)[0])
+    assert torch.allclose(
+        vjpfunc((v,))[0], linear_operator.adjoint(v)[0], rtol=relative_tolerance, atol=absolute_tolerance
+    )
 
     # Gradient of the adjoint via vjp
     (_, vjpfunc) = torch.func.vjp(linear_operator.adjoint, v)
     assert torch.allclose(
         vjpfunc((u,))[0], linear_operator.forward(u)[0], rtol=relative_tolerance, atol=absolute_tolerance
+    )
+
+
+def forward_mode_autodiff_of_linear_operator_test(
+    linear_operator: LinearOperator,
+    u: torch.Tensor,
+    v: torch.Tensor,
+    relative_tolerance: float = 1e-3,
+    absolute_tolerance=1e-5,
+):
+    """Test the forward-mode autodiff calculation.
+
+    Verifies that the Jacobian-vector product (jvp) is equivalent to applying the operator.
+
+    Note: This property should hold for all u and v.
+    Commonly, this function is called with two random vectors u and v.
+
+
+    Parameters
+    ----------
+    linear_operator
+        linear operator
+    u
+        element of the domain of the operator
+    v
+        element of the range of the operator
+    relative_tolerance
+        default is pytorch's default for float16
+    absolute_tolerance
+        default is pytorch's default for float16
+
+    Raises
+    ------
+    AssertionError
+        if the jvp yields different results than applying the operator
+
+
+    """
+    # jvp of the forward
+    assert torch.allclose(
+        torch.func.jvp(linear_operator.forward, (u,), (u,))[0],
+        linear_operator.forward(u)[0],
+        rtol=relative_tolerance,
+        atol=absolute_tolerance,
+    )
+
+    # jvp of the adjoint
+    assert torch.allclose(
+        torch.func.jvp(linear_operator.adjoint, (v,), (v,))[0],
+        linear_operator.adjoint(v)[0],
+        rtol=relative_tolerance,
+        atol=absolute_tolerance,
     )
 
 

--- a/tests/operators/models/test_inversion_recovery.py
+++ b/tests/operators/models/test_inversion_recovery.py
@@ -19,6 +19,7 @@ import torch
 from mrpro.operators.models import InversionRecovery
 from tests.conftest import SHAPE_VARIATIONS_SIGNAL_MODELS
 from tests.conftest import create_parameter_tensor_tuples
+from tests.helper import autodiff_of_operator_test
 
 
 @pytest.mark.parametrize(
@@ -54,3 +55,11 @@ def test_inversion_recovery_shape(parameter_shape, contrast_dim_shape, signal_sh
     m0, t1 = create_parameter_tensor_tuples(parameter_shape, number_of_tensors=2)
     (signal,) = model_op.forward(m0, t1)
     assert signal.shape == signal_shape
+
+
+@pytest.mark.filterwarnings('ignore:Anomaly Detection has been enabled')
+def test_autodiff_inversion_recovery():
+    """Test autodiff works for inversion_recovery model."""
+    model = InversionRecovery(ti=10)
+    m0, t1 = create_parameter_tensor_tuples(parameter_shape=(2, 5, 10, 10, 10), number_of_tensors=2)
+    autodiff_of_operator_test(model, m0, t1)

--- a/tests/operators/models/test_molli.py
+++ b/tests/operators/models/test_molli.py
@@ -19,6 +19,7 @@ import torch
 from mrpro.operators.models import MOLLI
 from tests.conftest import SHAPE_VARIATIONS_SIGNAL_MODELS
 from tests.conftest import create_parameter_tensor_tuples
+from tests.helper import autodiff_of_operator_test
 
 
 @pytest.mark.parametrize(
@@ -60,3 +61,11 @@ def test_molli_shape(parameter_shape, contrast_dim_shape, signal_shape):
     a, b, t1 = create_parameter_tensor_tuples(parameter_shape, number_of_tensors=3)
     (signal,) = model_op.forward(a, b, t1)
     assert signal.shape == signal_shape
+
+
+@pytest.mark.filterwarnings('ignore:Anomaly Detection has been enabled')
+def test_autodiff_molli():
+    """Test autodiff works for molli model."""
+    model = MOLLI(ti=10)
+    a, b, t1 = create_parameter_tensor_tuples((2, 5, 10, 10, 10), number_of_tensors=3)
+    autodiff_of_operator_test(model, a, b, t1)

--- a/tests/operators/models/test_mono_exponential_decay.py
+++ b/tests/operators/models/test_mono_exponential_decay.py
@@ -59,6 +59,7 @@ def test_mono_exponential_decay_shape(parameter_shape, contrast_dim_shape, signa
     assert signal.shape == signal_shape
 
 
+@pytest.mark.filterwarnings('ignore:Anomaly Detection has been enabled')
 def test_autodiff_exponential_decay():
     """Test autodiff works for mono-exponential decay model."""
     model = MonoExponentialDecay(decay_time=20)

--- a/tests/operators/models/test_mono_exponential_decay.py
+++ b/tests/operators/models/test_mono_exponential_decay.py
@@ -19,6 +19,7 @@ import torch
 from mrpro.operators.models import MonoExponentialDecay
 from tests.conftest import SHAPE_VARIATIONS_SIGNAL_MODELS
 from tests.conftest import create_parameter_tensor_tuples
+from tests.helper import autodiff_of_operator_test
 
 
 @pytest.mark.parametrize(
@@ -56,3 +57,10 @@ def test_mono_exponential_decay_shape(parameter_shape, contrast_dim_shape, signa
     m0, decay_constant = create_parameter_tensor_tuples(parameter_shape, number_of_tensors=2)
     (signal,) = model_op.forward(m0, decay_constant)
     assert signal.shape == signal_shape
+
+
+def test_autodiff_exponential_decay():
+    """Test autodiff works for mono-exponential decay model."""
+    model = MonoExponentialDecay(decay_time=20)
+    m0, decay_constant = create_parameter_tensor_tuples(parameter_shape=(2, 5, 10, 10, 10), number_of_tensors=2)
+    autodiff_of_operator_test(model, m0, decay_constant)

--- a/tests/operators/models/test_saturation_recovery.py
+++ b/tests/operators/models/test_saturation_recovery.py
@@ -19,6 +19,7 @@ import torch
 from mrpro.operators.models import SaturationRecovery
 from tests.conftest import SHAPE_VARIATIONS_SIGNAL_MODELS
 from tests.conftest import create_parameter_tensor_tuples
+from tests.helper import autodiff_of_operator_test
 
 
 @pytest.mark.parametrize(
@@ -56,3 +57,11 @@ def test_saturation_recovery_shape(parameter_shape, contrast_dim_shape, signal_s
     m0, t1 = create_parameter_tensor_tuples(parameter_shape, number_of_tensors=2)
     (signal,) = model_op.forward(m0, t1)
     assert signal.shape == signal_shape
+
+
+@pytest.mark.filterwarnings('ignore:Anomaly Detection has been enabled')
+def test_autodiff_aturation_recovery():
+    """Test autodiff works for aturation recovery model."""
+    model = SaturationRecovery(ti=10)
+    m0, t1 = create_parameter_tensor_tuples((2, 5, 10, 10, 10), number_of_tensors=2)
+    autodiff_of_operator_test(model, m0, t1)

--- a/tests/operators/models/test_wasabi.py
+++ b/tests/operators/models/test_wasabi.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import torch
 from mrpro.operators.models import WASABI
 from tests.conftest import SHAPE_VARIATIONS_SIGNAL_MODELS
@@ -61,6 +62,7 @@ def test_WASABI_shape(parameter_shape, contrast_dim_shape, signal_shape):
     assert signal.shape == signal_shape
 
 
+@pytest.mark.filterwarnings('ignore:Anomaly Detection has been enabled')
 def test_autodiff_WASABI():
     """Test autodiff works for WASABI model."""
     offset, b0_shift, rb1, c, d = create_data(offset_max=300, n_offsets=2)

--- a/tests/operators/models/test_wasabi.py
+++ b/tests/operators/models/test_wasabi.py
@@ -18,6 +18,7 @@ import torch
 from mrpro.operators.models import WASABI
 from tests.conftest import SHAPE_VARIATIONS_SIGNAL_MODELS
 from tests.conftest import create_parameter_tensor_tuples
+from tests.helper import autodiff_of_operator_test
 
 
 def create_data(offset_max=500, n_offsets=101, b0_shift=0, rb1=1.0, c=1.0, d=2.0):
@@ -58,3 +59,10 @@ def test_WASABI_shape(parameter_shape, contrast_dim_shape, signal_shape):
     b0_shift, rb1, c, d = create_parameter_tensor_tuples(parameter_shape, number_of_tensors=4)
     (signal,) = model_op.forward(b0_shift, rb1, c, d)
     assert signal.shape == signal_shape
+
+
+def test_autodiff_WASABI():
+    """Test autodiff works for WASABI model."""
+    offset, b0_shift, rb1, c, d = create_data(offset_max=300, n_offsets=2)
+    wasabi_model = WASABI(offsets=offset)
+    autodiff_of_operator_test(wasabi_model, b0_shift, rb1, c, d)

--- a/tests/operators/models/test_wasabiti.py
+++ b/tests/operators/models/test_wasabiti.py
@@ -19,6 +19,7 @@ import torch
 from mrpro.operators.models import WASABITI
 from tests.conftest import SHAPE_VARIATIONS_SIGNAL_MODELS
 from tests.conftest import create_parameter_tensor_tuples
+from tests.helper import autodiff_of_operator_test
 
 
 def create_data(offset_max=500, n_offsets=101, b0_shift=0, rb1=1.0, t1=1.0):
@@ -89,3 +90,11 @@ def test_WASABITI_shape(parameter_shape, contrast_dim_shape, signal_shape):
     b0_shift, rb1, t1 = create_parameter_tensor_tuples(parameter_shape, number_of_tensors=3)
     (signal,) = model_op.forward(b0_shift, rb1, t1)
     assert signal.shape == signal_shape
+
+
+def test_autodiff_WASABITI():
+    """Test autodiff works for WASABITI model."""
+    offset, b0_shift, rb1, t1 = create_data(offset_max=300, n_offsets=2)
+    trec = torch.ones_like(offset) * t1
+    wasabiti_model = WASABITI(offsets=offset, trec=trec)
+    autodiff_of_operator_test(wasabiti_model, b0_shift, rb1, t1)

--- a/tests/operators/models/test_wasabiti.py
+++ b/tests/operators/models/test_wasabiti.py
@@ -92,6 +92,7 @@ def test_WASABITI_shape(parameter_shape, contrast_dim_shape, signal_shape):
     assert signal.shape == signal_shape
 
 
+@pytest.mark.filterwarnings('ignore:Anomaly Detection has been enabled')
 def test_autodiff_WASABITI():
     """Test autodiff works for WASABITI model."""
     offset, b0_shift, rb1, t1 = create_data(offset_max=300, n_offsets=2)

--- a/tests/operators/test_fast_fourier_op.py
+++ b/tests/operators/test_fast_fourier_op.py
@@ -20,6 +20,7 @@ from mrpro.operators import FastFourierOp
 
 from tests import RandomGenerator
 from tests.helper import dotproduct_adjointness_test
+from tests.helper import gradient_test
 
 
 @pytest.mark.parametrize(('npoints', 'a'), [(100, 20), (300, 20)])
@@ -86,14 +87,7 @@ def test_fast_fourier_op_grad(encoding_matrix, recon_matrix):
     # Create operator and apply
     ff_op = FastFourierOp(recon_matrix=recon_matrix, encoding_matrix=encoding_matrix)
 
-    # Gradient of the forward via vjp
-    with pytest.warns(ImportWarning, match='allow_ops_in_compiled_graph failed'):
-        (_, vjpfunc) = torch.func.vjp(ff_op.forward, u)
-    assert torch.allclose(vjpfunc((v,))[0], ff_op.adjoint(v)[0])
-
-    # Gradient of the adjoint via vjp
-    (_, vjpfunc) = torch.func.vjp(ff_op.adjoint, v)
-    assert torch.allclose(vjpfunc((u,))[0], ff_op.forward(u)[0])
+    gradient_test(ff_op, u, v)
 
 
 def test_fast_fourier_op_spatial_dim():

--- a/tests/operators/test_fast_fourier_op.py
+++ b/tests/operators/test_fast_fourier_op.py
@@ -74,6 +74,9 @@ def test_fast_fourier_op_adjoint(encoding_matrix, recon_matrix):
     ('encoding_matrix', 'recon_matrix'),
     [
         ((101, 201, 50), (13, 221, 64)),
+        ((100, 200, 50), (14, 220, 64)),
+        ((101, 201, 50), (14, 220, 64)),
+        ((100, 200, 50), (13, 221, 64)),
     ],
 )
 def test_fast_fourier_op_grad(encoding_matrix, recon_matrix):
@@ -86,7 +89,6 @@ def test_fast_fourier_op_grad(encoding_matrix, recon_matrix):
 
     # Create operator and apply
     ff_op = FastFourierOp(recon_matrix=recon_matrix, encoding_matrix=encoding_matrix)
-
     gradient_test(ff_op, u, v)
 
 

--- a/tests/operators/test_fast_fourier_op.py
+++ b/tests/operators/test_fast_fourier_op.py
@@ -70,19 +70,12 @@ def test_fast_fourier_op_adjoint(encoding_matrix, recon_matrix):
     dotproduct_adjointness_test(ff_op, u, v)
 
 
-@pytest.mark.parametrize(
-    ('encoding_matrix', 'recon_matrix'),
-    [
-        ((101, 201, 50), (13, 221, 64)),
-        ((100, 200, 50), (14, 220, 64)),
-        ((101, 201, 50), (14, 220, 64)),
-        ((100, 200, 50), (13, 221, 64)),
-    ],
-)
-def test_fast_fourier_op_grad(encoding_matrix, recon_matrix):
+def test_fast_fourier_op_grad():
     """Test the gradient of the Fast Fourier Op."""
 
     # Create test data
+    recon_matrix = (13, 221, 64)
+    encoding_matrix = (101, 201, 50)
     generator = RandomGenerator(seed=0)
     u = generator.complex64_tensor(recon_matrix)
     v = generator.complex64_tensor(encoding_matrix)

--- a/tests/operators/test_fast_fourier_op.py
+++ b/tests/operators/test_fast_fourier_op.py
@@ -20,6 +20,7 @@ from mrpro.operators import FastFourierOp
 
 from tests import RandomGenerator
 from tests.helper import dotproduct_adjointness_test
+from tests.helper import forward_mode_autodiff_of_linear_operator_test
 from tests.helper import gradient_of_linear_operator_test
 
 
@@ -83,6 +84,21 @@ def test_fast_fourier_op_grad():
     # Create operator and apply
     ff_op = FastFourierOp(recon_matrix=recon_matrix, encoding_matrix=encoding_matrix)
     gradient_of_linear_operator_test(ff_op, u, v)
+
+
+def test_fast_fourier_op_forward_mode_autodiff():
+    """Test forward-mode autodiff of the Fast Fourier Op."""
+
+    # Create test data
+    recon_matrix = (13, 221, 64)
+    encoding_matrix = (101, 201, 50)
+    generator = RandomGenerator(seed=0)
+    u = generator.complex64_tensor(recon_matrix)
+    v = generator.complex64_tensor(encoding_matrix)
+
+    # Create operator and apply
+    ff_op = FastFourierOp(recon_matrix=recon_matrix, encoding_matrix=encoding_matrix)
+    forward_mode_autodiff_of_linear_operator_test(ff_op, u, v)
 
 
 def test_fast_fourier_op_spatial_dim():

--- a/tests/operators/test_fast_fourier_op.py
+++ b/tests/operators/test_fast_fourier_op.py
@@ -20,7 +20,7 @@ from mrpro.operators import FastFourierOp
 
 from tests import RandomGenerator
 from tests.helper import dotproduct_adjointness_test
-from tests.helper import gradient_test
+from tests.helper import gradient_of_linear_operator_test
 
 
 @pytest.mark.parametrize(('npoints', 'a'), [(100, 20), (300, 20)])
@@ -89,7 +89,7 @@ def test_fast_fourier_op_grad(encoding_matrix, recon_matrix):
 
     # Create operator and apply
     ff_op = FastFourierOp(recon_matrix=recon_matrix, encoding_matrix=encoding_matrix)
-    gradient_test(ff_op, u, v)
+    gradient_of_linear_operator_test(ff_op, u, v)
 
 
 def test_fast_fourier_op_spatial_dim():

--- a/tests/operators/test_linear_operator.py
+++ b/tests/operators/test_linear_operator.py
@@ -1,0 +1,40 @@
+"""Tests for linear operator."""
+
+# Copyright 2023 Physikalisch-Technische Bundesanstalt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import pytest
+import torch
+from mrpro.data import KTrajectory
+from mrpro.data import SpatialDimension
+from mrpro.operators import FastFourierOp
+
+from tests import RandomGenerator
+from tests.data.test_trajectory import create_traj
+from tests.helper import dotproduct_adjointness_test
+
+
+def test_autograd_wrapper():
+    """Test the autograd wrapper using the fast fourier op as an example."""
+
+    # Create test data, gradcheck requires double precision
+    encoding_matrix = [5,10,15]
+    recon_matrix = [3,6,9]
+    generator = RandomGenerator(seed=0)
+    u = generator.complex128_tensor(recon_matrix)
+    v = generator.complex128_tensor(encoding_matrix)
+
+    # Create operator
+    ff_op = FastFourierOp(recon_matrix=recon_matrix, encoding_matrix=encoding_matrix)
+
+    torch.autograd.gradcheck.gradcheck(ff_op.forward, u.requires_grad_())
+    torch.autograd.gradcheck.gradcheck(ff_op.adjoint, v.requires_grad_())

--- a/tests/operators/test_linear_operator.py
+++ b/tests/operators/test_linear_operator.py
@@ -12,23 +12,18 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import pytest
 import torch
-from mrpro.data import KTrajectory
-from mrpro.data import SpatialDimension
 from mrpro.operators import FastFourierOp
 
 from tests import RandomGenerator
-from tests.data.test_trajectory import create_traj
-from tests.helper import dotproduct_adjointness_test
 
 
 def test_autograd_wrapper():
     """Test the autograd wrapper using the fast fourier op as an example."""
 
     # Create test data, gradcheck requires double precision
-    encoding_matrix = [5,10,15]
-    recon_matrix = [3,6,9]
+    encoding_matrix = [5, 10, 15]
+    recon_matrix = [3, 6, 9]
     generator = RandomGenerator(seed=0)
     u = generator.complex128_tensor(recon_matrix)
     v = generator.complex128_tensor(encoding_matrix)

--- a/tests/operators/test_linear_operator.py
+++ b/tests/operators/test_linear_operator.py
@@ -31,5 +31,5 @@ def test_autograd_wrapper():
     # Create operator
     ff_op = FastFourierOp(recon_matrix=recon_matrix, encoding_matrix=encoding_matrix)
 
-    torch.autograd.gradcheck.gradcheck(ff_op.forward, u.requires_grad_())
-    torch.autograd.gradcheck.gradcheck(ff_op.adjoint, v.requires_grad_())
+    torch.autograd.gradcheck(ff_op.forward, u.requires_grad_())
+    torch.autograd.gradcheck(ff_op.adjoint, v.requires_grad_())

--- a/tests/operators/test_sensitivity_op.py
+++ b/tests/operators/test_sensitivity_op.py
@@ -21,11 +21,11 @@ from mrpro.operators import SensitivityOp
 
 from tests import RandomGenerator
 from tests.helper import dotproduct_adjointness_test
+from tests.helper import forward_mode_autodiff_of_linear_operator_test
+from tests.helper import gradient_of_linear_operator_test
 
 
-def test_sensitivity_op_adjointness():
-    """Test Sensitivity operator adjoint property."""
-
+def create_sensitivity_op_and_domain_range():
     random_generator = RandomGenerator(seed=0)
 
     n_zyx = (2, 3, 4)
@@ -37,10 +37,24 @@ def test_sensitivity_op_adjointness():
     random_csmdata = CsmData(data=random_tensor, header=QHeader(fov=SpatialDimension(1.0, 1.0, 1.0)))
     sensitivity_op = SensitivityOp(random_csmdata)
 
-    # Check adjoint property
     u = random_generator.complex64_tensor(size=(*n_other, 1, *n_zyx))
     v = random_generator.complex64_tensor(size=(*n_other, n_coils, *n_zyx))
-    dotproduct_adjointness_test(sensitivity_op, u, v)
+    return sensitivity_op, u, v
+
+
+def test_sensitivity_op_adjointness():
+    """Test Sensitivity operator adjoint property."""
+    dotproduct_adjointness_test(*create_sensitivity_op_and_domain_range())
+
+
+def test_sensitivity_op_grad():
+    """Test gradient of sensitivity operator."""
+    gradient_of_linear_operator_test(*create_sensitivity_op_and_domain_range())
+
+
+def test_sensitivity_op_forward_mode_autodiff():
+    """Test forward-mode autodiff of sensitivity operator."""
+    forward_mode_autodiff_of_linear_operator_test(*create_sensitivity_op_and_domain_range())
 
 
 def test_sensitivity_op_csmdata_tensor():


### PR DESCRIPTION
closes #303 
closes #68

also addresses #8 

First test implementation to make autograd use adjoint of linear operators. 

Mypy does not like it, but I am not sure this can be fixed...
src/mrpro/operators/LinearOperator.py:41: error: Signature of "forward" incompatible with supertype "_SingleLevelFunction"  [override]
src/mrpro/operators/LinearOperator.py:41: note:      Superclass:
src/mrpro/operators/LinearOperator.py:41: note:          def forward(ctx: Any, *args: Any, **kwargs: Any) -> Any
src/mrpro/operators/LinearOperator.py:41: note:      Subclass:
src/mrpro/operators/LinearOperator.py:41: note:          @staticmethod
src/mrpro/operators/LinearOperator.py:41: note:          def forward(fw: Callable[[Tensor], Tensor], bw: Callable[[Tensor], Tensor], x: Tensor) -> Any

@fzimmermann89 could you explain a bit more what you meant with "a) forward and reverse mode autograd using torch.func work on both the .forward and the .adjoint" in #303?