### PR TITLE
Docker build for main

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,6 +68,9 @@ jobs:
           dockerfile=${{ matrix.dockerfile }}
           echo "image_name=${dockerfile/Dockerfile_/ghcr.io/ptb-mr/mrpro_}" >> $GITHUB_OUTPUT
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to GitHub Packages
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Run PyTest
         run: |
-          pytest -n auto -m "not cuda"
+          pytest -n 4 -m "not cuda"
 
   push_latest:
     name: Pull latest images and push to GCR with new tag

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths-ignore:
       - "**.md"
+  push:
+    branches:
+      - main
+
 
 jobs:
   get_dockerfiles:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,7 +28,6 @@ jobs:
           filters: |
             docker_toml:
               - 'docker/*'
-              - 'pyproject.toml'
               - '.github/workflows/docker.yml'
 
       - name: Do we need to do something?

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -79,7 +79,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./docker
           file: ./docker/${{ matrix.dockerfile }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths-ignore:
       - "**.md"
+  push:
+    branches:
+      - main
 
 jobs:
   get_dockerfiles:
@@ -28,6 +31,7 @@ jobs:
               - '.github/workflows/docker.yml'
 
       - run: |
+          echo "Push to main? ${{GITHUB_EVENT_NAME}}"
           echo "Rebuild containers? ${{ steps.filter.outputs.docker_toml }}"
 
       - id: set-matrix

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,8 @@ jobs:
               - 'pyproject.toml'
               - '.github/workflows/docker.yml'
 
-      - run: |
+      - name: Do we need to do something?
+        run: |
           echo "Push to main?"
           echo "Rebuild containers? ${{ steps.filter.outputs.docker_toml }}"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Do we need to do something?
         run: |
-          echo "Push to main?"
+          echo "Push to main? ${{ github.event_name }} "
           echo "Rebuild containers? ${{ steps.filter.outputs.docker_toml }}"
 
       - id: set-matrix

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,8 @@ jobs:
           echo "Push to main? ${{ github.event_name }} "
           echo "Rebuild containers? ${{ steps.filter.outputs.docker_toml }}"
 
-      - id: set-matrix
+      - name: Define docker image names
+        id: set-matrix
         if: steps.filter.outputs.docker_toml == 'true' || github.event_name == 'push'
         run: |
           cd ./docker/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   get_dockerfiles:
-    name: Get list of dockerfiles for different containers
+    name: Get list of Docker files for different containers
     runs-on: ubuntu-latest
     outputs:
       docker_toml: ${{ steps.filter.outputs.docker_toml }}
@@ -119,7 +119,7 @@ jobs:
           pytest -n 4 -m "not cuda"
 
   push_latest:
-    name: Create latest images and push to GCR
+    name: Pull latest images and push to GCR with new tag
     needs: [get_dockerfiles, test]
     if: ${{ needs.get_dockerfiles.outputs.docker_toml == 'true' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,7 +58,7 @@ jobs:
   push_test:
     name: Create test images and push to GCR
     needs: get_dockerfiles
-    if: needs.get_dockerfiles.outputs.docker_toml == 'true'
+    if: needs.get_dockerfiles.outputs.docker_toml == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -96,7 +96,7 @@ jobs:
   test:
     name: Test docker containers
     needs: [get_dockerfiles, push_test]
-    if: needs.get_dockerfiles.outputs.docker_toml == 'true'
+    if: needs.get_dockerfiles.outputs.docker_toml == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -126,7 +126,7 @@ jobs:
   push_latest:
     name: Pull latest images and push to GCR with new tag
     needs: [get_dockerfiles, test]
-    if: needs.get_dockerfiles.outputs.docker_toml == 'true'
+    if: needs.get_dockerfiles.outputs.docker_toml == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -75,7 +75,7 @@ jobs:
           username: ptb-mr
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Build and push docker image
         uses: docker/build-push-action@v5
         with:
           context: ./docker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,7 +58,7 @@ jobs:
   push_test:
     name: Create test images and push to GCR
     needs: get_dockerfiles
-    if: ${{ needs.get_dockerfiles.outputs.docker_toml == 'true' }}
+    if: needs.get_dockerfiles.outputs.docker_toml == 'true'
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -96,7 +96,7 @@ jobs:
   test:
     name: Test docker containers
     needs: [get_dockerfiles, push_test]
-    if: ${{ needs.get_dockerfiles.outputs.docker_toml == 'true' }}
+    if: needs.get_dockerfiles.outputs.docker_toml == 'true'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -126,7 +126,7 @@ jobs:
   push_latest:
     name: Pull latest images and push to GCR with new tag
     needs: [get_dockerfiles, test]
-    if: ${{ needs.get_dockerfiles.outputs.docker_toml == 'true' }}
+    if: needs.get_dockerfiles.outputs.docker_toml == 'true'
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,6 +32,7 @@ jobs:
               - '.github/workflows/docker.yml'
 
       - run: |
+          echo "Push to main?"
           echo "Rebuild containers? ${{ steps.filter.outputs.docker_toml }}"
 
       - id: set-matrix

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,7 +78,7 @@ jobs:
           username: ptb-mr
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push docker image
+      - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: ./docker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,8 +85,6 @@ jobs:
           file: ./docker/${{ matrix.dockerfile }}
           push: true
           tags: ${{ steps.image_name.outputs.image_name }}:test
-          cache-from: type=registry,ref=${{ steps.image_name.outputs.image_name }}:buildcache
-          cache-to: type=registry,ref=${{ steps.image_name.outputs.image_name }}:buildcache,mode=max
 
   test:
     name: Test docker containers
@@ -116,7 +114,7 @@ jobs:
 
       - name: Run PyTest
         run: |
-          pytest -n 4 -m "not cuda"
+          pytest -n auto -m "not cuda"
 
   push_latest:
     name: Pull latest images and push to GCR with new tag

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -82,6 +82,8 @@ jobs:
           file: ./docker/${{ matrix.dockerfile }}
           push: true
           tags: ${{ steps.image_name.outputs.image_name }}:test
+          cache-from: type=registry,ref=${{ steps.image_name.outputs.image_name }}:buildcache
+          cache-to: type=registry,ref=${{ steps.image_name.outputs.image_name }}:buildcache,mode=max
 
   test:
     name: Test docker containers

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
             docker_toml:
               - 'docker/*'
               - 'pyproject.toml'
-              - '/.github/workflows/docker.yml'
+              - '.github/workflows/docker.yml'
 
       - run: |
           echo "Rebuild containers? ${{ steps.filter.outputs.docker_toml }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ jobs:
           echo "Rebuild containers? ${{ steps.filter.outputs.docker_toml }}"
 
       - id: set-matrix
-        if: steps.filter.outputs.docker_toml == 'true'
+        if: steps.filter.outputs.docker_toml == 'true' || github.event_name == 'push'
         run: |
           cd ./docker/
           ls
@@ -49,7 +49,7 @@ jobs:
           echo "imagenames=$imagenames" >> $GITHUB_OUTPUT
 
       - name: Dockerfile overview
-        if: steps.filter.outputs.docker_toml == 'true'
+        if: steps.filter.outputs.docker_toml == 'true' || github.event_name == 'push'
         run: |
           echo "final list of dockerfiles: ${{ steps.set-matrix.outputs.dockerfiles }}"
           echo "final list of images: ${{ steps.set-matrix.outputs.imagenames }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
             docker_toml:
               - 'docker/*'
               - 'pyproject.toml'
-              - '/.github/docker.yml'
+              - '/.github/workflows/docker.yml'
 
       - run: |
           echo "Rebuild containers? ${{ steps.filter.outputs.docker_toml }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,7 +28,6 @@ jobs:
               - '.github/workflows/docker.yml'
 
       - run: |
-          echo "Push to main? ${{GITHUB_EVENT_NAME}}"
           echo "Rebuild containers? ${{ steps.filter.outputs.docker_toml }}"
 
       - id: set-matrix

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     paths-ignore:
       - "**.md"
-  push:
-    branches:
-      - main
 
 jobs:
   get_dockerfiles:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "pypulseq@git+https://github.com/imr-framework/pypulseq",
     "torchkbnufft>=1.4.0",
     "scipy>=1.12",
+    "nibabel",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "pypulseq@git+https://github.com/imr-framework/pypulseq",
     "torchkbnufft>=1.4.0",
     "scipy>=1.12",
-    "nibabel",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
evaluate #244

Wrong pathname meant that the docker build was not triggered if docker.yml was modified -> fixed

Currently the docker build pipeline is only run when certain files (files in the docker folder, docker.yml or pyproject.toml) are changed. For docker.yml or any other file in the docker folder this is all fine. 

Changes to pyproject.toml (e.g. adding a new package) on the other hand do not have any effect on the container build because the packages inside the container a created by a checkout of MRpro main branch. Afterwards we do run pytest inside the container which uses the new pyproject.toml. Afterwards we push the container image based on the old pyproject.toml to the registry and this container image is then used for all subsequent tests. If we never update any of the above mentioned files which trigger this docker pipeline, the container will never be updated to the latest pyproject.toml.

Therefore I removed the trigger which starts a new container build when pyproject.toml is changed (because it doesn't do anything, and it is tested anyway in the normal pytest pipeline) and I added a new trigger for all pushes to main. This will mean that we will build the container image more often than we need to but at least it will be up-to-date.