### PR TITLE
Consider user indices when sorting kdata

### DIFF
--- a/src/mrpro/data/_kdata/KData.py
+++ b/src/mrpro/data/_kdata/KData.py
@@ -124,10 +124,10 @@ class KData(KDataSplitMixin, KDataRearrangeMixin, KDataSelectMixin, KDataRemoveO
 
         acqinfo = AcqInfo.from_ismrmrd_acquisitions(acquisitions)
 
-        user_indices = (acqinfo.idx.user5, acqinfo.idx.user6)
+        user_index = (acqinfo.idx.user5, acqinfo.idx.user6)
 
-        for ind in user_indices:
-            if len(torch.unique(ind)) > 1:
+        for indx in user_index:
+            if len(torch.unique(indx)) > 1:
                 warnings.warn(
                     'The Siemens to ismrmrd converter currently (ab)uses '
                     'the user 5 and 6 indices for storing the kspace center line and partition number.\n'

--- a/src/mrpro/data/_kdata/KData.py
+++ b/src/mrpro/data/_kdata/KData.py
@@ -124,16 +124,16 @@ class KData(KDataSplitMixin, KDataRearrangeMixin, KDataSelectMixin, KDataRemoveO
 
         acqinfo = AcqInfo.from_ismrmrd_acquisitions(acquisitions)
 
-        for i in (5, 6):
-            user_indices = getattr(acqinfo.idx, f'user{i}', [])
-            for j in user_indices:
-                if j != 0:
-                    warnings.warn(
-                        'The Siemens to ismrmrd converter currently (ab)uses '
-                        f'the user {i} indices for storing the kspace center line and partition number\n'
-                        f'User {i} indices will be ignored',
-                        stacklevel=1,
-                    )
+        user_indices = (acqinfo.idx.user5, acqinfo.idx.user6)
+
+        for j in user_indices:
+            if len(torch.unique(user_indices)) > 1:
+                warnings.warn(
+                    'The Siemens to ismrmrd converter currently (ab)uses '
+                    f'the user {j} indices for storing the kspace center line and partition number\n'
+                    f'User {j} indices will be ignored',
+                    stacklevel=1,
+                )
 
         # Raises ValueError if required fields are missing in the header
         kheader = KHeader.from_ismrmrd(

--- a/src/mrpro/data/_kdata/KData.py
+++ b/src/mrpro/data/_kdata/KData.py
@@ -124,22 +124,16 @@ class KData(KDataSplitMixin, KDataRearrangeMixin, KDataSelectMixin, KDataRemoveO
 
         acqinfo = AcqInfo.from_ismrmrd_acquisitions(acquisitions)
 
-        for i in acqinfo.idx.user5:
-            if i != 0:
-                warnings.warn(
-                    'The Siemens to ismrmrd converter currently (ab)uses '
-                    'the user indices 5 for storing the kspace center line and partition number\n'
-                    'User 5 indices will be ignored',
-                    stacklevel=1,
-                )
-        for i in acqinfo.idx.user6:
-            if i != 0:
-                warnings.warn(
-                    'The Siemens to ismrmrd converter currently (ab)uses '
-                    'the user indices 6 for storing the kspace center line and partition number\n'
-                    'User 6 indices will be ignored',
-                    stacklevel=1,
-                )
+        for i in (5, 6):
+            user_indices = getattr(acqinfo.idx, f'user{i}', [])
+            for j in user_indices:
+                if j != 0:
+                    warnings.warn(
+                        'The Siemens to ismrmrd converter currently (ab)uses '
+                        f'the user {i} indices for storing the kspace center line and partition number\n'
+                        f'User {i} indices will be ignored',
+                        stacklevel=1,
+                    )
 
         # Raises ValueError if required fields are missing in the header
         kheader = KHeader.from_ismrmrd(

--- a/src/mrpro/data/_kdata/KData.py
+++ b/src/mrpro/data/_kdata/KData.py
@@ -43,9 +43,37 @@ from mrpro.data.traj_calculators.KTrajectoryCalculator import KTrajectoryCalcula
 from mrpro.data.traj_calculators.KTrajectoryIsmrmrd import KTrajectoryIsmrmrd
 from mrpro.utils import modify_acq_info
 
-KDIM_SORT_LABELS = ('k1', 'k2', 'average', 'slice', 'contrast', 'phase', 'repetition', 'set')
-# TODO: Consider adding the users labels here, but remember issue #32 and NOT add user5 and user6.
-OTHER_LABELS = ('average', 'slice', 'contrast', 'phase', 'repetition', 'set')
+KDIM_SORT_LABELS = (
+    'k1',
+    'k2',
+    'average',
+    'slice',
+    'contrast',
+    'phase',
+    'repetition',
+    'set',
+    'user0_idx',
+    'user1_idx',
+    'user2_idx',
+    'user3_idx',
+    'user4_idx',
+    'user7_idx',
+)
+
+OTHER_LABELS = (
+    'average',
+    'slice',
+    'contrast',
+    'phase',
+    'repetition',
+    'set',
+    'user0_idx',
+    'user1_idx',
+    'user2_idx',
+    'user3_idx',
+    'user4_idx',
+    'user7_idx',
+)
 
 
 @dataclasses.dataclass(slots=True, frozen=True)
@@ -95,6 +123,23 @@ class KData(KDataSplitMixin, KDataRearrangeMixin, KDataSelectMixin, KDataRemoveO
         kdata = torch.stack([torch.as_tensor(acq.data, dtype=torch.complex64) for acq in acquisitions])
 
         acqinfo = AcqInfo.from_ismrmrd_acquisitions(acquisitions)
+
+        for i in acqinfo.idx.user5:
+            if i != 0:
+                warnings.warn(
+                    'The Siemens to ismrmrd converter currently (ab)uses '
+                    'the user indices 5 for storing the kspace center line and partition number\n'
+                    'User 5 indices will be ignored',
+                    stacklevel=1,
+                )
+        for i in acqinfo.idx.user6:
+            if i != 0:
+                warnings.warn(
+                    'The Siemens to ismrmrd converter currently (ab)uses '
+                    'the user indices 6 for storing the kspace center line and partition number\n'
+                    'User 6 indices will be ignored',
+                    stacklevel=1,
+                )
 
         # Raises ValueError if required fields are missing in the header
         kheader = KHeader.from_ismrmrd(

--- a/src/mrpro/data/_kdata/KData.py
+++ b/src/mrpro/data/_kdata/KData.py
@@ -52,12 +52,12 @@ KDIM_SORT_LABELS = (
     'phase',
     'repetition',
     'set',
-    'user0_idx',
-    'user1_idx',
-    'user2_idx',
-    'user3_idx',
-    'user4_idx',
-    'user7_idx',
+    'user0',
+    'user1',
+    'user2',
+    'user3',
+    'user4',
+    'user7',
 )
 
 OTHER_LABELS = (
@@ -67,12 +67,12 @@ OTHER_LABELS = (
     'phase',
     'repetition',
     'set',
-    'user0_idx',
-    'user1_idx',
-    'user2_idx',
-    'user3_idx',
-    'user4_idx',
-    'user7_idx',
+    'user0',
+    'user1',
+    'user2',
+    'user3',
+    'user4',
+    'user7',
 )
 
 

--- a/src/mrpro/data/_kdata/KData.py
+++ b/src/mrpro/data/_kdata/KData.py
@@ -124,16 +124,21 @@ class KData(KDataSplitMixin, KDataRearrangeMixin, KDataSelectMixin, KDataRemoveO
 
         acqinfo = AcqInfo.from_ismrmrd_acquisitions(acquisitions)
 
-        user_index = (acqinfo.idx.user5, acqinfo.idx.user6)
+        if len(torch.unique(acqinfo.idx.user5)) > 1:
+            warnings.warn(
+                'The Siemens to ismrmrd converter currently (ab)uses '
+                'the user 5 indices for storing the kspace center line and partition number.\n'
+                'User 5 indices will be ignored',
+                stacklevel=1,
+            )
 
-        for indx in user_index:
-            if len(torch.unique(indx)) > 1:
-                warnings.warn(
-                    'The Siemens to ismrmrd converter currently (ab)uses '
-                    'the user 5 and 6 indices for storing the kspace center line and partition number.\n'
-                    'User 5 and 6 indices will be ignored',
-                    stacklevel=1,
-                )
+        if len(torch.unique(acqinfo.idx.user6)) > 1:
+            warnings.warn(
+                'The Siemens to ismrmrd converter currently (ab)uses '
+                'the user 6 indices for storing the kspace center line and partition number.\n'
+                'User 6 indices will be ignored',
+                stacklevel=1,
+            )
 
         # Raises ValueError if required fields are missing in the header
         kheader = KHeader.from_ismrmrd(

--- a/src/mrpro/data/_kdata/KData.py
+++ b/src/mrpro/data/_kdata/KData.py
@@ -126,12 +126,12 @@ class KData(KDataSplitMixin, KDataRearrangeMixin, KDataSelectMixin, KDataRemoveO
 
         user_indices = (acqinfo.idx.user5, acqinfo.idx.user6)
 
-        for j in user_indices:
-            if len(torch.unique(user_indices)) > 1:
+        for ind in user_indices:
+            if len(torch.unique(ind)) > 1:
                 warnings.warn(
                     'The Siemens to ismrmrd converter currently (ab)uses '
-                    f'the user {j} indices for storing the kspace center line and partition number\n'
-                    f'User {j} indices will be ignored',
+                    'the user 5 and 6 indices for storing the kspace center line and partition number.\n'
+                    'User 5 and 6 indices will be ignored',
                     stacklevel=1,
                 )
 

--- a/src/mrpro/data/_kdata/KData.py
+++ b/src/mrpro/data/_kdata/KData.py
@@ -127,7 +127,7 @@ class KData(KDataSplitMixin, KDataRearrangeMixin, KDataSelectMixin, KDataRemoveO
         if len(torch.unique(acqinfo.idx.user5)) > 1:
             warnings.warn(
                 'The Siemens to ismrmrd converter currently (ab)uses '
-                'the user 5 indices for storing the kspace center line and partition number.\n'
+                'the user 5 indices for storing the kspace center line number.\n'
                 'User 5 indices will be ignored',
                 stacklevel=1,
             )
@@ -135,7 +135,7 @@ class KData(KDataSplitMixin, KDataRearrangeMixin, KDataSelectMixin, KDataRemoveO
         if len(torch.unique(acqinfo.idx.user6)) > 1:
             warnings.warn(
                 'The Siemens to ismrmrd converter currently (ab)uses '
-                'the user 6 indices for storing the kspace center line and partition number.\n'
+                'the user 6 indices for storing the kspace center partition number.\n'
                 'User 6 indices will be ignored',
                 stacklevel=1,
             )


### PR DESCRIPTION
We ignore user index 5 and 6.
These are abused by the ismrmrd converter to store other information.
We now print a warning if these are used and use all other user idx for sorting

closes #32 