### PR TITLE
Add test for minimum dependencies

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -41,6 +41,25 @@ jobs:
         run: |
           echo "final list of images with tag latest: ${{ steps.set-matrix.outputs.imagenames }}"
 
+  test_min_dependency:
+    name: Run tests with minimum dependencies
+    needs: get_dockerfiles
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        imagename: ${{ fromJson(needs.get_dockerfiles.outputs.imagenames) }}
+    # runs within Docker container
+    container:
+      image: ghcr.io/ptb-mr/${{ matrix.imagename }}:latest
+      options: --user runner
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install mrpro with minimum dependencies
+        run: uv pip install --resolution "lowest
+
   test:
     name: Run tests and get coverage report
     needs: get_dockerfiles

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -104,29 +104,6 @@ jobs:
           script: |
             core.setFailed('PyTest workflow failed with ${{ steps.coverageComment.outputs.errors }} errors and ${{ steps.coverageComment.outputs.failures }} failures.')
 
-  test_min_dependency:
-    name: Run tests with minimum dependencies
-    needs: test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        imagename: ${{ fromJson(needs.get_dockerfiles.outputs.imagenames) }}
-    # runs within Docker container
-    container:
-      image: ghcr.io/ptb-mr/${{ matrix.imagename }}:latest
-      options: --user runner
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Install mrpro with minimum dependencies
-        run: uv pip install --resolution "lowest
-
-      - name: Run PyTest
-        run: |
-          pytest
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -41,29 +41,6 @@ jobs:
         run: |
           echo "final list of images with tag latest: ${{ steps.set-matrix.outputs.imagenames }}"
 
-  test_min_dependency:
-    name: Run tests with minimum dependencies
-    needs: get_dockerfiles
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        imagename: ${{ fromJson(needs.get_dockerfiles.outputs.imagenames) }}
-    # runs within Docker container
-    container:
-      image: ghcr.io/ptb-mr/${{ matrix.imagename }}:latest
-      options: --user runner
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Install mrpro with minimum dependencies
-        run: uv pip install --resolution "lowest
-
-      - name: Run PyTest
-        run: |
-          pytest
-
   test:
     name: Run tests and get coverage report
     needs: get_dockerfiles
@@ -126,6 +103,29 @@ jobs:
         with:
           script: |
             core.setFailed('PyTest workflow failed with ${{ steps.coverageComment.outputs.errors }} errors and ${{ steps.coverageComment.outputs.failures }} failures.')
+
+  test_min_dependency:
+    name: Run tests with minimum dependencies
+    needs: test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        imagename: ${{ fromJson(needs.get_dockerfiles.outputs.imagenames) }}
+    # runs within Docker container
+    container:
+      image: ghcr.io/ptb-mr/${{ matrix.imagename }}:latest
+      options: --user runner
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install mrpro with minimum dependencies
+        run: uv pip install --resolution "lowest
+
+      - name: Run PyTest
+        run: |
+          pytest
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -60,6 +60,10 @@ jobs:
       - name: Install mrpro with minimum dependencies
         run: uv pip install --resolution "lowest
 
+      - name: Run PyTest
+        run: |
+          pytest
+
   test:
     name: Run tests and get coverage report
     needs: get_dockerfiles

--- a/.github/workflows/test_min_dependencies.yml
+++ b/.github/workflows/test_min_dependencies.yml
@@ -46,7 +46,7 @@ jobs:
       run: pip install .[test]
 
     - name: Run tests
-      run: pytest
+      run: pytest -n 4 -m "not cuda"
 
     - name: Cleanup
       run: rm requirements-min.txt

--- a/.github/workflows/test_min_dependencies.yml
+++ b/.github/workflows/test_min_dependencies.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Create temporary requirements-min.txt
       run: |
         python -m pip install --upgrade pip
-        pip install toml, distutils
+        pip install toml distutils
 
         # Generate requirements-min.txt
         python - <<EOF

--- a/.github/workflows/test_min_dependencies.yml
+++ b/.github/workflows/test_min_dependencies.yml
@@ -26,17 +26,17 @@ jobs:
 
         # Generate requirements-min.txt
         python - <<EOF
-          import toml
+        import toml
 
-          with open('pyproject.toml', 'r') as f:
-              pyproject = toml.load(f)
+        with open('pyproject.toml', 'r') as f:
+            pyproject = toml.load(f)
 
-          dependencies = pyproject.get('project', {}).get('dependencies', [])
+        dependencies = pyproject.get('project', {}).get('dependencies', [])
 
-          with open('requirements-min.txt', 'w') as f:
-              for dep in dependencies:
-                  dep = dep.replace('>=', '==').split(',')[0]
-                  f.write(f"{dep}\n")
+        with open('requirements-min.txt', 'w') as f:
+            for dep in dependencies:
+                dep = dep.replace('>=', '==').split(',')[0]
+                f.write(f"{dep}\n")
         EOF
 
         # Install minimum dependencies

--- a/.github/workflows/test_min_dependencies.yml
+++ b/.github/workflows/test_min_dependencies.yml
@@ -43,7 +43,7 @@ jobs:
       run: pip install -r requirements-min.txt
 
     - name: Install the package
-      run: pip install .
+      run: pip install .[test]
 
     - name: Run tests
       run: pytest

--- a/.github/workflows/test_min_dependencies.yml
+++ b/.github/workflows/test_min_dependencies.yml
@@ -2,7 +2,7 @@ name: Test min dependencies
 
 on:
   schedule:
-    - cron: '5 15 * * *'
+    - cron: '0/10 * * * *'
 
 jobs:
   test_min_dependencies:

--- a/.github/workflows/test_min_dependencies.yml
+++ b/.github/workflows/test_min_dependencies.yml
@@ -1,6 +1,6 @@
 name: Run Tests with Minimum Dependencies
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   test:
@@ -19,10 +19,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
+    - name: Create temporary requirements-min.txt
       run: |
         python -m pip install --upgrade pip
-        pip install toml
+        pip install toml, distutils
 
         # Generate requirements-min.txt
         python - <<EOF
@@ -39,8 +39,8 @@ jobs:
                 f.write(f"{dep}\n")
         EOF
 
-        # Install minimum dependencies
-        pip install -r requirements-min.txt
+    - name: Install minimum dependencies
+      run: pip install -r requirements-min.txt
 
     - name: Install the package
       run: pip install .

--- a/.github/workflows/test_min_dependencies.yml
+++ b/.github/workflows/test_min_dependencies.yml
@@ -1,0 +1,28 @@
+name: Test min dependencies
+
+on:
+  schedule:
+    - cron: '5 15 * * *'
+
+jobs:
+  test_min_dependencies:
+    name: Run tests with min dependencies
+    runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: "${{needs.build_info.outputs.PYTHON_MIN_VERSION}}"
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install mrpro with minimum dependencies
+        run: uv pip install --resolution lowest .[test]
+
+      - name: Run PyTest with minimum dependencies
+        run: |
+          pytest -n 4 -m "not cuda" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=mrpro | tee pytest-coverage.txt
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+  # Cancel in-progress runs when a new workflow with the same group name is triggered
+  cancel-in-progress: true

--- a/.github/workflows/test_min_dependencies.yml
+++ b/.github/workflows/test_min_dependencies.yml
@@ -1,28 +1,52 @@
-name: Test min dependencies
+name: Run Tests with Minimum Dependencies
 
-on:
-  schedule:
-    - cron: '0/10 * * * *'
+on: [push, pull_request]
 
 jobs:
-  test_min_dependencies:
-    name: Run tests with min dependencies
+  test:
     runs-on: ubuntu-latest
-    env:
-      PYTHON_VERSION: "${{needs.build_info.outputs.PYTHON_MIN_VERSION}}"
+
+    strategy:
+      matrix:
+        python-version: [3.11, 3.12]
+
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
+    - name: Checkout code
+      uses: actions/checkout@v3
 
-      - name: Install mrpro with minimum dependencies
-        run: uv pip install --resolution lowest .[test]
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
 
-      - name: Run PyTest with minimum dependencies
-        run: |
-          pytest -n 4 -m "not cuda" --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=mrpro | tee pytest-coverage.txt
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install toml
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+        # Generate requirements-min.txt
+        python - <<EOF
+          import toml
 
-  # Cancel in-progress runs when a new workflow with the same group name is triggered
-  cancel-in-progress: true
+          with open('pyproject.toml', 'r') as f:
+              pyproject = toml.load(f)
+
+          dependencies = pyproject.get('project', {}).get('dependencies', [])
+
+          with open('requirements-min.txt', 'w') as f:
+              for dep in dependencies:
+                  dep = dep.replace('>=', '==').split(',')[0]
+                  f.write(f"{dep}\n")
+        EOF
+
+        # Install minimum dependencies
+        pip install -r requirements-min.txt
+
+    - name: Install the package
+      run: pip install .
+
+    - name: Run tests
+      run: pytest
+
+    - name: Cleanup
+      run: rm requirements-min.txt

--- a/.github/workflows/test_min_dependencies.yml
+++ b/.github/workflows/test_min_dependencies.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Create temporary requirements-min.txt
       run: |
         python -m pip install --upgrade pip
-        pip install toml distutils
+        pip install toml setuptools
 
         # Generate requirements-min.txt
         python - <<EOF

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
-    "numpy>=1.23, <2.0",
+    "numpy>=1.26, <2.0",
     "torch>=2.3",
     "ismrmrd>=1.14.1",
     "einops",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.26, <2.0",
-    "torch>=2.3",
+    "torch>=2.3.1",
     "ismrmrd>=1.14.1",
     "einops",
     "pydicom",


### PR DESCRIPTION
Things to do:
- [ ] change to scheduled run (once every day/week?) when finished testing

Required changes so far:
- increase mininum numpy version from 1.23 to 1.26 (required to install numpy in py311/py312)
- increase minium torch version from 2.3 to 2.3.1 to pass https://github.com/PTB-MR/mrpro/blob/bdf849c7e876d6ec96810a43479ae64a24bd0956/tests/data/test_movedatamixin.py#L90