### PR TITLE
Run pytest also for changes to .md

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,8 +2,6 @@ name: PyTest
 
 on:
   pull_request:
-    paths-ignore:
-      - "**.md"
 
 jobs:
   get_dockerfiles:


### PR DESCRIPTION
Currently we do not run pytest for the readme but we require that pytest has run for all PRs before they can be merged. Therefore the current PR #362 cannot be merged. 

If we require pytest to run before merge then we need to run it always.