### PR TITLE
SI unit conversion in dicom and unit info in docstring

### DIFF
--- a/src/mrpro/data/AcqInfo.py
+++ b/src/mrpro/data/AcqInfo.py
@@ -133,7 +133,7 @@ class AcqInfo(MoveDataMixin):
     """Unique ID corresponding to the readout."""
 
     number_of_samples: torch.Tensor
-    """Number of readout sample points per readout (readouts may have different number of sample points)."""
+    """Number of sample points per readout (readouts may have different number of sample points)."""
 
     patient_table_position: SpatialDimension[torch.Tensor]
     """Offset position of the patient table, in LPS coordinates [m]."""

--- a/src/mrpro/data/AcqInfo.py
+++ b/src/mrpro/data/AcqInfo.py
@@ -103,7 +103,7 @@ class AcqInfo(MoveDataMixin):
     """Indices describing acquisitions (i.e. readouts)."""
 
     acquisition_time_stamp: torch.Tensor
-    """Clock time stamp [s]."""
+    """Clock time stamp. Not in s but in vendor-specific time units (e.g. 2.5ms for Siemens)"""
 
     active_channels: torch.Tensor
     """Number of active receiver coil elements."""
@@ -142,7 +142,7 @@ class AcqInfo(MoveDataMixin):
     """Directional cosine of phase encoding (2D)."""
 
     physiology_time_stamp: torch.Tensor
-    """Time stamps relative to physiological triggering, e.g. ECG, pulse oximetry, respiratory [s]."""
+    """Time stamps relative to physiological triggering, e.g. ECG, pulse oximetry, respiratory."""
 
     position: SpatialDimension[torch.Tensor]
     """Center of the excited volume, in LPS coordinates relative to isocenter [m]."""

--- a/src/mrpro/data/AcqInfo.py
+++ b/src/mrpro/data/AcqInfo.py
@@ -142,7 +142,7 @@ class AcqInfo(MoveDataMixin):
     """Directional cosine of phase encoding (2D)."""
 
     physiology_time_stamp: torch.Tensor
-    """Time stamps relative to physiological triggering, e.g. ECG, pulse oximetry, respiratory."""
+    """Time stamps relative to physiological triggering, e.g. ECG. Not in s but in vendor-specific time units"""
 
     position: SpatialDimension[torch.Tensor]
     """Center of the excited volume, in LPS coordinates relative to isocenter [m]."""

--- a/src/mrpro/data/AcqInfo.py
+++ b/src/mrpro/data/AcqInfo.py
@@ -151,7 +151,7 @@ class AcqInfo(MoveDataMixin):
     """Directional cosine of readout/frequency encoding."""
 
     sample_time_us: torch.Tensor
-    """Readout bandwidth, as time between samples [ms]."""
+    """Readout bandwidth, as time between samples [us]."""
 
     scan_counter: torch.Tensor
     """Zero-indexed incrementing counter for readouts."""

--- a/src/mrpro/data/IHeader.py
+++ b/src/mrpro/data/IHeader.py
@@ -37,19 +37,19 @@ class IHeader(MoveDataMixin):
 
     # ToDo: decide which attributes to store in the header
     fov: SpatialDimension[float]
-    """Field of view."""
+    """Field of view [m]."""
 
     te: torch.Tensor | None
-    """Echo time."""
+    """Echo time [s]."""
 
     ti: torch.Tensor | None
-    """Inversion time."""
+    """Inversion time [s]."""
 
     fa: torch.Tensor | None
-    """Flip angle."""
+    """Flip angle [rad]."""
 
     tr: torch.Tensor | None
-    """Repetition time."""
+    """Repetition time [s]."""
 
     misc: dict = dataclasses.field(default_factory=dict)
     """Dictionary with miscellaneous parameters."""
@@ -107,15 +107,22 @@ class IHeader(MoveDataMixin):
             else:
                 return torch.as_tensor(values)
 
-        fa = make_unique_tensor(get_float_items_from_all_dicoms('FlipAngle'))
-        ti = make_unique_tensor(get_float_items_from_all_dicoms('InversionTime'))
-        tr = make_unique_tensor(get_float_items_from_all_dicoms('RepetitionTime'))
+        # Conversion functions for units
+        def ms_to_s(ms: torch.Tensor | None) -> torch.Tensor | None:
+            return None if ms is None else ms / 1000
+
+        def deg_to_rad(deg: torch.Tensor | None) -> torch.Tensor | None:
+            return None if deg is None else torch.deg2rad(deg)
+
+        fa = deg_to_rad(make_unique_tensor(get_float_items_from_all_dicoms('FlipAngle')))
+        ti = ms_to_s(make_unique_tensor(get_float_items_from_all_dicoms('InversionTime')))
+        tr = ms_to_s(make_unique_tensor(get_float_items_from_all_dicoms('RepetitionTime')))
 
         # get echo time(s). Some scanners use 'EchoTime', some use 'EffectiveEchoTime'
         te_list = get_float_items_from_all_dicoms('EchoTime')
         if all(val is None for val in te_list):  # check if all entries are None
             te_list = get_float_items_from_all_dicoms('EffectiveEchoTime')
-        te = make_unique_tensor(te_list)
+        te = ms_to_s(make_unique_tensor(te_list))
 
         fov_x_mm = get_float_items_from_all_dicoms('Rows')[0] * float(get_items_from_all_dicoms('PixelSpacing')[0][0])
         fov_y_mm = get_float_items_from_all_dicoms('Columns')[0] * float(

--- a/src/mrpro/data/KHeader.py
+++ b/src/mrpro/data/KHeader.py
@@ -26,7 +26,7 @@ import ismrmrd.xsd.ismrmrdschema.ismrmrd as ismrmrdschema
 import torch
 
 from mrpro.data import enums
-from mrpro.data.AcqInfo import AcqInfo
+from mrpro.data.AcqInfo import AcqInfo, mm_to_m, ms_to_s
 from mrpro.data.EncodingLimits import EncodingLimits
 from mrpro.data.MoveDataMixin import MoveDataMixin
 from mrpro.data.SpatialDimension import SpatialDimension
@@ -53,7 +53,7 @@ class KHeader(MoveDataMixin):
     """Function to calculate the k-space trajectory."""
 
     b0: float
-    """Magnetic field strength."""
+    """Magnetic field strength [T]."""
 
     encoding_limits: EncodingLimits
     """K-space encoding limits."""
@@ -62,19 +62,19 @@ class KHeader(MoveDataMixin):
     """Dimensions of the reconstruction matrix."""
 
     recon_fov: SpatialDimension[float]
-    """Field-of-view of the reconstructed image."""
+    """Field-of-view of the reconstructed image [m]."""
 
     encoding_matrix: SpatialDimension[int]
     """Dimensions of the encoded k-space matrix."""
 
     encoding_fov: SpatialDimension[float]
-    """Field of view of the image encoded by the k-space trajectory."""
+    """Field of view of the image encoded by the k-space trajectory [m]."""
 
     acq_info: AcqInfo
     """Information of the acquisitions (i.e. readout lines)."""
 
     h1_freq: float
-    """Lamor frequency of hydrogen nuclei."""
+    """Lamor frequency of hydrogen nuclei [Hz]."""
 
     n_coils: int | None = None
     """Number of receiver coils."""
@@ -83,19 +83,19 @@ class KHeader(MoveDataMixin):
     """Date and time of acquisition."""
 
     te: torch.Tensor | None = None
-    """Echo time."""
+    """Echo time [s]."""
 
     ti: torch.Tensor | None = None
-    """Inversion time."""
+    """Inversion time [s]."""
 
     fa: torch.Tensor | None = None
-    """Flip angle."""
+    """Flip angle [rad]."""
 
     tr: torch.Tensor | None = None
-    """Repetition time."""
+    """Repetition time [s]."""
 
     echo_spacing: torch.Tensor | None = None
-    """Echo spacing."""
+    """Echo spacing [s]."""
 
     echo_train_length: int = 1
     """Number of echoes in a multi-echo acquisition."""
@@ -166,14 +166,6 @@ class KHeader(MoveDataMixin):
         encoding_number
             as ismrmrdHeader can contain multiple encodings, selects which to consider
         """
-
-        # Conversion functions for units
-        def ms_to_s(ms: torch.Tensor) -> torch.Tensor:
-            return ms / 1000
-
-        def mm_to_m(m: float) -> float:
-            return m / 1000
-
         if not 0 <= encoding_number < len(header.encoding):
             raise ValueError(f'encoding_number must be between 0 and {len(header.encoding)}')
 

--- a/tests/data/test_idata.py
+++ b/tests/data/test_idata.py
@@ -33,7 +33,8 @@ def test_IData_from_dcm_folder(dcm_multi_echo_times):
     # Verify correct echo times
     original_echo_times = torch.as_tensor([ds.te for ds in dcm_multi_echo_times])
     assert idata.header.te is not None
-    assert torch.allclose(torch.sort(original_echo_times)[0], torch.sort(idata.header.te)[0])
+    # dicom expects echo times in ms, mrpro in s
+    assert torch.allclose(torch.sort(original_echo_times)[0] / 1000, torch.sort(idata.header.te)[0])
     # Verify all images were read in
     assert idata.data.shape[0] == original_echo_times.shape[0]
 
@@ -44,7 +45,8 @@ def test_IData_from_dcm_folder_via_path(dcm_multi_echo_times):
     # Verify correct echo times
     original_echo_times = torch.as_tensor([ds.te for ds in dcm_multi_echo_times])
     assert idata.header.te is not None
-    assert torch.allclose(torch.sort(original_echo_times)[0], torch.sort(idata.header.te)[0])
+    # dicom expects echo times in ms, mrpro in s
+    assert torch.allclose(torch.sort(original_echo_times)[0] / 1000, torch.sort(idata.header.te)[0])
     # Verify all images were read in
     assert idata.data.shape[0] == len(original_echo_times)
 
@@ -67,7 +69,8 @@ def test_IData_from_dcm_files(dcm_multi_echo_times_multi_folders):
     # Verify correct echo times
     original_echo_times = torch.as_tensor([ds.te for ds in dcm_multi_echo_times_multi_folders])
     assert idata.header.te is not None
-    assert torch.allclose(torch.sort(original_echo_times)[0], torch.sort(idata.header.te)[0])
+    # dicom expects echo times in ms, mrpro in s
+    assert torch.allclose(torch.sort(original_echo_times)[0] / 1000, torch.sort(idata.header.te)[0])
     # Verify all images were read in
     assert idata.data.shape[0] == len(original_echo_times)
 


### PR DESCRIPTION
As a follow up from the hackathon I verified that dicom requires ms for MR timing info and deg for flip angles. This is now converted to s and rad in MRpro. I added the unit info to the doc strings. Please check that I didn't miss anything.

Open points:

- `acquisition_time_stamp`: in ISMRMRD this is defined in Siemens time steps which is 2.5ms and is of type uint. One option would be to check if the file is from a Siemens scanner and then convert it to [s]. The same applies to `physiology_time_stamp`.

- `sample_time_us`: as the name suggests this is defined in [us]. Do we want to convert this to [s] and change the name of the variable to `sample_time`?