### PR TITLE
Fix warning in pickle test

### DIFF
--- a/tests/utils/test_rotation.py
+++ b/tests/utils/test_rotation.py
@@ -1209,6 +1209,8 @@ def test_rotation_within_numpy_object_array():
     assert array.shape == (3, 2)
 
 
+# Needed because of bug in torch 2.4.0. Should be fixed with 2.4.1
+@pytest.mark.filterwarnings('ignore::FutureWarning')
 def test_pickling():
     """Test pickling a Rotation"""
     r = Rotation.from_quat([0, 0, np.sin(torch.pi / 4), np.cos(torch.pi / 4)])


### PR DESCRIPTION
Due to a bug in pytorch there is a FutureWarning when calling pickle of a tensor: https://github.com/pytorch/pytorch/issues/130658

This will be solved with pytorch 2.4.1. I added an issue to remove `@pytest.mark.filterwarnings('ignore::FutureWarning')` again when we require at least 2.4.1.

Fixes one error reported in #371 