### PR TITLE
Fix doc string format

### DIFF
--- a/src/mrpro/algorithms/csm/iterative_walsh.py
+++ b/src/mrpro/algorithms/csm/iterative_walsh.py
@@ -30,7 +30,7 @@ def iterative_walsh(
     This is for a single set of coil images. The input should be a tensor with dimensions
     (coils, z, y, x). The output will have the same dimensions.
     Either apply this function individually to each set of coil images,
-    or see CsmData.from_idata_walsh which performs this operation on a whole dataset [1]_.
+    or see CsmData.from_idata_walsh which performs this operation on a whole dataset [WAL2000]_.
 
     This function is inspired by https://github.com/ismrmrd/ismrmrd-python-tools.
 
@@ -45,8 +45,7 @@ def iterative_walsh(
 
     References
     ----------
-    .. [1] Daval-Frerot G, Ciuciu P (2022) Iterative static field map estimation for off-resonance correction in
-           non-Cartesian susceptibility weighted imaging. MRM 88(4): mrm.29297.
+    .. [WAL2000] Walsh DO, Gmitro AF, Marcellin MW (2000) Adaptive reconstruction of phased array MR imagery. MRM 43
     """
     if isinstance(smoothing_width, int):
         smoothing_width = SpatialDimension(smoothing_width, smoothing_width, smoothing_width)

--- a/src/mrpro/algorithms/optimizers/adam.py
+++ b/src/mrpro/algorithms/optimizers/adam.py
@@ -57,7 +57,7 @@ def adam(
         whether to use the AMSGrad variant of this algorithm from the paper
         `On the Convergence of Adam and Beyond`
     decoupled_weight_decay
-        whether to use Adam (default) or AdamW (if set to true) [1]_
+        whether to use Adam (default) or AdamW (if set to true) [LOS2019]_
 
     Returns
     -------
@@ -65,8 +65,8 @@ def adam(
 
     References
     ----------
-    .. [1] Loshchilov I, Hutter F (2019) Decoupled Weight Decay Regularization. ICLR
-            https://doi.org/10.48550/arXiv.1711.05101
+    .. [LOS2019] Loshchilov I, Hutter F (2019) Decoupled Weight Decay Regularization. ICLR
+       https://doi.org/10.48550/arXiv.1711.05101
     """
     parameters = [p.detach().clone().requires_grad_(True) for p in initial_parameters]
 

--- a/src/mrpro/algorithms/optimizers/cg.py
+++ b/src/mrpro/algorithms/optimizers/cg.py
@@ -29,22 +29,23 @@ def cg(
     tolerance: float = 1e-4,
     callback: Callable | None = None,
 ) -> torch.Tensor:
-    """CG for solving a linear system Hx=b.
+    r"""CG for solving a linear system :math:`Hx=b`.
 
-    Thereby, H is a linear self-adjoint operator, b is the right-hand-side
-    of the system and x is the sought solution.
+    Thereby, :math:`H` is a linear self-adjoint operator, :math:`b` is the right-hand-side
+    of the system and :math:`x` is the sought solution.
 
-    Note that this implementation allows for simultaneously solving a batch of N problems
-    of the form
-        H_i x_i = b_i,      i=1,...,N.
-    Thereby, the underlying assumption is that the considered problem is H x = b with
-        H:= diag(H_1, ..., H_N), b:= [b_1, ..., b_N]^T.
-    Thus, if all H_i are self-adjoint, so is H and the CG can be applied.
+    Note that this implementation allows for simultaneously solving a batch of :math:`N` problems
+    of the form :math:`H_i x_i = b_i` with :math:`i=1,...,N`.
+
+    Thereby, the underlying assumption is that the considered problem is :math:`Hx=b` with
+    :math:`H:= diag(H_1, ..., H_N)` and  :math:`b:= [b_1, ..., b_N]^T`.
+
+    Thus, if all :math:`H_i` are self-adjoint, so is :math:`H` and the CG can be applied.
     Note however, that the accuracy of the obtained solutions might vary among the different
     problems.
     Note also that we don't test if the input operator is self-adjoint or not.
 
-    Further, note that if the condition of H is very large, a small residual does not necessarily
+    Further, note that if the condition of :math:`H` is very large, a small residual does not necessarily
     imply that the solution is accurate.
 
     Parameters

--- a/src/mrpro/algorithms/prewhiten_kspace.py
+++ b/src/mrpro/algorithms/prewhiten_kspace.py
@@ -24,16 +24,16 @@ from mrpro.data.KNoise import KNoise
 
 
 def prewhiten_kspace(kdata: KData, knoise: KNoise, scale_factor: float | torch.Tensor = 1.0) -> KData:
-    """Calculate noise prewhitening matrix and decorrelate coils [1]_ [2]_ [3]_.
+    """Calculate noise prewhitening matrix and decorrelate coils.
 
-    Step 1: Calculate noise correlation matrix N
-    Step 2: Carry out Cholesky decomposition L L^H = N
-    Step 3: Estimate noise decorrelation matrix D = inv(L)
-    Step 4: Apply D to k-space data
+    Steps:
 
-    More information can be found in
-    http://onlinelibrary.wiley.com/doi/10.1002/jmri.24687/full
-    https://doi.org/10.1002/mrm.1910160203
+    - Calculate noise correlation matrix N
+    - Carry out Cholesky decomposition L L^H = N
+    - Estimate noise decorrelation matrix D = inv(L)
+    - Apply D to k-space data
+
+    More information can be found in [ISMa]_ [HAN2014]_ [ROE1990]_.
 
     If the the data has more samples in the 'other'-dimensions (batch/slice/...),
     the noise covariance matrix is calculated jointly over all samples.
@@ -57,10 +57,10 @@ def prewhiten_kspace(kdata: KData, knoise: KNoise, scale_factor: float | torch.T
 
     References
     ----------
-    .. [1] https://github.com/ismrmrd/ismrmrd-python-tools
-    .. [2] Hansen M, Kellman P (2014) Image reconstruction: An overview for clinicians. JMRI 41(3): jmri.24687.
+    .. [ISMa] ISMRMRD Python tools https://github.com/ismrmrd/ismrmrd-python-tools
+    .. [HAN2014] Hansen M, Kellman P (2014) Image reconstruction: An overview for clinicians. JMRI 41(3)
             https://doi.org/10.1002/jmri.24687
-    .. [3] Roemer P, Mueller O (1990) The NMR phased array. MRM 16(2): mrm.1910160203.
+    .. [ROE1990] Roemer P, Mueller O (1990) The NMR phased array. MRM 16(2)
             https://doi.org/10.1002/mrm.1910160203
     """
     # Reshape noise to (coil, everything else)

--- a/src/mrpro/data/EncodingLimits.py
+++ b/src/mrpro/data/EncodingLimits.py
@@ -49,12 +49,11 @@ class Limits:
 
 @dataclass(slots=True)
 class EncodingLimits:
-    """Encoding limits dataclass with limits for each attribute [1]_.
+    """Encoding limits dataclass with limits for each attribute [INA2016]_.
 
     References
     ----------
-    .. [1] Inati S, Hanse M (2016) ISMRM Raw data format:
-    A proposed standard for MRI raw datasets. MRM 77(1): mrm.26089.
+    .. [INA2016] Inati S, Hansen M (2016) ISMRM Raw data format: A proposed standard for MRI raw datasets. MRM 77(1)
         https://doi.org/10.1002/mrm.26089
 
     """

--- a/src/mrpro/data/IData.py
+++ b/src/mrpro/data/IData.py
@@ -34,16 +34,16 @@ from mrpro.data.KHeader import KHeader
 def _dcm_pixelarray_to_tensor(dataset: Dataset) -> torch.Tensor:
     """Transform pixel array in dicom file to tensor.
 
-    "Rescale intercept, (0028|1052), and rescale slope (0028|1053) are
+    Rescale intercept, (0028|1052), and rescale slope (0028|1053) are
     DICOM tags that specify the linear transformation from pixels in
     their stored on disk representation to their in memory
     representation.     U = m*SV + b where U is in output units, m is
     the rescale slope, SV is the stored value, and b is the rescale
-    intercept." [1]_
+    intercept. [RES]_
 
     References
     ----------
-    .. [1] https://www.kitware.com/dicom-rescale-intercept-rescale-slope-and-itk/
+    .. [RES] Rescale intercept and slope https://www.kitware.com/dicom-rescale-intercept-rescale-slope-and-itk/
     """
     slope = (
         float(element.value)
@@ -73,15 +73,12 @@ class IData(Data):
         Parameters
         ----------
         keepdim
-            if True, the output tensor has the same number of dimensions as the data tensor,
-               and the coil dimension is kept as a singleton dimension.
-            If False, the coil dimension is removed.
+            if True, the output tensor has the same number of dimensions as the data tensor, and the coil dimension is
+            kept as a singleton dimension. If False, the coil dimension is removed.
 
         Returns
         -------
-            image data tensor with shape either
-            (..., 1, z, y, x) if keepdim is True.
-            or (..., z, y, x), if  keepdim if False.
+            image data tensor with shape (..., 1, z, y, x) if keepdim is True or (..., z, y, x) if keepdim is False.
         """
         coildim = -4
         return self.data.abs().square().sum(dim=coildim, keepdim=keepdim).sqrt()

--- a/src/mrpro/data/MoveDataMixin.py
+++ b/src/mrpro/data/MoveDataMixin.py
@@ -73,7 +73,7 @@ class MoveDataMixin:
         """Perform dtype and/or device conversion of data.
 
         A torch.dtype and torch.device are inferred from the arguments
-        of self.to(*args, **kwargs). Please have a look at the
+        args and kwargs. Please have a look at the
         documentation of torch.Tensor.to() for more details.
 
         A new instance of the dataclass will be returned.
@@ -82,15 +82,16 @@ class MoveDataMixin:
         fields of the dataclass, and to all fields that implement
         the MoveDataMixin.
 
-        The dtype-type, i.e. float/complex will always be preserved,
+        The dtype-type, i.e. float or complex will always be preserved,
         but the precision of floating point dtypes might be changed.
 
         Example:
-            If called with dtype=torch.float32 OR dtype=torch.complex64:
-                - A complex128 tensor will be converted to complex64
-                - A float64 tensor will be converted to float32
-                - A bool tensor will remain bool
-                - An int64 tensor will remain int64
+        If called with dtype=torch.float32 OR dtype=torch.complex64:
+
+        - A complex128 tensor will be converted to complex64
+        - A float64 tensor will be converted to float32
+        - A bool tensor will remain bool
+        - An int64 tensor will remain int64
 
         If other conversions are desired, please use the torch.Tensor.to() method of
         the fields directly.

--- a/src/mrpro/data/_kdata/KDataProtocol.py
+++ b/src/mrpro/data/_kdata/KDataProtocol.py
@@ -27,11 +27,11 @@ class _KDataProtocol(Protocol):
     Note that the actual KData class can have more properties and methods than those defined here.
 
     If you want to use a property or method of KData in a new KDataMixin class,
-    you must add it to this Protocol to make sure that the type hinting works [1]_.
+    you must add it to this Protocol to make sure that the type hinting works [PRO]_.
 
     References
     ----------
-    .. [1] https://typing.readthedocs.io/en/latest/spec/protocol.html#protocols
+    .. [PRO] Protocols https://typing.readthedocs.io/en/latest/spec/protocol.html#protocols
     """
 
     @property

--- a/src/mrpro/data/_kdata/KDataRemoveOsMixin.py
+++ b/src/mrpro/data/_kdata/KDataRemoveOsMixin.py
@@ -24,7 +24,7 @@ class KDataRemoveOsMixin(_KDataProtocol):
     """Remove oversampling along readout dimension."""
 
     def remove_readout_os(self: Self) -> Self:
-        """Remove any oversampling along the readout (k0) direction [1]_.
+        """Remove any oversampling along the readout (k0) direction [GAD]_.
 
         Returns a copy of the data.
 
@@ -44,7 +44,7 @@ class KDataRemoveOsMixin(_KDataProtocol):
 
         References
         ----------
-        .. [1] https://github.com/gadgetron/gadgetron-python
+        .. [GAD] Gadgetron https://github.com/gadgetron/gadgetron-python
         """
         from mrpro.operators.FastFourierOp import FastFourierOp
 

--- a/src/mrpro/data/enums.py
+++ b/src/mrpro/data/enums.py
@@ -21,11 +21,11 @@ class AcqFlags(Flag):
     """Acquisition flags.
 
     NOTE: values in enum ISMRMRD_AcquisitionFlags start at 1 and not 0, but
-    1 << (val-1) is used in 'ismrmrd_is_flag_set' function to calc bitmask value [1]_.
+    1 << (val-1) is used in 'ismrmrd_is_flag_set' function to calc bitmask value [ISMb]_.
 
     References
     ----------
-    .. [1] https://github.com/ismrmrd/ismrmrd/blob/master/include/ismrmrd/ismrmrd.h
+    .. [ISMb] ISMRMRD https://github.com/ismrmrd/ismrmrd/blob/master/include/ismrmrd/ismrmrd.h
     """
 
     ACQ_NO_FLAG = 0

--- a/src/mrpro/data/traj_calculators/KTrajectoryIsmrmrd.py
+++ b/src/mrpro/data/traj_calculators/KTrajectoryIsmrmrd.py
@@ -25,7 +25,7 @@ from mrpro.data.KTrajectoryRawShape import KTrajectoryRawShape
 class KTrajectoryIsmrmrd:
     """Get trajectory in ISMRMRD raw data file.
 
-    The trajectory in the ISMRMRD raw data file is read out [1]_.
+    The trajectory in the ISMRMRD raw data file is read out [TRA]_.
 
     The value range of the trajectory in the ISMRMRD file is not well defined. Here we simple normalize everything
     based on the highest value and ensure it is within [-pi, pi]. The trajectory is in the shape of the unsorted
@@ -33,7 +33,7 @@ class KTrajectoryIsmrmrd:
 
     References
     ----------
-    .. [1] https://ismrmrd.readthedocs.io/en/latest/mrd_raw_data.html#k-space-trajectory
+    .. [TRA] ISMRMRD trajectory https://ismrmrd.readthedocs.io/en/latest/mrd_raw_data.html#k-space-trajectory
     """
 
     def __call__(self, acquisitions: Sequence[ismrmrd.Acquisition]) -> KTrajectoryRawShape:

--- a/src/mrpro/data/traj_calculators/KTrajectoryRpe.py
+++ b/src/mrpro/data/traj_calculators/KTrajectoryRpe.py
@@ -25,16 +25,15 @@ class KTrajectoryRpe(KTrajectoryCalculator):
     """Radial phase encoding trajectory.
 
     Frequency encoding along kx is carried out in a standard Cartesian way. The phase encoding points along ky and kz
-    are positioned along radial lines [1]_ [2]_.
+    are positioned along radial lines [BOU2009]_ [KOL2014]_.
 
     References
     ----------
-    .. [1] Boubertakh R, Schaeffter T (2009) Whole-heart imaging using undersampled radial phase encoding (RPE)
-    and iterative sensitivity encoding (SENSE) reconstruction. MRM 62(5): mrm.22102.
-            https://doi.org/10.1002/mrm.22102
-    .. [2] Kolbitsch C, Schaeffter T (2014) A 3D MR-acquisition scheme for nonrigid bulk motion correction
-    in simultaneous PET-MR. Medical Physics 41(8): 1.4890095.
-            https://doi.org/10.1118/1.4890095
+    .. [BOU2009] Boubertakh R, Schaeffter T (2009) Whole-heart imaging using undersampled radial phase encoding (RPE)
+        and iterative sensitivity encoding (SENSE) reconstruction. MRM 62(5) https://doi.org/10.1002/mrm.22102
+
+    .. [KOL2014] Kolbitsch C, Schaeffter T (2014) A 3D MR-acquisition scheme for nonrigid bulk motion correction
+        in simultaneous PET-MR. Medical Physics 41(8) https://doi.org/10.1118/1.4890095
     """
 
     def __init__(self, angle: float, shift_between_rpe_lines: tuple | torch.Tensor = (0, 0.5, 0.25, 0.75)) -> None:
@@ -58,7 +57,7 @@ class KTrajectoryRpe(KTrajectoryCalculator):
 
         Example: shift_between_rpe_lines = [0, 0.5, 0.25, 0.75] leads to a shift of the 0th line by 0,
         the 1st line by 0.5, the 2nd line by 0.25, the 3rd line by 0.75, the 4th line by 0, the 5th line
-        by 0.5 and so on. Phase encoding points in k-space center are not shifted [1]_.
+        by 0.5 and so on. Phase encoding points in k-space center are not shifted [PRI2010]_.
 
         Line #          k-space points before shift             k-space points after shift
         0               +    +    +    +    +    +    +         +    +    +    +    +    +    +
@@ -77,9 +76,8 @@ class KTrajectoryRpe(KTrajectoryCalculator):
 
         References
         ----------
-        .. [1] Prieto C, Schaeffter T (2010) 3D undersampled golden-radial phase encoding
-        for DCE-MRA using inherently regularized iterative SENSE. MRM 64(2): mrm.22446.
-                https://doi.org/10.1002/mrm.22446
+        .. [PRI2010] Prieto C, Schaeffter T (2010) 3D undersampled golden-radial phase encoding
+        for DCE-MRA using inherently regularized iterative SENSE. MRM 64(2). https://doi.org/10.1002/mrm.22446
         """
         for ind, shift in enumerate(self.shift_between_rpe_lines):
             curr_angle_idx = torch.nonzero(

--- a/src/mrpro/operators/EinsumOp.py
+++ b/src/mrpro/operators/EinsumOp.py
@@ -21,36 +21,34 @@ from mrpro.operators.LinearOperator import LinearOperator
 
 
 class EinsumOp(LinearOperator):
-    """A Linear Operator that implements sum products in einstein notation.
+    r"""A Linear Operator that implements sum products in Einstein notation.
 
-    Implements A_{indices_A}*x^{indices_x} = y{indices_y}
+    Implements :math:`A_{indices_A}*x^{indices_x} = y_{indices_y}`
     with Einstein summation rules over the indices, see torch.einsum or einops.einsum
     for more information. Note, that the indices must be space separated (einops convention).
 
 
     It can be used to implement tensor contractions, such as for example, different versions of
-    matrix-vector / matrix-matrix products of the form A @ x, depending on the chosen einsum rules and
-    shapes of A and x.
+    matrix-vector or matrix-matrix products of the form :math:`A @ x`, depending on the chosen einsum rules and
+    shapes of :math:`A` and :math:`x`.
 
     Examples are:
-    - matrix-vector multiplication of A and the batched vector x = [x1,...,xN] consisting
-      of N vectors x1, x2, ..., xN. Then, the operation defined by
-        A @ x := diag(A, A, ..., A) * [x1, x2, ..., xN]^T = [A*x1, A*x2, ..., A*xN]^T
-      can be implemented by the einsum rule
-        "i j, ... j -> ... i"
 
-    - matrix-vector multiplication of a matrix A consisting of N different matrices
-      A1, A2, ... AN with one vector x. Then, the operation defined by
-        A @ x: = diag(A1, A2,..., AN) * [x, x, ..., x]^T
-      can be implemented by the einsum rule
-        "... i j, j -> ... i"
+    - matrix-vector multiplication of :math:`A` and the batched vector :math:`x = [x1,...,xN]` consisting
+      of :math:`N` vectors :math:`x1, x2, ..., xN`. Then, the operation defined by
+      :math:`A @ x := diag(A, A, ..., A) * [x1, x2, ..., xN]^T = [A*x1, A*x2, ..., A*xN]^T`
+      can be implemented by the einsum rule ``"i j, ... j -> ... i"``.
 
-    - matrix-vector multiplication of a matrix A consisting of N different matrices
-      A1, A2, ... AN with a vector x = [x1,...,xN] consisting
-      of N vectors x1, x2, ..., xN. Then, the operation defined by
-        A @ x: = diag(A1, A2,..., AN) * [x1, x2, ..., xN]^T
-      can be implemented by the einsum rule
-        "... i j, ... j -> ... i"
+    - matrix-vector multiplication of a matrix :math:`A` consisting of :math:`N` different matrices
+      :math:`A1, A2, ... AN` with one vector :math:`x`. Then, the operation defined by
+      :math:`A @ x: = diag(A1, A2,..., AN) * [x, x, ..., x]^T`
+      can be implemented by the einsum rule ``"... i j, j -> ... i"``.
+
+    - matrix-vector multiplication of a matrix :math:`A` consisting of :math:`N` different matrices
+      :math:`A1, A2, ... AN` with a vector :math:`x = [x1,...,xN]` consisting
+      of :math:`N` vectors :math:`x1, x2, ..., xN`. Then, the operation defined by
+      :math:`A @ x: = diag(A1, A2,..., AN) * [x1, x2, ..., xN]^T`
+      can be implemented by the einsum rule ``"... i j, ... j -> ... i"``.
       This is the default behaviour of the operator.
     """
 
@@ -60,7 +58,7 @@ class EinsumOp(LinearOperator):
         Parameters
         ----------
         matrix
-            'Matrix' `A` to be used as first factor in the sum product A*x
+            'Matrix' :math:`A` to be used as first factor in the sum product :math:`A*x`
 
         einsum_rule
             Einstein summation rule describing the forward of the operator.

--- a/src/mrpro/operators/FastFourierOp.py
+++ b/src/mrpro/operators/FastFourierOp.py
@@ -31,7 +31,7 @@ class FastFourierOp(LinearOperator):
     along these selected dimensions
 
     The transformation is done with 'ortho' normalization, i.e. the normalization constant is split between
-    forward and adjoint [1]_.
+    forward and adjoint [FFT]_.
 
     Remark regarding the fftshift/ifftshift:
     fftshift shifts the zero-frequency point to the center of the data, ifftshift undoes this operation.
@@ -41,7 +41,7 @@ class FastFourierOp(LinearOperator):
 
     References
     ----------
-    .. [1] https://numpy.org/doc/stable/reference/routines.fft.html
+    .. [FFT] FFT https://numpy.org/doc/stable/reference/routines.fft.html
 
     """
 

--- a/src/mrpro/operators/GridSamplingOp.py
+++ b/src/mrpro/operators/GridSamplingOp.py
@@ -177,12 +177,12 @@ class GridSamplingOp(LinearOperator):
         padding_mode: Literal['zeros', 'border', 'reflection'] = 'zeros',
         align_corners: bool = False,
     ):
-        """Initialize Sampling Operator.
+        r"""Initialize Sampling Operator.
 
         Parameters
         ----------
         grid
-            sampling grid. Shape *batchdim, z,y,x,3 / *batchdim, y,x,2.
+            sampling grid. Shape \*batchdim, z,y,x,3 / \*batchdim, y,x,2.
             Values should be in [-1, 1.]
         input_shape
             Used in the adjoint. The z,y,x shape of the domain of the operator.

--- a/src/mrpro/operators/functionals/MSEDataDiscrepancy.py
+++ b/src/mrpro/operators/functionals/MSEDataDiscrepancy.py
@@ -23,14 +23,11 @@ from mrpro.operators.Operator import Operator
 class MSEDataDiscrepancy(Operator[torch.Tensor, tuple[torch.Tensor]]):
     """Mean Squared Error (MSE) loss function.
 
-        This class implements the function
-            1./N * || . - data ||_2^2,
-        where N equals to the number of elements of the tensor.
+    This class implements the function :math:`1./N * || . - data ||_2^2`, where :math:`N` equals to the number of
+    elements of the tensor.
 
-        N.B. if one of data or input is complex-valued, we
-        identify the space C^N with R^2N and multiply the output
-        by 2. By this, we achieve that for example
-            MSE(1) = MSE(1+1j*0) = 1.
+    Note: if one of data or input is complex-valued, we identify the space :math:`C^N` with :math:`R^{2N}` and
+    multiply the output by 2. By this, we achieve that for example :math:`MSE(1)` = :math:`MSE(1+1j*0)` = 1.
 
     Parameters
     ----------

--- a/src/mrpro/operators/models/InversionRecovery.py
+++ b/src/mrpro/operators/models/InversionRecovery.py
@@ -49,8 +49,7 @@ class InversionRecovery(SignalModel[torch.Tensor, torch.Tensor]):
 
         Returns
         -------
-            signal
-            with shape (time ... other, coils, z, y, x)
+            signal with shape (time ... other, coils, z, y, x)
         """
         delta_ndim = m0.ndim - (self.ti.ndim - 1)  # -1 for time
         ti = self.ti[..., *[None] * (delta_ndim)] if delta_ndim > 0 else self.ti

--- a/src/mrpro/operators/models/MOLLI.py
+++ b/src/mrpro/operators/models/MOLLI.py
@@ -52,8 +52,7 @@ class MOLLI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
 
         Returns
         -------
-            signal
-            with shape (time ... other, coils, z, y, x)
+            signal with shape (time ... other, coils, z, y, x)
         """
         delta_ndim = a.ndim - (self.ti.ndim - 1)  # -1 for time
         ti = self.ti[..., *[None] * (delta_ndim)] if delta_ndim > 0 else self.ti

--- a/src/mrpro/operators/models/MonoExponentialDecay.py
+++ b/src/mrpro/operators/models/MonoExponentialDecay.py
@@ -49,8 +49,7 @@ class MonoExponentialDecay(SignalModel[torch.Tensor, torch.Tensor]):
 
         Returns
         -------
-            signal
-            with shape (time ... other, coils, z, y, x)
+            signal with shape (time ... other, coils, z, y, x)
         """
         delta_ndim = m0.ndim - (self.decay_time.ndim - 1)  # -1 for time
         decay_time = self.decay_time[..., *[None] * (delta_ndim)] if delta_ndim > 0 else self.decay_time

--- a/src/mrpro/operators/models/SaturationRecovery.py
+++ b/src/mrpro/operators/models/SaturationRecovery.py
@@ -49,8 +49,7 @@ class SaturationRecovery(SignalModel[torch.Tensor, torch.Tensor]):
 
         Returns
         -------
-            signal
-            with shape (time ... other, coils, z, y, x)
+            signal with shape (time ... other, coils, z, y, x)
         """
         delta_ndim = m0.ndim - (self.ti.ndim - 1)  # -1 for time
         ti = self.ti[..., *[None] * (delta_ndim)] if delta_ndim > 0 else self.ti

--- a/src/mrpro/operators/models/TransientSteadyStateWithPreparation.py
+++ b/src/mrpro/operators/models/TransientSteadyStateWithPreparation.py
@@ -20,40 +20,39 @@ from mrpro.operators.SignalModel import SignalModel
 
 
 class TransientSteadyStateWithPreparation(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
-    """Signal model for transient steady state.
+    r"""Signal model for transient steady state.
 
     This signal model describes the behavior of the longitudinal magnetisation during continuous acquisition after
     a preparation pulse. The effect of the preparation pulse is modelled by a scaling factor applied to the
     equilibrium magnetisation. A delay after the preparation pulse can be defined. During this time T1 relaxation to M0
     occurs. Data acquisition starts after this delay. Perfect spoiling is assumed and hence T2 effects are not
-    considered in the model. In addition this model assumes TR << T1 and TR << T1* (see definition below) [1]_ [2]_.
+    considered in the model. In addition this model assumes :math:`TR << T1` and :math:`TR << T1^*`
+    (see definition below) [DEI1992]_ [LOO1970]_.
 
     Let's assume we want to describe a continuous acquisition after an inversion pulse, then we have three parts:
     [Part A: 180° inversion pulse][Part B: spoiler gradient][Part C: Continuous data acquisition]
 
-    Part A: The 180° pulse leads to an inversion of the equilibrium magnetisation (M0) to -M0. This can be described by
-            setting the scaling factor m0_scaling_preparation to -1
+    - Part A: The 180° pulse leads to an inversion of the equilibrium magnetisation (:math:`M_0`) to :math:`-M_0`.
+      This can be described by setting the scaling factor ``m0_scaling_preparation`` to -1.
 
-    Part B: Commonly after an inversion pulse a strong spoiler gradient is played out to compensate for non-perfect
-            inversion. During this time the magnetisation follows Mz(t) the signal model:
-                    Mz(t) = M0 + (m0_scaling_preparation*M0 - M0)e^(-t / T1)
+    - Part B: Commonly after an inversion pulse a strong spoiler gradient is played out to compensate for non-perfect
+      inversion. During this time the magnetisation :math:`M_z(t)` follows the signal model:
+      :math:`M_z(t) = M_0 + (s * M_0 - M_0)e^{(-t / T1)}` where :math:`s` is ``m0_scaling_preparation``.
 
-    Part C: After the spoiler gradient the data acquisition starts and the magnetisation Mz(t) can be described by the
-            signal model:
-                    Mz(t) = M0* + (M0_init - M0*)e^(-t / T1*)
-            where the initial magnetisation is
-                    M0_init = M0 + (m0_scaling_preparation*M0 - M0)e^(-delay_after_preparation / T1)
-            the effective longitudinal relaxation time is
-                    T1* = 1/(1/T1 - 1/repetition_time ln(cos(flip_angle)))
-            and the steady-state magnetisation is
-                    M0* = M0 T1* / T1
+    - Part C: After the spoiler gradient the data acquisition starts and the magnetisation :math:`M_z(t)` can be
+      described by the signal model: :math:`M_z(t) = M_0^* + (M_{init} - M_0^*)e^{(-t / T1^*)}` where the initial
+      magnetisation is :math:`M_{init} = M_0 + (s*M_0 - M_0)e^{(-\Delta t / T1)}` where :math:`s` is
+      ``m0_scaling_preparation`` and :math:`\Delta t` is ``delay_after_preparation``. The effective longitudinal
+      relaxation time is :math:`T1^* = 1/(1/T1 - ln(cos(\alpha)/TR)`
+      where :math:`TR` is ``repetition_time`` and :math:`\alpha` is ``flip_angle``.
+      The steady-state magnetisation is :math:`M_0^* = M_0 T1^* / T1`.
 
     References
     ----------
-    .. [1] Deichmann R, Haase A (1992) Quantification of T1 values by SNAPSHOT-FLASH NMR imaging. J. Magn. Reson. 612
-        http://doi.org/10.1016/0022-2364(92)90347-A
-    .. [2] Look D, Locker R (1970) Time Saving in Measurement of NMR and EPR Relaxation Times. Rev. Sci. Instrum 41
-        https://doi.org/10.1063/1.1684482
+    .. [DEI1992] Deichmann R, Haase A (1992) Quantification of T1 values by SNAPSHOT-FLASH NMR imaging. J. Magn. Reson.
+       612 http://doi.org/10.1016/0022-2364(92)90347-A
+    .. [LOO1970] Look D, Locker R (1970) Time Saving in Measurement of NMR and EPR Relaxation Times. Rev. Sci. Instrum
+       41 https://doi.org/10.1063/1.1684482
     """
 
     def __init__(
@@ -105,8 +104,7 @@ class TransientSteadyStateWithPreparation(SignalModel[torch.Tensor, torch.Tensor
 
         Returns
         -------
-            signal
-            with shape (time ... other, coils, z, y, x)
+            signal with shape (time ... other, coils, z, y, x)
         """
         delta_ndim = m0.ndim - (self.sampling_time.ndim - 1)  # -1 for time
         sampling_time = self.sampling_time[..., *[None] * (delta_ndim)] if delta_ndim > 0 else self.sampling_time

--- a/src/mrpro/operators/models/WASABI.py
+++ b/src/mrpro/operators/models/WASABI.py
@@ -31,7 +31,7 @@ class WASABI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
         gamma: float | torch.Tensor = 42.5764,
         freq: float | torch.Tensor = 127.7292,
     ) -> None:
-        """Initialize WASABI signal model for mapping of B0 and B1 [1]_.
+        """Initialize WASABI signal model for mapping of B0 and B1 [SCHU2016]_.
 
         Parameters
         ----------
@@ -49,9 +49,8 @@ class WASABI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
 
         References
         ----------
-        .. [1] Schuenke P, Zaiss M (2016) Simultaneous mapping of water shift
-        and B1(WASABI)—Application to field-Inhomogeneity correction of CEST MRI data. MRM 77(2): mrm.26133.
-               https://doi.org/10.1002/mrm.26133
+        .. [SCHU2016] Schuenke P, Zaiss M (2016) Simultaneous mapping of water shift and B1(WASABI)—Application to
+           field-Inhomogeneity correction of CEST MRI data. MRM 77(2). https://doi.org/10.1002/mrm.26133
         """
         super().__init__()
         # convert all parameters to tensors
@@ -93,8 +92,7 @@ class WASABI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
 
         Returns
         -------
-            signal
-            with shape (offsets ... other, coils, z, y, x)
+            signal with shape (offsets ... other, coils, z, y, x)
         """
         delta_ndim = b0_shift.ndim - (self.offsets.ndim - 1)  # -1 for offset
         offsets = self.offsets[..., *[None] * (delta_ndim)] if delta_ndim > 0 else self.offsets

--- a/src/mrpro/operators/models/WASABITI.py
+++ b/src/mrpro/operators/models/WASABITI.py
@@ -32,18 +32,14 @@ class WASABITI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
         gamma: float | torch.Tensor = 42.5764,
         freq: float | torch.Tensor = 127.7292,
     ) -> None:
-        """Initialize WASABITI signal model for mapping of B0, B1 and T1 [1]_.
-
-        For more details see: Proc. Intl. Soc. Mag. Reson. Med. 31 (2023): 0906
+        """Initialize WASABITI signal model for mapping of B0, B1 and T1 [PAP2023]_.
 
         Parameters
         ----------
         offsets
-            frequency offsets [Hz]
-            with shape (offsets, ...)
+            frequency offsets [Hz] with shape (offsets, ...)
         trec
-            recovery time between offsets [s]
-            with shape (offsets, ...)
+            recovery time between offsets [s] with shape (offsets, ...)
         tp
             RF pulse duration [s]
         b1_nom
@@ -55,9 +51,8 @@ class WASABITI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
 
         References
         ----------
-        .. [1] Papageorgakis C, Casagranda S (2023) Fast WASABI post-processing:
-        Access to rapid B0 and B1 correction in clinical routine for CEST MRI. MRM 102(203-2011).
-               https://doi.org/10.1016/j.mri.2023.06.001
+        .. [PAP2023] Papageorgakis C, Casagranda S (2023) Fast WASABI post-processing: Access to rapid B0 and B1
+           correction in clinical routine for CEST MRI. MRM 102. https://doi.org/10.1016/j.mri.2023.06.001
         """
         super().__init__()
         # convert all parameters to tensors
@@ -94,8 +89,7 @@ class WASABITI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
 
         Returns
         -------
-            signal
-            with shape (offsets ... other, coils, z, y, x)
+            signal with shape (offsets ... other, coils, z, y, x)
         """
         delta_ndim = b0_shift.ndim - (self.offsets.ndim - 1)  # -1 for offset
         offsets = self.offsets[..., *[None] * (delta_ndim)] if delta_ndim > 0 else self.offsets

--- a/src/mrpro/operators/models/WASABITI.py
+++ b/src/mrpro/operators/models/WASABITI.py
@@ -18,7 +18,7 @@ class WASABITI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
         gamma: float | torch.Tensor = 42.5764,
         freq: float | torch.Tensor = 127.7292,
     ) -> None:
-        """Initialize WASABITI signal model for mapping of B0, B1 and T1 [PAP2023]_.
+        """Initialize WASABITI signal model for mapping of B0, B1 and T1 [SCH2023]_.
 
         Parameters
         ----------
@@ -37,8 +37,9 @@ class WASABITI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
 
         References
         ----------
-        .. [PAP2023] Papageorgakis C, Casagranda S (2023) Fast WASABI post-processing: Access to rapid B0 and B1
-           correction in clinical routine for CEST MRI. MRM 102. https://doi.org/10.1016/j.mri.2023.06.001
+        .. [SCH2023] Schuenke P, Zimmermann F, Kaspar K, Zaiss M, Kolbitsch C (2023) An Analytic Solution for the
+           Modified WASABI Method: Application to Simultaneous B0, B1 and T1 Mapping and Correction of CEST MRI,
+           Proceedings of the Annual Meeting of ISMRM
         """
         super().__init__()
         # convert all parameters to tensors

--- a/src/mrpro/phantoms/EllipsePhantom.py
+++ b/src/mrpro/phantoms/EllipsePhantom.py
@@ -57,7 +57,7 @@ class EllipsePhantom:
 
         For a corresponding image with 256 x 256 voxel, the k-space locations should be defined within [-128, 127]
 
-        The Fourier representation of ellipses can be analytically described by Bessel functions [1]_.
+        The Fourier representation of ellipses can be analytically described by Bessel functions [KOA2007]_.
 
         Parameters
         ----------
@@ -68,9 +68,8 @@ class EllipsePhantom:
 
         References
         ----------
-        .. [1] Koay C, Sarlls J, Özarslan E (2007) Three-dimensional analytical magnetic resonance imaging
-        phantom in the Fourier domain. MRM 58(2): mrm.21292.
-               https://doi.org/10.1002/mrm.21292
+        .. [KOA2007] Koay C, Sarlls J, Oezarslan E (2007) Three-dimensional analytical magnetic resonance imaging
+           phantom in the Fourier domain. MRM 58(2) https://doi.org/10.1002/mrm.21292
         ..
         """
         # kx and ky have to be of same shape

--- a/src/mrpro/phantoms/coils.py
+++ b/src/mrpro/phantoms/coils.py
@@ -41,12 +41,12 @@ def birdcage_2d(
     normalize_with_rss
         If set to true, the calculated sensitivities are normalized by the root-sum-of-squares
 
-    This function is strongly inspired by ISMRMRD Python Tools [1]_. The associated license
+    This function is strongly inspired by ISMRMRD Python Tools [ISMc]_. The associated license
     information can be found at the end of this file.
 
     References
     ----------
-    .. [1] https://github.com/ismrmrd/ismrmrd-python-tools
+    .. [ISMc] ISMRMRD Python tools https://github.com/ismrmrd/ismrmrd-python-tools
     """
     dim = [number_of_coils, image_dimensions.y, image_dimensions.x]
     x_co, y_co = torch.meshgrid(

--- a/src/mrpro/phantoms/coils.py
+++ b/src/mrpro/phantoms/coils.py
@@ -29,6 +29,9 @@ def birdcage_2d(
 ) -> torch.Tensor:
     """Numerical simulation of 2D Birdcage coil sensitivities.
 
+    This function is strongly inspired by ISMRMRD Python Tools [ISMc]_. The associated license
+    information can be found at the end of this file.
+
     Parameters
     ----------
     number_of_coils
@@ -40,9 +43,6 @@ def birdcage_2d(
         relative radius of birdcage
     normalize_with_rss
         If set to true, the calculated sensitivities are normalized by the root-sum-of-squares
-
-    This function is strongly inspired by ISMRMRD Python Tools [ISMc]_. The associated license
-    information can be found at the end of this file.
 
     References
     ----------

--- a/src/mrpro/utils/Rotation.py
+++ b/src/mrpro/utils/Rotation.py
@@ -625,6 +625,7 @@ class Rotation(torch.nn.Module):
             - First angle belongs to [-180, 180] degrees (both inclusive)
             - Third angle belongs to [-180, 180] degrees (both inclusive)
             - Second angle belongs to:
+
              + [-90, 90] degrees if all axes are different (like xyz)
              + [0, 180] degrees if first and third axes are the same (like zxz)
 
@@ -698,7 +699,7 @@ class Rotation(torch.nn.Module):
 
         - As a projection of vector components expressed in the final frame to the original frame.
         - As the physical rotation of a vector being glued to the original frame as it rotates. In this case the vector
-        components are expressed in the original frame before and after the rotation.
+          components are expressed in the original frame before and after the rotation.
 
         In terms of rotation matrices, this application is the same as
         ``self.as_matrix() @ vectors``.

--- a/src/mrpro/utils/Rotation.py
+++ b/src/mrpro/utils/Rotation.py
@@ -255,6 +255,7 @@ class Rotation(torch.nn.Module):
     """A pytorch implementation of scipy.spatial.transform.Rotation.
 
     Differences compared to scipy.spatial.transform.Rotation:
+
     - torch.nn.Module based, the quaternions are a Parameter
     - .apply is replaced by call/forward.
     - not all features are implemented. Notably, mrp, davenport, and reduce are missing.
@@ -264,8 +265,7 @@ class Rotation(torch.nn.Module):
     def __init__(self, quaternions: torch.Tensor | _NestedSequence[float], normalize: bool = True, copy: bool = True):
         """Initialize a new Rotation.
 
-        Instead of calling this method, also consider the different
-        from_* class methods to construct a Rotation.
+        Instead of calling this method, also consider the different ``from_*`` class methods to construct a Rotation.
 
         Parameters
         ----------
@@ -314,7 +314,7 @@ class Rotation(torch.nn.Module):
     def from_quat(cls, quaternions: torch.Tensor | _NestedSequence[float]) -> Self:
         """Initialize from quaternions.
 
-        3D rotations can be represented using unit-norm quaternions [1]_.
+        3D rotations can be represented using unit-norm quaternions [QUAa]_.
 
         Parameters
         ----------
@@ -331,7 +331,7 @@ class Rotation(torch.nn.Module):
 
         References
         ----------
-        .. [1] https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation
+        .. [QUAa] Quaternions and spatial rotation https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation
         """
         if not isinstance(quaternions, torch.Tensor):
             quaternions = torch.as_tensor(quaternions)
@@ -342,8 +342,8 @@ class Rotation(torch.nn.Module):
         """Initialize from rotation matrix.
 
         Rotations in 3 dimensions can be represented with 3 x 3 proper
-        orthogonal matrices [1]_. If the input is not proper orthogonal,
-        an approximation is created using the method described in [2]_.
+        orthogonal matrices [ROTa]_. If the input is not proper orthogonal,
+        an approximation is created using the method described in [MAR2008]_.
 
         Parameters
         ----------
@@ -358,10 +358,9 @@ class Rotation(torch.nn.Module):
 
         References
         ----------
-        .. [1] https://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions
-        .. [2] F. Landis Markley, "Unit Quaternion from Rotation Matrix",
-               Journal of guidance, control, and dynamics vol. 31.2, pp.
-               440-442, 2008.
+        .. [ROTa] Rotation matrix https://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions
+        .. [MAR2008] Landis Markley F (2008) Unit Quaternion from Rotation Matrix, Journal of guidance, control, and
+           dynamics 31(2),440-442.
         """
         if not isinstance(matrix, torch.Tensor):
             matrix = torch.as_tensor(matrix)
@@ -421,7 +420,7 @@ class Rotation(torch.nn.Module):
 
         The three rotations can either be in a global frame of reference
         (extrinsic) or in a body centred frame of reference (intrinsic), which
-        is attached to, and moves with, the object under rotation [1]_.
+        is attached to, and moves with, the object under rotation [EULa]_.
 
         Parameters
         ----------
@@ -446,7 +445,7 @@ class Rotation(torch.nn.Module):
 
         References
         ----------
-        .. [1] https://en.wikipedia.org/wiki/Euler_angles#Definition_by_intrinsic_rotations
+        .. [EULa] Euler angles https://en.wikipedia.org/wiki/Euler_angles#Definition_by_intrinsic_rotations
         """
         n_axes = len(seq)
         if n_axes < 1 or n_axes > 3:
@@ -501,7 +500,7 @@ class Rotation(torch.nn.Module):
         """Represent as quaternions.
 
         Active rotations in 3 dimensions can be represented using unit norm
-        quaternions [1]_. The mapping from quaternions to rotations is
+        quaternions [QUAb]_. The mapping from quaternions to rotations is
         two-to-one, i.e. quaternions ``q`` and ``-q``, where ``-q`` simply
         reverses the sign of each component, represent the same spatial
         rotation. The returned value is in scalar-last (x, y, z, w) format.
@@ -522,7 +521,7 @@ class Rotation(torch.nn.Module):
 
         References
         ----------
-        .. [1] https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation
+        .. [QUAb] Quaternions https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation
         """
         quaternions: torch.Tensor = self._quaternions
         if canonical:
@@ -535,7 +534,7 @@ class Rotation(torch.nn.Module):
         """Represent as rotation matrix.
 
         3D rotations can be represented using rotation matrices, which
-        are 3 x 3 real orthogonal matrices with determinant equal to +1 [1]_.
+        are 3 x 3 real orthogonal matrices with determinant equal to +1 [ROTb]_.
 
         Returns
         -------
@@ -544,7 +543,7 @@ class Rotation(torch.nn.Module):
 
         References
         ----------
-        .. [1] https://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions
+        .. [ROTb] Rotation matrix https://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions
         """
         quaternions = self._quaternions
         matrix = _quaternion_to_matrix(quaternions)
@@ -557,7 +556,7 @@ class Rotation(torch.nn.Module):
         """Represent as rotation vectors.
 
         A rotation vector is a 3 dimensional vector which is co-directional to
-        the axis of rotation and whose norm gives the angle of rotation [1]_.
+        the axis of rotation and whose norm gives the angle of rotation [ROTc]_.
 
         Parameters
         ----------
@@ -571,7 +570,7 @@ class Rotation(torch.nn.Module):
 
         References
         ----------
-        .. [1] https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation#Rotation_vector
+        .. [ROTc] Rotation vector https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation#Rotation_vector
         """
         quaternions: torch.Tensor = self._quaternions
         quaternions = _canonical_quaternion(quaternions)  # w > 0 ensures that 0 <= angle <= pi
@@ -594,12 +593,12 @@ class Rotation(torch.nn.Module):
 
         Any orientation can be expressed as a composition of 3 elementary
         rotations. Once the axis sequence has been chosen, Euler angles define
-        the angle of rotation around each respective axis [1]_.
+        the angle of rotation around each respective axis [EULb]_.
 
-        The algorithm from [2]_ has been used to calculate Euler angles for the
+        The algorithm from [BER2022]_ has been used to calculate Euler angles for the
         rotation about a given sequence of axes.
 
-        Euler angles suffer from the problem of gimbal lock [3]_, where the
+        Euler angles suffer from the problem of gimbal lock [GIM]_, where the
         representation loses a degree of freedom and it is not possible to
         determine the first and third angles uniquely. In this case,
         a warning is raised, and the third angle is set to zero. Note however
@@ -609,7 +608,7 @@ class Rotation(torch.nn.Module):
         ----------
         seq
             3 characters belonging to the set {'X', 'Y', 'Z'} for intrinsic
-            rotations, or {'x', 'y', 'z'} for extrinsic rotations [1]_.
+            rotations, or {'x', 'y', 'z'} for extrinsic rotations [EULb]_.
             Adjacent axes cannot be the same.
             Extrinsic and intrinsic rotations cannot be mixed in one function
             call.
@@ -622,21 +621,19 @@ class Rotation(torch.nn.Module):
         angles
             shape (3,) or (..., 3), depending on shape of inputs used to initialize object.
             The returned angles are in the range:
+
             - First angle belongs to [-180, 180] degrees (both inclusive)
             - Third angle belongs to [-180, 180] degrees (both inclusive)
             - Second angle belongs to:
-                - [-90, 90] degrees if all axes are different (like xyz)
-                - [0, 180] degrees if first and third axes are the same
-                  (like zxz)
+             + [-90, 90] degrees if all axes are different (like xyz)
+             + [0, 180] degrees if first and third axes are the same (like zxz)
 
         References
         ----------
-        .. [1] https://en.wikipedia.org/wiki/Euler_angles#Definition_by_intrinsic_rotations
-        .. [2] Bernardes E, Viollet S (2022) Quaternion to Euler angles
-               conversion: A direct, general and computationally efficient
-               method. PLoS ONE 17(11): e0276302.
-               https://doi.org/10.1371/journal.pone.0276302
-        .. [3] https://en.wikipedia.org/wiki/Gimbal_lock#In_applied_mathematics
+        .. [EULb] Euler Angles https://en.wikipedia.org/wiki/Euler_angles#Definition_by_intrinsic_rotations
+        .. [BER2022] Bernardes E, Viollet S (2022) Quaternion to Euler angles conversion: A direct, general and
+           computationally efficient method. PLoS ONE 17(11) https://doi.org/10.1371/journal.pone.0276302
+        .. [GIM] Gimbal lock https://en.wikipedia.org/wiki/Gimbal_lock#In_applied_mathematics
         """
         if len(seq) != 3:
             raise ValueError(f'Expected 3 axes, got {seq}.')
@@ -699,11 +696,9 @@ class Rotation(torch.nn.Module):
         If the original frame rotates to the final frame by this rotation, then
         its application to a vector can be seen in two ways:
 
-            - As a projection of vector components expressed in the final frame
-              to the original frame.
-            - As the physical rotation of a vector being glued to the original
-              frame as it rotates. In this case the vector components are
-              expressed in the original frame before and after the rotation.
+        - As a projection of vector components expressed in the final frame to the original frame.
+        - As the physical rotation of a vector being glued to the original frame as it rotates. In this case the vector
+        components are expressed in the original frame before and after the rotation.
 
         In terms of rotation matrices, this application is the same as
         ``self.as_matrix() @ vectors``.
@@ -724,6 +719,7 @@ class Rotation(torch.nn.Module):
         rotated_vectors
             Result of applying rotation on input vectors.
             Shape depends on the following cases:
+
                 - If object contains a single rotation (as opposed to a stack
                   with a single rotation) and a single vector is specified with
                   shape ``(3,)``, then `rotated_vectors` has shape ``(3,)``.
@@ -1213,14 +1209,10 @@ class Rotation(torch.nn.Module):
         r"""Get the mean of the rotations.
 
         The mean used is the chordal L2 mean (also called the projected or
-        induced arithmetic mean) [1]_. If ``A`` is a set of rotation matrices,
+        induced arithmetic mean) [HAR2013]_. If ``A`` is a set of rotation matrices,
         then the mean ``M`` is the rotation matrix that minimizes the
         following loss function:
-
-        .. math::
-
-            L(M) = \\sum_{i = 1}^{n} w_i \\lVert \\mathbf{A}_i -
-            \\mathbf{M} \\rVert^2 ,
+        :math:`L(M) = \sum_{i = 1}^{n} w_i \lVert \mathbf{A}_i - \mathbf{M} \rVert^2`,
 
         where :math:`w_i`'s are the `weights` corresponding to each matrix.
 
@@ -1247,8 +1239,8 @@ class Rotation(torch.nn.Module):
 
         References
         ----------
-        .. [1] Hartley R, Li H (2013) Rotation Averaging. International Journal of Computer Vision (103)
-               https://link.springer.com/article/10.1007/s11263-012-0601-0
+        .. [HAR2013] Hartley R, Li H (2013) Rotation Averaging. International Journal of Computer Vision (103)
+           https://link.springer.com/article/10.1007/s11263-012-0601-0
 
         """
         if weights is None:


### PR DESCRIPTION
This fixes lots of formatting errors in our doc strings. Spinx now runs through without any serious errors. 

Closes #335 
Closes #336 

Some comments for future reference:
- References, e.g. [xyz]_ in doc strings need to be unique, therefore I changed our numbering [1]_ to letters [KOL2012]_
- pylance (which shows the doc string if you hover over the function name in vs code) does not support latex formatting: https://github.com/microsoft/vscode/issues/168100. Therefore inline math using `:math:'some nice latex'` works better than using `.. math:: some nice latex`. vs code still does not render it correctly but at least it removes :math: and displays "some nice latex" as a differently formatted string. 
- Please always check that your doc strings are actually displayed as you think they will be displayed, e.g. having two separate lines after `Returns` leads to a list with bullet points.