### PR TITLE
Fix errors due to pydicom 3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,10 @@ notebook = [
 # PyTest section
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-filterwarnings = ["error:::mrpro"]
+filterwarnings = [
+    "error",
+    "ignore:'write_like_original':DeprecationWarning:pydicom:"
+]
 addopts = "-n auto"
 markers = ["cuda : Tests only to be run when cuda device is available"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "torch>=2.3",
     "ismrmrd>=1.14.1",
     "einops",
-    "pydicom",
+    "pydicom>=2.3",
     "pypulseq>=1.4.2",
     "torchkbnufft>=1.4.0",
     "scipy>=1.12",
@@ -63,7 +63,7 @@ notebook = [
 # PyTest section
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-filterwarnings = ["error"]
+filterwarnings = ["error:::mrpro"]
 addopts = "-n auto"
 markers = ["cuda : Tests only to be run when cuda device is available"]
 

--- a/src/mrpro/data/IHeader.py
+++ b/src/mrpro/data/IHeader.py
@@ -64,10 +64,8 @@ class IHeader(MoveDataMixin):
 
         def get_item(dataset: Dataset, name: TagType):
             """Get item with a given name or Tag from a pydicom dataset."""
-            tag = Tag(name) if isinstance(name, str) else name  # find item via value name
-
             # iterall is recursive, so it will find all items with the given name
-            found_item = [item.value for item in dataset.iterall() if item.tag == tag]
+            found_item = [item.value for item in dataset.iterall() if item.tag == Tag(name)]
 
             if len(found_item) == 0:
                 return None

--- a/src/mrpro/data/IHeader.py
+++ b/src/mrpro/data/IHeader.py
@@ -62,7 +62,7 @@ class IHeader(MoveDataMixin):
             list of dataset objects containing the DICOM file.
         """
 
-        def get_item(dataset: Dataset, name: str | TagType):
+        def get_item(dataset: Dataset, name: TagType):
             """Get item with a given name or Tag from a pydicom dataset."""
             tag = Tag(name) if isinstance(name, str) else name  # find item via value name
 
@@ -76,11 +76,11 @@ class IHeader(MoveDataMixin):
             else:
                 raise ValueError(f'Item {name} found {len(found_item)} times.')
 
-        def get_items_from_all_dicoms(name: str | TagType):
+        def get_items_from_all_dicoms(name: TagType):
             """Get list of items for all dataset objects in the list."""
             return [get_item(ds, name) for ds in dicom_datasets]
 
-        def get_float_items_from_all_dicoms(name: str | TagType):
+        def get_float_items_from_all_dicoms(name: TagType):
             """Convert items to float."""
             items = get_items_from_all_dicoms(name)
             return [float(val) if val is not None else None for val in items]

--- a/tests/data/_Dicom2DTestImage.py
+++ b/tests/data/_Dicom2DTestImage.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import numpy as np
 import pydicom
-import pydicom._storage_sopclass_uids
 import torch
 from mrpro.data import SpatialDimension
 from mrpro.phantoms import EllipsePhantom
@@ -51,7 +50,7 @@ class Dicom2DTestImage:
 
         # Metadata
         file_meta = pydicom.dataset.FileMetaDataset()
-        file_meta.MediaStorageSOPClassUID = pydicom._storage_sopclass_uids.MRImageStorage
+        file_meta.MediaStorageSOPClassUID = pydicom.uid.MRImageStorage
         file_meta.MediaStorageSOPInstanceUID = pydicom.uid.generate_uid()
         file_meta.TransferSyntaxUID = pydicom.uid.ExplicitVRLittleEndian
 

--- a/tests/utils/test_rotation.py
+++ b/tests/utils/test_rotation.py
@@ -98,6 +98,7 @@ def test_quat_double_to_canonical_single_cover():
     torch.testing.assert_close(r.as_quat(canonical=True), expected_quat)
 
 
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_quat_double_cover():
     # See the scipy Rotation.from_quat() docstring for scope of the quaternion
     # double cover property.

--- a/tests/utils/test_rotation.py
+++ b/tests/utils/test_rotation.py
@@ -98,7 +98,6 @@ def test_quat_double_to_canonical_single_cover():
     torch.testing.assert_close(r.as_quat(canonical=True), expected_quat)
 
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_quat_double_cover():
     # See the scipy Rotation.from_quat() docstring for scope of the quaternion
     # double cover property.


### PR DESCRIPTION
Pydicom 3.0 was released which led to several errors due to deprecation, see e.g. https://github.com/pydicom/pydicom/pull/1567/files#diff-9b5a2e48457143cde31b1bbe1c7546a6733e577c306cfe582d56099851e12468

