### PR TITLE
Add arithmetic for SpatialDimension

### DIFF
--- a/src/mrpro/data/SpatialDimension.py
+++ b/src/mrpro/data/SpatialDimension.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Generic, Protocol, TypeVar
+from typing import Any, Generic, Protocol, TypeVar
 
 import numpy as np
 import torch
@@ -27,9 +27,25 @@ class XYZ(Protocol[T]):
 class SpatialDimension(MoveDataMixin, Generic[T]):
     """Spatial dataclass of float/int/tensors (z, y, x)."""
 
-    z: T
-    y: T
-    x: T
+    z: torch.Tensor
+    y: torch.Tensor
+    x: torch.Tensor
+
+    def __init__(self, z: T, y: T, x: T):
+        """Create a SpatialDimension from torch.tensors, float or int values.
+
+        Parameters
+        ----------
+        z
+            spatial dimension along z direction
+        y
+            spatial dimension along y direction
+        x
+            spatial dimension along x direction
+        """
+        self.z = torch.as_tensor(z)
+        self.y = torch.as_tensor(y)
+        self.x = torch.as_tensor(x)
 
     @classmethod
     def from_xyz(cls, data: XYZ[T], conversion: Callable[[T], T] | None = None) -> SpatialDimension[T]:
@@ -94,10 +110,67 @@ class SpatialDimension(MoveDataMixin, Generic[T]):
         return SpatialDimension.from_array_xyz(data, conversion)
 
     @property
-    def zyx(self) -> tuple[T, T, T]:
+    def zyx(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Return a z,y,x tuple."""
         return (self.z, self.y, self.x)
+
+    @property
+    def xyz(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Return a x,y,z tuple."""
+        return (self.x, self.y, self.z)
 
     def __str__(self) -> str:
         """Return a string representation of the SpatialDimension."""
         return f'z={self.z}, y={self.y}, x={self.x}'
+
+    def __getitem__(self, idx: Any) -> SpatialDimension:
+        """Get SpatialDimension item."""
+        return SpatialDimension(self.z[idx], self.y[idx], self.x[idx])
+
+    def __setitem__(self, idx: Any, value: SpatialDimension):
+        """Set SpatialDimension item."""
+        self.z[idx] = value.z
+        self.y[idx] = value.y
+        self.x[idx] = value.x
+
+    def __mul__(self, value: float | int | SpatialDimension) -> SpatialDimension:
+        """Multiply SpatialDimension with numeric value or SpatialDimension."""
+        if isinstance(value, SpatialDimension):
+            return SpatialDimension(self.z * value.z, self.y * value.y, self.x * value.x)
+        return SpatialDimension(self.z * value, self.y * value, self.x * value)
+
+    def __rmul__(self, value: float | int | SpatialDimension) -> SpatialDimension:
+        """Right multiply SpatialDimension with numeric value or SpatialDimension."""
+        return self.__mul__(value)
+
+    def __truediv__(self, value: float | int | SpatialDimension) -> SpatialDimension:
+        """Divide SpatialDimension with numeric value or SpatialDimension."""
+        if isinstance(value, SpatialDimension):
+            return SpatialDimension(self.z / value.z, self.y / value.y, self.x / value.x)
+        return SpatialDimension(self.z / value, self.y / value, self.x / value)
+
+    def __rtruediv__(self, value: float | int) -> SpatialDimension:
+        """Right divide SpatialDimension with numeric value."""
+        return SpatialDimension(value / self.z, value / self.y, value / self.x)
+
+    def __add__(self, value: float | int | SpatialDimension) -> SpatialDimension:
+        """Add SpatialDimension or numeric value to SpatialDimension."""
+        if isinstance(value, SpatialDimension):
+            return SpatialDimension(self.z + value.z, self.y + value.y, self.x + value.x)
+        return SpatialDimension(self.z + value, self.y + value, self.x + value)
+
+    def __radd__(self, value: float | int | SpatialDimension) -> SpatialDimension:
+        """Right add SpatialDimension or numeric value to SpatialDimension."""
+        return self.__add__(value)
+
+    def __sub__(self, value: float | int | SpatialDimension) -> SpatialDimension:
+        """Subtract SpatialDimension or numeric value to SpatialDimension."""
+        if isinstance(value, SpatialDimension):
+            return SpatialDimension(self.z - value.z, self.y - value.y, self.x - value.x)
+        return SpatialDimension(self.z - value, self.y - value, self.x - value)
+
+    def __rsub__(self, value: float | int | SpatialDimension) -> SpatialDimension:
+        """Right subtract SpatialDimension or numeric value to SpatialDimension."""
+        if isinstance(value, SpatialDimension):
+            return SpatialDimension(value.z - self.z, value.y - self.y, value.x - self.x)
+        return SpatialDimension(value - self.z, value - self.y, value - self.x)

--- a/tests/data/test_spatial_dimension.py
+++ b/tests/data/test_spatial_dimension.py
@@ -87,6 +87,14 @@ def test_spatial_dimension_zyx():
     assert spatial_dimension.zyx == (z, y, x)
 
 
+def test_spatial_dimension_xyz():
+    """Test the xyz tuple property"""
+    z, y, x = (2, 3, 4)
+    spatial_dimension = SpatialDimension(z=z, y=y, x=x)
+    assert isinstance(spatial_dimension.xyz, tuple)
+    assert spatial_dimension.xyz == (x, y, z)
+
+
 @pytest.mark.cuda()
 def test_spatial_dimension_cuda_tensor():
     """Test moving to CUDA"""
@@ -104,18 +112,173 @@ def test_spatial_dimension_cuda_tensor():
     assert not spatial_dimension.is_cuda
 
 
-def test_spatial_dimension_cuda_float():
-    """Test moving to CUDA without tensors -> copy only"""
+def test_spatial_dimension_getitem():
+    """Test accessing elements of SpatialDimension."""
+    zyx = RandomGenerator(0).float32_tensor((4, 2, 3))
+    spatial_dimension = SpatialDimension.from_array_zyx(zyx.numpy())
+    torch.testing.assert_close(torch.stack(spatial_dimension[:2, ...].zyx, dim=-1), zyx[:2, ...])
+
+
+def test_spatial_dimension_setitem():
+    """Test setting elements of SpatialDimension."""
+    zyx = RandomGenerator(0).float32_tensor((4, 2, 3))
+    spatial_dimension = SpatialDimension.from_array_zyx(zyx.numpy())
+    spatial_dimension_to_set = SpatialDimension(z=1.0, y=2.0, x=3.0)
+    spatial_dimension[2, 1] = spatial_dimension_to_set
+    assert spatial_dimension[2, 1].zyx == spatial_dimension_to_set.zyx
+
+
+def test_spatial_dimension_mul():
+    """Test multiplication of SpatialDimension with numeric value."""
     spatial_dimension = SpatialDimension(z=1.0, y=2.0, x=3.0)
-    # the device number should not matter, has there is no
-    # data to move to the device
-    spatial_dimension_cuda = spatial_dimension.cuda(42)
-    # if a dataclass has no tensors, it is both on CPU and CUDA
-    # and the device is None
-    assert spatial_dimension_cuda.is_cuda
-    assert spatial_dimension.is_cpu
-    assert spatial_dimension_cuda.is_cpu
-    assert spatial_dimension.is_cuda
-    assert spatial_dimension.device is None
-    assert spatial_dimension_cuda.device is None
-    assert spatial_dimension_cuda is not spatial_dimension
+    value = 3
+    spatial_dimension_add = spatial_dimension * value
+    assert isinstance(spatial_dimension_add, SpatialDimension)
+    assert spatial_dimension_add.zyx == (
+        spatial_dimension.z * value,
+        spatial_dimension.y * value,
+        spatial_dimension.x * value,
+    )
+
+
+def test_spatial_dimension_rmul():
+    """Test right multiplication of SpatialDimension with numeric value."""
+    spatial_dimension = SpatialDimension(z=1.0, y=2.0, x=3.0)
+    value = 3
+    spatial_dimension_add = value * spatial_dimension
+    assert isinstance(spatial_dimension_add, SpatialDimension)
+    assert spatial_dimension_add.zyx == (
+        spatial_dimension.z * value,
+        spatial_dimension.y * value,
+        spatial_dimension.x * value,
+    )
+
+
+def test_spatial_dimension_mul_spatial_dimension():
+    """Test multiplication of SpatialDimension with SpatialDimension."""
+    spatial_dimension_1 = SpatialDimension(z=1.0, y=2.0, x=3.0)
+    spatial_dimension_2 = SpatialDimension(z=4.0, y=5.0, x=6.0)
+    spatial_dimension_add = spatial_dimension_1 * spatial_dimension_2
+    assert isinstance(spatial_dimension_add, SpatialDimension)
+    assert spatial_dimension_add.zyx == (
+        spatial_dimension_1.z * spatial_dimension_2.z,
+        spatial_dimension_1.y * spatial_dimension_2.y,
+        spatial_dimension_1.x * spatial_dimension_2.x,
+    )
+
+
+def test_spatial_dimension_truediv():
+    """Test division of SpatialDimension with numeric value."""
+    spatial_dimension = SpatialDimension(z=1.0, y=2.0, x=3.0)
+    value = 3
+    spatial_dimension_add = spatial_dimension / value
+    assert isinstance(spatial_dimension_add, SpatialDimension)
+    assert spatial_dimension_add.zyx == (
+        spatial_dimension.z / value,
+        spatial_dimension.y / value,
+        spatial_dimension.x / value,
+    )
+
+
+def test_spatial_dimension_rtruediv():
+    """Test right division of SpatialDimension with numeric value."""
+    spatial_dimension = SpatialDimension(z=1.0, y=2.0, x=3.0)
+    value = 3
+    spatial_dimension_add = value / spatial_dimension
+    assert isinstance(spatial_dimension_add, SpatialDimension)
+    assert spatial_dimension_add.zyx == (
+        value / spatial_dimension.z,
+        value / spatial_dimension.y,
+        value / spatial_dimension.x,
+    )
+
+
+def test_spatial_dimension_truediv_spatial_dimension():
+    """Test divitions of SpatialDimension with SpatialDimension."""
+    spatial_dimension_1 = SpatialDimension(z=1.0, y=2.0, x=3.0)
+    spatial_dimension_2 = SpatialDimension(z=4.0, y=5.0, x=6.0)
+    spatial_dimension_add = spatial_dimension_1 / spatial_dimension_2
+    assert isinstance(spatial_dimension_add, SpatialDimension)
+    assert spatial_dimension_add.zyx == (
+        spatial_dimension_1.z / spatial_dimension_2.z,
+        spatial_dimension_1.y / spatial_dimension_2.y,
+        spatial_dimension_1.x / spatial_dimension_2.x,
+    )
+
+
+def test_spatial_dimension_add():
+    """Test addition of SpatialDimension with numeric value."""
+    spatial_dimension = SpatialDimension(z=1.0, y=2.0, x=3.0)
+    value = 3
+    spatial_dimension_add = spatial_dimension + value
+    assert isinstance(spatial_dimension_add, SpatialDimension)
+    assert spatial_dimension_add.zyx == (
+        spatial_dimension.z + value,
+        spatial_dimension.y + value,
+        spatial_dimension.x + value,
+    )
+
+
+def test_spatial_dimension_radd():
+    """Test right addition of SpatialDimension with numeric value."""
+    spatial_dimension = SpatialDimension(z=1.0, y=2.0, x=3.0)
+    value = 3
+    spatial_dimension_add = value + spatial_dimension
+    assert isinstance(spatial_dimension_add, SpatialDimension)
+    assert spatial_dimension_add.zyx == (
+        spatial_dimension.z + value,
+        spatial_dimension.y + value,
+        spatial_dimension.x + value,
+    )
+
+
+def test_spatial_dimension_add_spatial_dimension():
+    """Test addition of SpatialDimension with SpatialDimension."""
+    spatial_dimension_1 = SpatialDimension(z=1.0, y=2.0, x=3.0)
+    spatial_dimension_2 = SpatialDimension(z=4.0, y=5.0, x=6.0)
+    spatial_dimension_add = spatial_dimension_1 + spatial_dimension_2
+    assert isinstance(spatial_dimension_add, SpatialDimension)
+    assert spatial_dimension_add.zyx == (
+        spatial_dimension_1.z + spatial_dimension_2.z,
+        spatial_dimension_1.y + spatial_dimension_2.y,
+        spatial_dimension_1.x + spatial_dimension_2.x,
+    )
+
+
+def test_spatial_dimension_sub():
+    """Test subtraction of SpatialDimension with numeric value."""
+    spatial_dimension = SpatialDimension(z=1.0, y=2.0, x=3.0)
+    value = 3
+    spatial_dimension_add = spatial_dimension - value
+    assert isinstance(spatial_dimension_add, SpatialDimension)
+    assert spatial_dimension_add.zyx == (
+        spatial_dimension.z - value,
+        spatial_dimension.y - value,
+        spatial_dimension.x - value,
+    )
+
+
+def test_spatial_dimension_rsub():
+    """Test right subtraction of SpatialDimension with numeric value."""
+    spatial_dimension = SpatialDimension(z=1.0, y=2.0, x=3.0)
+    value = 3
+    spatial_dimension_add = value - spatial_dimension
+    assert isinstance(spatial_dimension_add, SpatialDimension)
+    assert spatial_dimension_add.zyx == (
+        value - spatial_dimension.z,
+        value - spatial_dimension.y,
+        value - spatial_dimension.x,
+    )
+
+
+def test_spatial_dimension_sub_spatial_dimension():
+    """Test subtraction of SpatialDimension with SpatialDimension."""
+    spatial_dimension_1 = SpatialDimension(z=1.0, y=2.0, x=3.0)
+    spatial_dimension_2 = SpatialDimension(z=4.0, y=5.0, x=6.0)
+    spatial_dimension_add = spatial_dimension_1 - spatial_dimension_2
+    assert isinstance(spatial_dimension_add, SpatialDimension)
+    assert spatial_dimension_add.zyx == (
+        spatial_dimension_1.z - spatial_dimension_2.z,
+        spatial_dimension_1.y - spatial_dimension_2.y,
+        spatial_dimension_1.x - spatial_dimension_2.x,
+    )


### PR DESCRIPTION
When saving our data to Dicom we need to recalculate positions and orientations. This would provide the arithemtic to do this more easily. 

Current disadvantage: `z,y,x` were `int | float | Tensor` but are now always `Tensor`. This makes lots of things easier but would require quite some changes to our code (especially the SliceProjectionOp). We could of course keep it as `int | float | Tensor` but then we would need quite a few checks in the arithmetic part.

Another option would be to have `z,y,x` as `int | float` and then things like `read_dir `would be a list of SpatialDimension objects.
