### PR TITLE
Outline for new header structure 

### DIFF
--- a/src/mrpro/data/AcqInfo.py
+++ b/src/mrpro/data/AcqInfo.py
@@ -1,40 +1,21 @@
 """Acquisition information dataclass."""
 
-import dataclasses
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Self, TypeVar
+from typing import Self
 
 import ismrmrd
 import numpy as np
 import torch
-from einops import rearrange
 
-from mrpro.data.MoveDataMixin import MoveDataMixin
+from mrpro.data.DataInfo import DataIdx, DataInfo
 from mrpro.data.Rotation import Rotation
 from mrpro.data.SpatialDimension import SpatialDimension
 from mrpro.utils.unit_conversion import mm_to_m
 
-T = TypeVar('T', torch.Tensor, Rotation, SpatialDimension)
-
-
-def rearrange_acq_info_fields(field: T, pattern: str, additional_info: dict[str, int] | None = None) -> T:
-    """Change the shape of the fields in AcqInfo."""
-    axes_lengths = {} if additional_info is None else additional_info
-    if isinstance(field, Rotation):
-        return Rotation.from_matrix(rearrange(field.as_matrix(), pattern, **axes_lengths))
-    elif isinstance(field, SpatialDimension):
-        return SpatialDimension(
-            z=rearrange(field.z, pattern, **axes_lengths),
-            y=rearrange(field.y, pattern, **axes_lengths),
-            x=rearrange(field.x, pattern, **axes_lengths),
-        )
-    else:
-        return rearrange(field, pattern, **axes_lengths)
-
 
 @dataclass(slots=True)
-class AcqIdx(MoveDataMixin):
+class AcqIdx(DataIdx):
     """Acquisition index for each readout."""
 
     k1: torch.Tensor
@@ -43,54 +24,9 @@ class AcqIdx(MoveDataMixin):
     k2: torch.Tensor
     """Second phase encoding."""
 
-    average: torch.Tensor
-    """Signal average."""
-
-    slice: torch.Tensor
-    """Slice number (multi-slice 2D)."""
-
-    contrast: torch.Tensor
-    """Echo number in multi-echo."""
-
-    phase: torch.Tensor
-    """Cardiac phase."""
-
-    repetition: torch.Tensor
-    """Counter in repeated/dynamic acquisitions."""
-
-    set: torch.Tensor
-    """Sets of different preparation, e.g. flow encoding, diffusion weighting."""
-
-    segment: torch.Tensor
-    """Counter for segmented acquisitions."""
-
-    user0: torch.Tensor
-    """User index 0."""
-
-    user1: torch.Tensor
-    """User index 1."""
-
-    user2: torch.Tensor
-    """User index 2."""
-
-    user3: torch.Tensor
-    """User index 3."""
-
-    user4: torch.Tensor
-    """User index 4."""
-
-    user5: torch.Tensor
-    """User index 5."""
-
-    user6: torch.Tensor
-    """User index 6."""
-
-    user7: torch.Tensor
-    """User index 7."""
-
 
 @dataclass(slots=True)
-class AcqInfo(MoveDataMixin):
+class AcqInfo(DataInfo):
     """Acquisition information for each readout."""
 
     idx: AcqIdx
@@ -129,18 +65,6 @@ class AcqInfo(MoveDataMixin):
     number_of_samples: torch.Tensor
     """Number of sample points per readout (readouts may have different number of sample points)."""
 
-    orientation: Rotation
-    """Rotation describing the orientation of the readout, phase and slice encoding direction."""
-
-    patient_table_position: SpatialDimension[torch.Tensor]
-    """Offset position of the patient table, in LPS coordinates [m]."""
-
-    physiology_time_stamp: torch.Tensor
-    """Time stamps relative to physiological triggering, e.g. ECG. Not in s but in vendor-specific time units"""
-
-    position: SpatialDimension[torch.Tensor]
-    """Center of the excited volume, in LPS coordinates relative to isocenter [m]."""
-
     sample_time_us: torch.Tensor
     """Readout bandwidth, as time between samples [us]."""
 
@@ -149,12 +73,6 @@ class AcqInfo(MoveDataMixin):
 
     trajectory_dimensions: torch.Tensor  # =3. We only support 3D Trajectories: kz always exists.
     """Dimensionality of the k-space trajectory vector."""
-
-    user_float: torch.Tensor
-    """User-defined float parameters."""
-
-    user_int: torch.Tensor
-    """User-defined int parameters."""
 
     version: torch.Tensor
     """Major version number."""
@@ -284,21 +202,3 @@ class AcqInfo(MoveDataMixin):
             version=tensor_2d(headers['version']),
         )
         return acq_info
-
-    def _apply_(self, modify_acq_info_field: Callable) -> None:
-        """Go through all fields of AcqInfo object and apply function in-place.
-
-        Parameters
-        ----------
-        modify_acq_info_field
-            Function which takes AcqInfo fields as input and returns modified AcqInfo field
-        """
-        for field in dataclasses.fields(self):
-            current = getattr(self, field.name)
-            if dataclasses.is_dataclass(current):
-                for subfield in dataclasses.fields(current):
-                    subcurrent = getattr(current, subfield.name)
-                    setattr(current, subfield.name, modify_acq_info_field(subcurrent))
-            else:
-                setattr(self, field.name, modify_acq_info_field(current))
-        return None

--- a/src/mrpro/data/DataInfo.py
+++ b/src/mrpro/data/DataInfo.py
@@ -1,0 +1,125 @@
+"""Data information dataclass."""
+
+import dataclasses
+from abc import ABC
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TypeVar
+
+import torch
+from einops import rearrange
+
+from mrpro.data.MoveDataMixin import MoveDataMixin
+from mrpro.data.Rotation import Rotation
+from mrpro.data.SpatialDimension import SpatialDimension
+
+T = TypeVar('T', torch.Tensor, Rotation, SpatialDimension)
+
+
+def rearrange_info_fields(field: T, pattern: str, additional_info: dict[str, int] | None = None) -> T:
+    """Change the shape of the fields in DataInfo."""
+    axes_lengths = {} if additional_info is None else additional_info
+    if isinstance(field, Rotation):
+        return Rotation.from_matrix(rearrange(field.as_matrix(), pattern, **axes_lengths))
+    elif isinstance(field, SpatialDimension):
+        return SpatialDimension(
+            z=rearrange(field.z, pattern, **axes_lengths),
+            y=rearrange(field.y, pattern, **axes_lengths),
+            x=rearrange(field.x, pattern, **axes_lengths),
+        )
+    else:
+        return rearrange(field, pattern, **axes_lengths)
+
+
+@dataclass(slots=True)
+class DataIdx(MoveDataMixin, ABC):
+    """Data index for each data entry."""
+
+    average: torch.Tensor
+    """Signal average."""
+
+    slice: torch.Tensor
+    """Slice number (multi-slice 2D)."""
+
+    contrast: torch.Tensor
+    """Echo number in multi-echo."""
+
+    phase: torch.Tensor
+    """Cardiac phase."""
+
+    repetition: torch.Tensor
+    """Counter in repeated/dynamic acquisitions."""
+
+    set: torch.Tensor
+    """Sets of different preparation, e.g. flow encoding, diffusion weighting."""
+
+    segment: torch.Tensor
+    """Counter for segmented acquisitions."""
+
+    user0: torch.Tensor
+    """User index 0."""
+
+    user1: torch.Tensor
+    """User index 1."""
+
+    user2: torch.Tensor
+    """User index 2."""
+
+    user3: torch.Tensor
+    """User index 3."""
+
+    user4: torch.Tensor
+    """User index 4."""
+
+    user5: torch.Tensor
+    """User index 5."""
+
+    user6: torch.Tensor
+    """User index 6."""
+
+    user7: torch.Tensor
+    """User index 7."""
+
+
+@dataclass(slots=True)
+class DataInfo(MoveDataMixin, ABC):
+    """Data information for each data entry."""
+
+    idx: DataIdx
+    """Indices describing data (e.g. slice number or repetition number)."""
+
+    orientation: Rotation
+    """Rotation describing the orientation of the readout, phase and slice encoding direction."""
+
+    patient_table_position: SpatialDimension[torch.Tensor]
+    """Offset position of the patient table, in LPS coordinates [m]."""
+
+    physiology_time_stamp: torch.Tensor
+    """Time stamps relative to physiological triggering, e.g. ECG. Not in s but in vendor-specific time units"""
+
+    position: SpatialDimension[torch.Tensor]
+    """Center of the excited volume, in LPS coordinates relative to isocenter [m]."""
+
+    user_float: torch.Tensor
+    """User-defined float parameters."""
+
+    user_int: torch.Tensor
+    """User-defined int parameters."""
+
+    def _apply_(self, modify_data_info_field: Callable) -> None:
+        """Go through all fields of DataInfo object and apply function in-place.
+
+        Parameters
+        ----------
+        modify_data_info_field
+            Function which takes DataInfo fields as input and returns modified DataInfo field
+        """
+        for field in dataclasses.fields(self):
+            current = getattr(self, field.name)
+            if dataclasses.is_dataclass(current):
+                for subfield in dataclasses.fields(current):
+                    subcurrent = getattr(current, subfield.name)
+                    setattr(current, subfield.name, modify_data_info_field(subcurrent))
+            else:
+                setattr(self, field.name, modify_data_info_field(current))
+        return None

--- a/src/mrpro/data/Header.py
+++ b/src/mrpro/data/Header.py
@@ -13,6 +13,7 @@ import torch
 from pydicom.dataset import Dataset
 from pydicom.tag import Tag, TagType
 
+from mrpro.data.DataInfo import DataInfo
 from mrpro.data.KHeader import KHeader
 from mrpro.data.MoveDataMixin import MoveDataMixin
 from mrpro.data.Rotation import Rotation
@@ -34,14 +35,8 @@ class Header(MoveDataMixin, ABC):
     lamor_frequency_proton: float | None
     """Lamor frequency of hydrogen nuclei [Hz]."""
 
-    position: SpatialDimension[torch.Tensor] | None
-    """Center of the excited volume, in LPS coordinates relative to isocenter [m]."""
-
-    orientation: Rotation | None
-    """Rotation describing the orientation of the readout, phase and slice encoding direction."""
-
-    patient_table_position: SpatialDimension[torch.Tensor] | None
-    """Offset position of the patient table, in LPS coordinates [m]."""
+    data_info: DataInfo
+    """Information of the data (e.g. different image slices)."""
 
     datetime: datetime.datetime | None
     """Date and time of acquisition."""


### PR DESCRIPTION
So far IData and QData has very limited header parameters. I am trying to extend this now and I am struggling a bit of how we can efficiently reuse things. 

@fzimmermann89 @schuenke do you think it makes sense to intruduce a base class for the AcqIdx and AcqInfo and reuse that also for the IData and QData? We would then have something like

KHeader including AcqIdx and AcqInfo with
DataIdx <- AcqIdx
DataInfo <- AcqInfo

I don't know what to call the overarching QData and IData space, so let's just call it X

XHeader including XIdx and XInfo with
DataIdx <- XIdx
DataInfo <- XInfo
this will include functionality such as from_kheader and from_dicom

and then QHeader and IHeader which will be child of XHeader with a few additional parameters (e.g. TE or TR for IHeader)

I would then rename Data to XData which would then also have the common functionality such as from_dicom

I would also do this as a separate PR to main before extending the IHeader and QHeader parameters.