### PR TITLE
Add gram to LinearOperator

### DIFF
--- a/src/mrpro/operators/LinearOperator.py
+++ b/src/mrpro/operators/LinearOperator.py
@@ -172,19 +172,30 @@ class LinearOperator(Operator[torch.Tensor, tuple[torch.Tensor]]):
         # Sum of linear operators is a linear operator
         return LinearOperatorSum(self, other)
 
-    def __mul__(self, other: torch.Tensor) -> LinearOperator:
+    def __mul__(self, other: torch.Tensor | complex) -> LinearOperator:
         """Operator elementwise left multiplication with tensor.
 
         Returns lambda x: self(other*x)
         """
         return LinearOperatorElementwiseProductLeft(self, other)
 
-    def __rmul__(self, other: torch.Tensor) -> LinearOperator:
+    def __rmul__(self, other: torch.Tensor | complex) -> LinearOperator:
         """Operator elementwise right multiplication with tensor.
 
         Returns lambda x: other*self(x)
         """
         return LinearOperatorElementwiseProductRight(self, other)
+
+    @property
+    def gram(self) -> LinearOperator:
+        """Gram operator.
+
+        For a LinearOperator :math:`A`, the self-adjoint Gram operator is defined as :math:`A^H A`.
+
+        Note: This is a default implementation that can be overwritten by subclasses for more efficient
+        implementations.
+        """
+        return self.H @ self
 
 
 class LinearOperatorComposition(LinearOperator, OperatorComposition[torch.Tensor, tuple[torch.Tensor,]]):
@@ -195,8 +206,14 @@ class LinearOperatorComposition(LinearOperator, OperatorComposition[torch.Tensor
 
     def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
         """Adjoint of the operator composition."""
-        # (AB)^T = B^T A^T
+        # (AB)^H = B^H A^H
         return self._operator2.adjoint(*self._operator1.adjoint(x))
+
+    @property
+    def gram(self) -> LinearOperator:
+        """Gram operator."""
+        # (AB)^H(AB) = B^H (A^H A) B
+        return self._operator2.H @ self._operator1.gram @ self._operator2
 
 
 class LinearOperatorSum(LinearOperator, OperatorSum[torch.Tensor, tuple[torch.Tensor,]]):
@@ -204,7 +221,7 @@ class LinearOperatorSum(LinearOperator, OperatorSum[torch.Tensor, tuple[torch.Te
 
     def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
         """Adjoint of the operator addition."""
-        # (A+B)^T = A^T + B^T
+        # (A+B)^H = A^H + B^H
         return (self._operator1.adjoint(x)[0] + self._operator2.adjoint(x)[0],)
 
 
@@ -218,7 +235,24 @@ class LinearOperatorElementwiseProductRight(
 
     def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
         """Adjoint Operator elementwise multiplication with a tensor."""
-        return self._operator.adjoint(x * self._tensor.conj())
+        if isinstance(self._tensor, torch.Tensor):
+            conj: torch.Tensor | complex = self._tensor.conj()
+        else:
+            conj = self._tensor.conjugate()
+
+        return self._operator.adjoint(x * conj)
+
+    @property
+    def gram(self) -> LinearOperator:
+        """Gram Operator."""
+        if isinstance(self._tensor, torch.Tensor):
+            factor: torch.Tensor | complex = self._tensor.conj() * self._tensor
+            if self._tensor.numel() > 1:
+                # only scalars can be moved outside the linear operator
+                return self._operator.H @ (factor * self._operator)
+        else:
+            factor = self._tensor.conjugate() * self._tensor
+        return factor * self._operator.gram
 
 
 class LinearOperatorElementwiseProductLeft(
@@ -231,7 +265,21 @@ class LinearOperatorElementwiseProductLeft(
 
     def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
         """Adjoint Operator elementwise multiplication with a tensor."""
-        return (self._operator.adjoint(x)[0] * self._tensor.conj(),)
+        if isinstance(self._tensor, torch.Tensor):
+            conj: torch.Tensor | complex = self._tensor.conj()
+        else:
+            conj = self._tensor.conjugate()
+        return (self._operator.adjoint(x)[0] * conj,)
+
+    @property
+    def gram(self) -> LinearOperator:
+        """Gram Operator."""
+        if isinstance(self._tensor, torch.Tensor):
+            conj: torch.Tensor | complex = self._tensor.conj()
+        else:
+            conj = self._tensor.conjugate()
+
+        return conj * self._operator.gram * self._tensor
 
 
 class AdjointLinearOperator(LinearOperator):
@@ -254,3 +302,8 @@ class AdjointLinearOperator(LinearOperator):
     def H(self) -> LinearOperator:  # noqa: N802
         """Adjoint of adjoint operator, i.e. original LinearOperator."""
         return self.operator
+
+    @property
+    def gram(self) -> LinearOperator:
+        """Gram operator."""
+        return self._operator.gram.H

--- a/src/mrpro/operators/Operator.py
+++ b/src/mrpro/operators/Operator.py
@@ -38,14 +38,14 @@ class Operator(Generic[*Tin, Tout], ABC, torch.nn.Module):
         """
         return OperatorSum(self, other)
 
-    def __mul__(self, other: torch.Tensor) -> Operator[*Tin, Tout]:
+    def __mul__(self, other: torch.Tensor | complex) -> Operator[*Tin, Tout]:
         """Operator multiplication with tensor.
 
         Returns lambda x: self(other*x)
         """
         return OperatorElementwiseProductLeft(self, other)
 
-    def __rmul__(self, other: torch.Tensor) -> Operator[*Tin, Tout]:
+    def __rmul__(self, other: torch.Tensor | complex) -> Operator[*Tin, Tout]:
         """Operator multiplication with tensor.
 
         Returns lambda x: other*self(x)
@@ -97,7 +97,7 @@ class OperatorElementwiseProductRight(Operator[*Tin, Tout]):
     Performs Tensor*Operator(x)
     """
 
-    def __init__(self, operator: Operator[*Tin, Tout], tensor: torch.Tensor):
+    def __init__(self, operator: Operator[*Tin, Tout], tensor: torch.Tensor | complex):
         """Operator elementwise right multiplication initialization."""
         super().__init__()
         self._operator = operator
@@ -115,7 +115,7 @@ class OperatorElementwiseProductLeft(Operator[*Tin, Tout]):
     Performs Operator(x*Tensor)
     """
 
-    def __init__(self, operator: Operator[*Tin, Tout], tensor: torch.Tensor):
+    def __init__(self, operator: Operator[*Tin, Tout], tensor: torch.Tensor | complex):
         """Operator elementwise left multiplication initialization."""
         super().__init__()
         self._operator = operator
@@ -123,6 +123,6 @@ class OperatorElementwiseProductLeft(Operator[*Tin, Tout]):
 
     def forward(self, *args: *Tin) -> Tout:
         """Operator elementwise left multiplication."""
-        multiplied = cast(tuple[*Tin], tuple(a * self._tensor for a in args))
+        multiplied = cast(tuple[*Tin], tuple(cast(torch.Tensor, a) * self._tensor for a in args))
         out = self._operator(*multiplied)
         return cast(Tout, out)

--- a/tests/operators/test_operators.py
+++ b/tests/operators/test_operators.py
@@ -245,3 +245,52 @@ def test_adjoint_sum():
     v = rng.complex64_tensor(3)
     linear_op_sum = a + b
     dotproduct_adjointness_test(linear_op_sum, u, v)
+
+
+def test_gram_shortcuts():
+    """Test that .gram for composition and sclalar multiplication results in shortcuts."""
+
+    class GramOnlyOperator(LinearOperator):
+        """Operator-Wrapper that only has a working .gram property."""
+
+        def __init__(self, op: LinearOperator):
+            super().__init__()
+            self.op = op
+
+        def forward(self, _: torch.Tensor):
+            raise RuntimeError('This operator should not be called')
+
+        def adjoint(self, _: torch.Tensor):
+            raise RuntimeError('This operator should not be called')
+
+        @property
+        def gram(self):
+            return self.op.H @ self.op
+
+    rng = RandomGenerator(2)
+    a = DummyLinearOperator(rng.complex64_tensor((3, 10)))
+    b = DummyLinearOperator(rng.complex64_tensor((10, 10)))
+    a_gram_only = GramOnlyOperator(a)
+    # ignore required due to https://github.com/pytorch/pytorch/issues/124015
+    op: LinearOperator = torch.tensor(1) * ((3 + 4j) * a_gram_only @ b) * (1 + 2j)  # type: ignore[assignment]
+    gram = op.gram
+
+    u = rng.complex64_tensor(10)
+    v = rng.complex64_tensor(10)
+
+    # Next line would raise an error if forward or adjoint were called on a_gram_only,
+    # but if all shortcuts are taken, it should work as only .gram is called
+    dotproduct_adjointness_test(gram, u, v)
+
+
+def test_gram_correctness():
+    """Test that the gram property is numerically correct."""
+    rng = RandomGenerator(2)
+    a = DummyLinearOperator(rng.complex64_tensor((3, 10)))
+    b = DummyLinearOperator(rng.complex64_tensor((10, 10)))
+    op = rng.complex64_tensor(3) * ((3 + 4j) * a @ b) * (1 + 2j) * rng.complex64_tensor(10)
+    gram = op.gram
+    u = rng.complex64_tensor(10)
+    actual = gram(u)[0]
+    expected = op.H(*op(u))[0]
+    torch.testing.assert_close(actual, expected)

--- a/tests/operators/test_operators.py
+++ b/tests/operators/test_operators.py
@@ -248,7 +248,7 @@ def test_adjoint_sum():
 
 
 def test_gram_shortcuts():
-    """Test that .gram for composition and sclalar multiplication results in shortcuts."""
+    """Test that .gram for composition and scalar multiplication results in shortcuts."""
 
     class GramOnlyOperator(LinearOperator):
         """Operator-Wrapper that only has a working .gram property."""


### PR DESCRIPTION
Some code I have to obtain the gram matrix/operator of a linear operator, i.e. A -> A.H@A
This has the advantages over writing  A.H@A that certain linear operators can implement a different .gram.

For example, the NUFFT-Op might. This is the ground work for it, currently no operator makes use of it. 
(To implement it for the FourierOp we might need to change FourierOp to be a composition of a NufftOp, FFTOp and CartesianSampling Op. This would then allow us to skip doing the frequency encoding ffts an A.H@A and using toeplitz for nufft....) 

I started doing this some time ago, but might not have to time right now to finish it right now -- at least the ground work should maybe already be merged to avoid loosing it

I am open to a name change (normal, hessian, selfadjoint, aha, adjoint_forward, psd,...) @koflera @guastinimara 