### PR TITLE
Add check-added-large-files to precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
+      - id: check-added-large-files
       - id: check-docstring-first
       - id: check-merge-conflict
       - id: check-yaml


### PR DESCRIPTION
#413 


> This option prevents big files from being committed.
> The default for "too big" is 500kB.
> This should be adjustable in the pre-commit hook using args: ['--maxkb=123']