### PR TITLE
Add multiple axes unsqueeze and broadcasting to the right

### DIFF
--- a/src/mrpro/operators/SignalModel.py
+++ b/src/mrpro/operators/SignalModel.py
@@ -12,26 +12,3 @@ Tin = TypeVarTuple('Tin')
 # SignalModel has multiple inputs and one output
 class SignalModel(Operator[*Tin, tuple[torch.Tensor,]]):
     """Signal Model Operator."""
-
-    @staticmethod
-    def expand_tensor_dim(parameter: torch.Tensor, n_dim_to_expand: int) -> torch.Tensor:
-        """Extend the number of dimensions of a parameter tensor.
-
-        This is commonly used in the `model.forward` to ensure the model parameters can be broadcasted to the
-        quantitative maps. E.g. a simple `InversionRecovery` model is evaluated for six different inversion times `ti`.
-        The inversion times are commonly the same for each voxel and hence `ti` could be of shape (6,) and the T1 and M0
-        map could be of shape (100,100,100). To make sure `ti` can be broadcasted to the maps it needs to be extended to
-        the shape (6,1,1,1) which then yields a signal of shape (6,100,100,100).
-
-        Parameters
-        ----------
-        parameter
-            Parameter (e.g with shape (m,n))
-        n_dim_to_expand
-            Number of dimensions to expand. If <= 0 then parameter is not changed.
-
-        Returns
-        -------
-            Parameter with expanded dimensions (e.g. (m,n,1,1) for n_dim_to_expand = 2)
-        """
-        return parameter[..., *[None] * (n_dim_to_expand)] if n_dim_to_expand > 0 else parameter

--- a/src/mrpro/operators/models/InversionRecovery.py
+++ b/src/mrpro/operators/models/InversionRecovery.py
@@ -3,6 +3,7 @@
 import torch
 
 from mrpro.operators.SignalModel import SignalModel
+from mrpro.utils import unsqueeze_right
 
 
 class InversionRecovery(SignalModel[torch.Tensor, torch.Tensor]):
@@ -37,6 +38,6 @@ class InversionRecovery(SignalModel[torch.Tensor, torch.Tensor]):
         -------
             signal with shape (time ... other, coils, z, y, x)
         """
-        ti = self.expand_tensor_dim(self.ti, m0.ndim - (self.ti.ndim - 1))  # -1 for time
+        ti = unsqueeze_right(self.ti, m0.ndim - (self.ti.ndim - 1))  # -1 for time
         signal = m0 * (1 - 2 * torch.exp(-(ti / t1)))
         return (signal,)

--- a/src/mrpro/operators/models/MOLLI.py
+++ b/src/mrpro/operators/models/MOLLI.py
@@ -3,6 +3,7 @@
 import torch
 
 from mrpro.operators.SignalModel import SignalModel
+from mrpro.utils import unsqueeze_right
 
 
 class MOLLI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
@@ -51,6 +52,6 @@ class MOLLI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
         -------
             signal with shape (time ... other, coils, z, y, x)
         """
-        ti = self.expand_tensor_dim(self.ti, a.ndim - (self.ti.ndim - 1))  # -1 for time
+        ti = unsqueeze_right(self.ti, a.ndim - (self.ti.ndim - 1))  # -1 for time
         signal = a * (1 - c * torch.exp(ti / t1 * (1 - c)))
         return (signal,)

--- a/src/mrpro/operators/models/MonoExponentialDecay.py
+++ b/src/mrpro/operators/models/MonoExponentialDecay.py
@@ -3,6 +3,7 @@
 import torch
 
 from mrpro.operators.SignalModel import SignalModel
+from mrpro.utils import unsqueeze_right
 
 
 class MonoExponentialDecay(SignalModel[torch.Tensor, torch.Tensor]):
@@ -37,6 +38,6 @@ class MonoExponentialDecay(SignalModel[torch.Tensor, torch.Tensor]):
         -------
             signal with shape (time ... other, coils, z, y, x)
         """
-        decay_time = self.expand_tensor_dim(self.decay_time, m0.ndim - (self.decay_time.ndim - 1))  # -1 for time
+        decay_time = unsqueeze_right(self.decay_time, m0.ndim - (self.decay_time.ndim - 1))  # -1 for time
         signal = m0 * torch.exp(-(decay_time / decay_constant))
         return (signal,)

--- a/src/mrpro/operators/models/SaturationRecovery.py
+++ b/src/mrpro/operators/models/SaturationRecovery.py
@@ -3,6 +3,7 @@
 import torch
 
 from mrpro.operators.SignalModel import SignalModel
+from mrpro.utils import unsqueeze_right
 
 
 class SaturationRecovery(SignalModel[torch.Tensor, torch.Tensor]):
@@ -37,6 +38,6 @@ class SaturationRecovery(SignalModel[torch.Tensor, torch.Tensor]):
         -------
             signal with shape (time ... other, coils, z, y, x)
         """
-        ti = self.expand_tensor_dim(self.ti, m0.ndim - (self.ti.ndim - 1))  # -1 for time
+        ti = unsqueeze_right(self.ti, m0.ndim - (self.ti.ndim - 1))  # -1 for time
         signal = m0 * (1 - torch.exp(-(ti / t1)))
         return (signal,)

--- a/src/mrpro/operators/models/TransientSteadyStateWithPreparation.py
+++ b/src/mrpro/operators/models/TransientSteadyStateWithPreparation.py
@@ -3,6 +3,7 @@
 import torch
 
 from mrpro.operators.SignalModel import SignalModel
+from mrpro.utils import unsqueeze_right
 
 
 class TransientSteadyStateWithPreparation(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
@@ -105,13 +106,13 @@ class TransientSteadyStateWithPreparation(SignalModel[torch.Tensor, torch.Tensor
         m0_ndim = m0.ndim
 
         # -1 for time
-        sampling_time = self.expand_tensor_dim(self.sampling_time, m0_ndim - (self.sampling_time.ndim - 1))
+        sampling_time = unsqueeze_right(self.sampling_time, m0_ndim - (self.sampling_time.ndim - 1))
 
-        repetition_time = self.expand_tensor_dim(self.repetition_time, m0_ndim - self.repetition_time.ndim)
-        m0_scaling_preparation = self.expand_tensor_dim(
+        repetition_time = unsqueeze_right(self.repetition_time, m0_ndim - self.repetition_time.ndim)
+        m0_scaling_preparation = unsqueeze_right(
             self.m0_scaling_preparation, m0_ndim - self.m0_scaling_preparation.ndim
         )
-        delay_after_preparation = self.expand_tensor_dim(
+        delay_after_preparation = unsqueeze_right(
             self.delay_after_preparation, m0_ndim - self.delay_after_preparation.ndim
         )
 

--- a/src/mrpro/operators/models/WASABI.py
+++ b/src/mrpro/operators/models/WASABI.py
@@ -4,6 +4,7 @@ import torch
 from torch import nn
 
 from mrpro.operators.SignalModel import SignalModel
+from mrpro.utils import unsqueeze_right
 
 
 class WASABI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]):
@@ -80,7 +81,7 @@ class WASABI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
         -------
             signal with shape (offsets ... other, coils, z, y, x)
         """
-        offsets = self.expand_tensor_dim(self.offsets, b0_shift.ndim - (self.offsets.ndim - 1))  # -1 for offset
+        offsets = unsqueeze_right(self.offsets, b0_shift.ndim - (self.offsets.ndim - 1))  # -1 for offset
         delta_x = offsets - b0_shift
         b1 = self.b1_nom * relative_b1
 

--- a/src/mrpro/operators/models/WASABITI.py
+++ b/src/mrpro/operators/models/WASABITI.py
@@ -4,6 +4,7 @@ import torch
 from torch import nn
 
 from mrpro.operators.SignalModel import SignalModel
+from mrpro.utils import unsqueeze_right
 
 
 class WASABITI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
@@ -79,8 +80,8 @@ class WASABITI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
             signal with shape (offsets ... other, coils, z, y, x)
         """
         delta_ndim = b0_shift.ndim - (self.offsets.ndim - 1)  # -1 for offset
-        offsets = self.expand_tensor_dim(self.offsets, delta_ndim)
-        trec = self.expand_tensor_dim(self.trec, delta_ndim)
+        offsets = unsqueeze_right(self.offsets, delta_ndim)
+        trec = unsqueeze_right(self.trec, delta_ndim)
 
         b1 = self.b1_nom * rb1
         da = offsets - b0_shift

--- a/src/mrpro/utils/__init__.py
+++ b/src/mrpro/utils/__init__.py
@@ -5,4 +5,5 @@ from mrpro.utils.remove_repeat import remove_repeat
 from mrpro.utils.zero_pad_or_crop import zero_pad_or_crop
 from mrpro.utils.modify_acq_info import modify_acq_info
 from mrpro.utils.split_idx import split_idx
-__all__ = ["slice_profiles", "typing", "smap", "remove_repeat", "zero_pad_or_crop", "modify_acq_info", "split_idx",]
+from mrpro.utils.reshape import broadcast_right, unsqueeze_left, unsqueeze_right
+__all__ = ["slice_profiles", "typing", "smap", "remove_repeat", "zero_pad_or_crop", "modify_acq_info", "split_idx", "broadcast_right", "unsqueeze_left", "unsqueeze_right"]

--- a/src/mrpro/utils/reshape.py
+++ b/src/mrpro/utils/reshape.py
@@ -27,7 +27,7 @@ def unsqueeze_left(x: torch.Tensor, n: int) -> torch.Tensor:
     """Unsqueze multiple times in the leftmost dimension.
 
     Example:
-        tensor with shape (1,2,3) and n=2 would result in tensor with shape (1,1,1,1,2,3)
+        tensor with shape (1,2,3) and n=2 would result in tensor with shape (1,1,1,2,3)
 
 
     Parameters

--- a/src/mrpro/utils/reshape.py
+++ b/src/mrpro/utils/reshape.py
@@ -36,7 +36,7 @@ def unsqueeze_left(x: torch.Tensor, n: int) -> torch.Tensor:
         tensor to unsqueeze
     n
         number of times to unsqueeze
-    
+
     Returns
     -------
     unsqueezed tensor (view)

--- a/src/mrpro/utils/reshape.py
+++ b/src/mrpro/utils/reshape.py
@@ -15,6 +15,10 @@ def unsqueeze_right(x: torch.Tensor, n: int) -> torch.Tensor:
         tensor to unsqueeze
     n
         number of times to unsqueeze
+
+    Returns
+    -------
+    unsqueezed tensor (view)
     """
     return x.reshape(*x.shape, *(n * (1,)))
 
@@ -32,6 +36,10 @@ def unsqueeze_left(x: torch.Tensor, n: int) -> torch.Tensor:
         tensor to unsqueeze
     n
         number of times to unsqueeze
+    
+    Returns
+    -------
+    unsqueezed tensor (view)
     """
     return x.reshape(*(n * (1,)), *x.shape)
 

--- a/src/mrpro/utils/reshape.py
+++ b/src/mrpro/utils/reshape.py
@@ -1,0 +1,61 @@
+"""Tensor reshaping utilities."""
+
+import torch
+
+
+def unsqueeze_right(x: torch.Tensor, n: int) -> torch.Tensor:
+    """Unsqueeze multiple times in the rightmost dimension.
+
+    Example:
+        tensor with shape (1,2,3) and n=2 would result in tensor with shape (1,2,3,1,1)
+
+    Parameters
+    ----------
+    x
+        tensor to unsqueeze
+    n
+        number of times to unsqueeze
+    """
+    return x.reshape(*x.shape, *(n * (1,)))
+
+
+def unsqueeze_left(x: torch.Tensor, n: int) -> torch.Tensor:
+    """Unsqueze multiple times in the leftmost dimension.
+
+    Example:
+        tensor with shape (1,2,3) and n=2 would result in tensor with shape (1,1,1,1,2,3)
+
+
+    Parameters
+    ----------
+    x
+        tensor to unsqueeze
+    n
+        number of times to unsqueeze
+    """
+    return x.reshape(*(n * (1,)), *x.shape)
+
+
+def broadcast_right(*x: torch.Tensor) -> tuple[torch.Tensor, ...]:
+    """Broadcasting on the right.
+
+    Given multiple tensors, apply broadcasting with unsqueezed on the right.
+    First, tensors are unsqueezed on the right to the same number of dimensions.
+    Then, torch.broadcasting is used.
+
+    Example:
+        tensors with shapes (1,2,3), (1,2), (2)
+        results in tensors with shape (2,2,3)
+
+    Parameters
+    ----------
+    x
+        tensors to broadcast
+
+    Returns
+    -------
+        broadcasted tensors (views)
+    """
+    max_dim = max(el.ndim for el in x)
+    unsqueezed = torch.broadcast_tensors(*(unsqueeze_right(el, max_dim - el.ndim) for el in x))
+    return unsqueezed

--- a/tests/utils/test_reshape.py
+++ b/tests/utils/test_reshape.py
@@ -1,3 +1,4 @@
+"""Tests for reshaping utilities."""
 import torch
 from mrpro.utils import broadcast_right, unsqueeze_left, unsqueeze_right
 

--- a/tests/utils/test_reshape.py
+++ b/tests/utils/test_reshape.py
@@ -1,0 +1,25 @@
+import torch
+from mrpro.utils import broadcast_right, unsqueeze_left, unsqueeze_right
+
+
+def test_broadcast_right():
+    """Test broadcast_right"""
+    tensors = (torch.ones(1, 2, 3), torch.ones(1, 2), torch.ones(2))
+    broadcasted = broadcast_right(*tensors)
+    assert broadcasted[0].shape == broadcasted[1].shape == broadcasted[2].shape == (2, 2, 3)
+
+
+def test_unsqueeze_left():
+    """Test unsqueeze left"""
+    tensor = torch.ones(1, 2, 3)
+    unsqueezed = unsqueeze_left(tensor, 2)
+    assert unsqueezed.shape == (1, 1, 1, 2, 3)
+    assert torch.equal(tensor.ravel(), unsqueezed.ravel())
+
+
+def test_unsqueeze_right():
+    """Test unsqueeze right"""
+    tensor = torch.ones(1, 2, 3)
+    unsqueezed = unsqueeze_right(tensor, 2)
+    assert unsqueezed.shape == (1, 2, 3, 1, 1)
+    assert torch.equal(tensor.ravel(), unsqueezed.ravel())

--- a/tests/utils/test_reshape.py
+++ b/tests/utils/test_reshape.py
@@ -1,4 +1,5 @@
 """Tests for reshaping utilities."""
+
 import torch
 from mrpro.utils import broadcast_right, unsqueeze_left, unsqueeze_right
 


### PR DESCRIPTION
Both are not implemented in pytorch
https://github.com/pytorch/pytorch/issues/9410
https://github.com/pytorch/pytorch/issues/130529
https://github.com/pytorch/pytorch/issues/62148

I moved the usage in the signal models already over.
There might be more uses of this pattern in our code base and future uses. This implementation works with torch.jit.