### PR TITLE
Python 3.10 support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.github
+.vscode
+binder
+examples
+docs
+tests

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,6 +62,7 @@ jobs:
     permissions:
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         dockerfile: ${{ fromJson(needs.get_dockerfiles.outputs.dockerfiles) }}
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -87,7 +87,9 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          context: ./docker
+          context: .
+          cache-from: type=gha,scope=${{ matrix.dockerfile }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.dockerfile }}
           file: ./docker/${{ matrix.dockerfile }}
           push: true
           tags: ${{ steps.image_name.outputs.image_name }}:test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -92,6 +92,7 @@ jobs:
       image: ghcr.io/ptb-mr/mrpro_py311:latest
       options: --user root
     strategy:
+      fail-fast: false
       matrix:
         notebook: ${{ fromJson(needs.get_notebooks.outputs.notebooks) }}
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -47,6 +47,7 @@ jobs:
       pull-requests: write
       contents: write
     strategy:
+      fail-fast: false 
       matrix:
         imagename: ${{ fromJson(needs.get_dockerfiles.outputs.imagenames) }}
     # runs within Docker container

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,7 @@ repos:
           - numpy
           - torch>=2.4.0
           - types-requests
+          - typing-extensions
           - einops
           - pydicom
           - matplotlib

--- a/docker/Dockerfile_py310
+++ b/docker/Dockerfile_py310
@@ -3,7 +3,7 @@ FROM ${BASE_IMAGE} AS base
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG PYTHON="python3.11"
+ARG PYTHON="python3.10"
 
 # install python
 COPY docker/install_system.sh .

--- a/docker/Dockerfile_py312
+++ b/docker/Dockerfile_py312
@@ -1,14 +1,23 @@
 ARG BASE_IMAGE=ubuntu:22.04
-FROM ${BASE_IMAGE} as base
+FROM ${BASE_IMAGE} AS base
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 ARG PYTHON="python3.12"
 
-# install python and mrpro dependencies
-COPY install_mrpro.sh .
-RUN bash install_mrpro.sh
-RUN rm install_mrpro.sh
+# install python
+COPY docker/install_system.sh .
+RUN bash install_system.sh && rm install_system.sh
+
+# install mrpro dependencies
+# forces rebuild if either the version or the pyproject.toml changes
+COPY docker/install_dependencies.sh pyproject.toml src/mrpro/VERSION ./
+RUN bash install_dependencies.sh && rm install_dependencies.sh pyproject.toml VERSION
+
+# install mrpro
+# forces rebuild on any change in the mrpro directory
+COPY . /mrpro/
+RUN python -m pip install  "/mrpro[notebook]" --no-cache-dir --upgrade --upgrade-strategy "eager" && rm -rf /mrpro
 
 # set user
 USER runner

--- a/docker/install_dependencies.sh
+++ b/docker/install_dependencies.sh
@@ -1,0 +1,21 @@
+# pre-install cpu-version of torch to avoid installation of cuda-version via dependencies
+python -m pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu
+
+#parse dependencies
+python -m pip install --no-cache-dir toml
+dependencies=$(python -c "
+import toml
+pyproject = toml.load('pyproject.toml')
+all_deps = (
+    pyproject['project']['dependencies'] + 
+    sum(pyproject['project'].get('optional-dependencies', {}).values(), [])
+)
+print(' '.join(f'\"{dep}\"' for dep in all_deps))
+")
+echo Dependencies to install: $dependencies
+
+# install dependencies
+eval python -m pip install --no-cache-dir --upgrade --upgrade-strategy "eager" $dependencies
+
+#clean up
+rm -rf /root/.cache

--- a/docker/install_system.sh
+++ b/docker/install_system.sh
@@ -1,4 +1,4 @@
-# define apt-get installation command
+# Commands
 APT_GET_INSTALL="apt-get install -yq --no-install-recommends"
 
 # update, qq: quiet
@@ -13,32 +13,26 @@ ${APT_GET_INSTALL} git software-properties-common gpg-agent
 # add repo for python installation
 add-apt-repository ppa:deadsnakes/ppa
 apt update -qq
+
 ${APT_GET_INSTALL} $PYTHON-full
+
+# pip
+if [[ "$PYTHON" == "python3.10" ]]; then
+    # System python on ubuntu does not support ensurepip
+    ${APT_GET_INSTALL} python3-pip
+else
+    $PYTHON -m ensurepip --upgrade
+fi
+$PYTHON -m pip install --upgrade pip --no-cache-dir
 
 # create alias for installed python version
 ln -s /usr/bin/$PYTHON /usr/local/bin/python
 ln -s /usr/bin/$PYTHON /usr/local/bin/python3
-
-pip install matplotlib
-
-# clone repo to get requirements
-git clone https://github.com/PTB-MR/mrpro --depth 1 /opt/mrpro
-cd /opt/mrpro
-python -m ensurepip --upgrade
-python -m pip install --upgrade pip
-
-# create alias to ensure pip works in the same way as pip3
 ln -s /usr/local/bin/pip3 /usr/local/bin/pip
 
-# pre-install cpu-version of torch to avoid installation of cuda-version via dependencies
-python -m pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu
-
-# install mrpro and dependencies
-python -m pip install --upgrade --upgrade-strategy "eager" .[notebook,test,docs]
-
 # clean up
-rm -r /opt/mrpro
 apt-get clean && rm -rf /var/lib/apt/lists/*
+rm -rf /root/.cache
 
 # add user runner
 adduser --disabled-password --gecos "" --uid 1001 runner \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ include-package-data = true
 name = "mrpro"
 description = "MR image reconstruction and processing package specifically developed for PyTorch."
 readme = "README.md"
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.10,<3.14"
 dynamic = ["version"]
 keywords = ["MRI, reconstruction, processing, PyTorch"]
 authors = [
@@ -38,6 +38,7 @@ authors = [
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
@@ -52,6 +53,7 @@ dependencies = [
     "torchkbnufft>=1.4.0",
     "scipy>=1.12",
     "ptwt>=0.1.8",
+    "typing-extensions>=4.12",
 ]
 
 [project.optional-dependencies]

--- a/src/mrpro/algorithms/optimizers/OptimizerStatus.py
+++ b/src/mrpro/algorithms/optimizers/OptimizerStatus.py
@@ -1,8 +1,7 @@
 """Optimizer Status base class."""
 
-from typing import TypedDict
-
 import torch
+from typing_extensions import TypedDict
 
 
 class OptimizerStatus(TypedDict):

--- a/src/mrpro/algorithms/optimizers/adam.py
+++ b/src/mrpro/algorithms/optimizers/adam.py
@@ -6,11 +6,11 @@ import torch
 from torch.optim import Adam, AdamW
 
 from mrpro.algorithms.optimizers.OptimizerStatus import OptimizerStatus
-from mrpro.operators.Operator import Operator
+from mrpro.operators.Operator import OperatorType
 
 
 def adam(
-    f: Operator[*tuple[torch.Tensor, ...], tuple[torch.Tensor]],
+    f: OperatorType,
     initial_parameters: Sequence[torch.Tensor],
     max_iter: int,
     lr: float = 1e-3,

--- a/src/mrpro/algorithms/optimizers/lbfgs.py
+++ b/src/mrpro/algorithms/optimizers/lbfgs.py
@@ -7,11 +7,11 @@ import torch
 from torch.optim import LBFGS
 
 from mrpro.algorithms.optimizers.OptimizerStatus import OptimizerStatus
-from mrpro.operators.Operator import Operator
+from mrpro.operators.Operator import OperatorType
 
 
 def lbfgs(
-    f: Operator[*tuple[torch.Tensor, ...], tuple[torch.Tensor]],
+    f: OperatorType,
     initial_parameters: Sequence[torch.Tensor],
     lr: float = 1.0,
     max_iter: int = 100,

--- a/src/mrpro/algorithms/reconstruction/Reconstruction.py
+++ b/src/mrpro/algorithms/reconstruction/Reconstruction.py
@@ -2,9 +2,10 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from typing import Literal, Self
+from typing import Literal
 
 import torch
+from typing_extensions import Self
 
 from mrpro.algorithms.prewhiten_kspace import prewhiten_kspace
 from mrpro.data._kdata.KData import KData

--- a/src/mrpro/data/AcqInfo.py
+++ b/src/mrpro/data/AcqInfo.py
@@ -2,11 +2,11 @@
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Self, TypeVar
 
 import ismrmrd
 import numpy as np
 import torch
+from typing_extensions import Self, TypeVar
 
 from mrpro.data.MoveDataMixin import MoveDataMixin
 from mrpro.data.SpatialDimension import SpatialDimension

--- a/src/mrpro/data/CsmData.py
+++ b/src/mrpro/data/CsmData.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING
 
 import torch
+from typing_extensions import Self
 
 from mrpro.data.IData import IData
 from mrpro.data.QData import QData

--- a/src/mrpro/data/Data.py
+++ b/src/mrpro/data/Data.py
@@ -2,9 +2,9 @@
 
 import dataclasses
 from abc import ABC
-from typing import Any
 
 import torch
+from typing_extensions import Any
 
 from mrpro.data.MoveDataMixin import MoveDataMixin
 

--- a/src/mrpro/data/DcfData.py
+++ b/src/mrpro/data/DcfData.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import dataclasses
 from functools import reduce
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING
 
 import torch
+from typing_extensions import Self
 
 from mrpro.algorithms.dcf.dcf_voronoi import dcf_1d, dcf_2d3d_voronoi
 from mrpro.data.KTrajectory import KTrajectory

--- a/src/mrpro/data/EncodingLimits.py
+++ b/src/mrpro/data/EncodingLimits.py
@@ -2,9 +2,9 @@
 
 import dataclasses
 from dataclasses import dataclass
-from typing import Self
 
 from ismrmrd.xsd.ismrmrdschema.ismrmrd import encodingLimitsType, limitType
+from typing_extensions import Self
 
 
 @dataclass(slots=True)

--- a/src/mrpro/data/IData.py
+++ b/src/mrpro/data/IData.py
@@ -3,7 +3,6 @@
 import dataclasses
 from collections.abc import Generator, Sequence
 from pathlib import Path
-from typing import Self
 
 import numpy as np
 import torch
@@ -11,6 +10,7 @@ from einops import repeat
 from pydicom import dcmread
 from pydicom.dataset import Dataset
 from pydicom.tag import TagType
+from typing_extensions import Self
 
 from mrpro.data.Data import Data
 from mrpro.data.IHeader import IHeader

--- a/src/mrpro/data/IHeader.py
+++ b/src/mrpro/data/IHeader.py
@@ -3,12 +3,12 @@
 import dataclasses
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Self
 
 import numpy as np
 import torch
 from pydicom.dataset import Dataset
 from pydicom.tag import Tag, TagType
+from typing_extensions import Self
 
 from mrpro.data.KHeader import KHeader
 from mrpro.data.MoveDataMixin import MoveDataMixin

--- a/src/mrpro/data/KHeader.py
+++ b/src/mrpro/data/KHeader.py
@@ -6,10 +6,11 @@ import dataclasses
 import datetime
 import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING
 
 import ismrmrd.xsd.ismrmrdschema.ismrmrd as ismrmrdschema
 import torch
+from typing_extensions import Self
 
 from mrpro.data import enums
 from mrpro.data.AcqInfo import AcqInfo, mm_to_m, ms_to_s

--- a/src/mrpro/data/KNoise.py
+++ b/src/mrpro/data/KNoise.py
@@ -3,11 +3,11 @@
 import dataclasses
 from collections.abc import Callable
 from pathlib import Path
-from typing import Self
 
 import ismrmrd
 import torch
 from einops import repeat
+from typing_extensions import Self
 
 from mrpro.data.acq_filters import is_noise_acquisition
 from mrpro.data.MoveDataMixin import MoveDataMixin

--- a/src/mrpro/data/KTrajectory.py
+++ b/src/mrpro/data/KTrajectory.py
@@ -1,10 +1,10 @@
 """KTrajectory dataclass."""
 
 from dataclasses import dataclass
-from typing import Self
 
 import numpy as np
 import torch
+from typing_extensions import Self
 
 from mrpro.data.enums import TrajType
 from mrpro.data.MoveDataMixin import MoveDataMixin

--- a/src/mrpro/data/MoveDataMixin.py
+++ b/src/mrpro/data/MoveDataMixin.py
@@ -4,9 +4,10 @@ import dataclasses
 from collections.abc import Iterator
 from copy import copy as shallowcopy
 from copy import deepcopy
-from typing import Any, ClassVar, Protocol, Self, TypeAlias, overload, runtime_checkable
+from typing import ClassVar, TypeAlias
 
 import torch
+from typing_extensions import Any, Protocol, Self, overload, runtime_checkable
 
 
 class InconsistentDeviceError(ValueError):  # noqa: D101

--- a/src/mrpro/data/QData.py
+++ b/src/mrpro/data/QData.py
@@ -2,12 +2,12 @@
 
 import dataclasses
 from pathlib import Path
-from typing import Self
 
 import numpy as np
 import torch
 from einops import repeat
 from pydicom import dcmread
+from typing_extensions import Self
 
 from mrpro.data.Data import Data
 from mrpro.data.IHeader import IHeader

--- a/src/mrpro/data/QHeader.py
+++ b/src/mrpro/data/QHeader.py
@@ -1,10 +1,10 @@
 """MR quantitative data header (QHeader) dataclass."""
 
 from dataclasses import dataclass
-from typing import Self
 
 from pydicom.dataset import Dataset
 from pydicom.tag import Tag
+from typing_extensions import Self
 
 from mrpro.data.IHeader import IHeader
 from mrpro.data.KHeader import KHeader

--- a/src/mrpro/data/Rotation.py
+++ b/src/mrpro/data/Rotation.py
@@ -45,12 +45,13 @@ from __future__ import annotations
 import re
 import warnings
 from collections.abc import Sequence
-from typing import Literal, Self, overload
+from typing import Literal
 
 import numpy as np
 import torch
 from scipy._lib._util import check_random_state
 from scipy.spatial.transform import Rotation as Rotation_scipy
+from typing_extensions import Self, overload
 
 from mrpro.data.SpatialDimension import SpatialDimension
 from mrpro.utils.typing import IndexerType, NestedSequence

--- a/src/mrpro/data/SpatialDimension.py
+++ b/src/mrpro/data/SpatialDimension.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Generic, Protocol, TypeVar
+from typing import Generic
 
 import numpy as np
 import torch
 from numpy.typing import ArrayLike
+from typing_extensions import Protocol, TypeVar
 
 from mrpro.data.MoveDataMixin import MoveDataMixin
 

--- a/src/mrpro/data/TrajectoryDescription.py
+++ b/src/mrpro/data/TrajectoryDescription.py
@@ -2,9 +2,9 @@
 
 import dataclasses
 from dataclasses import dataclass
-from typing import Self
 
 from ismrmrd.xsd.ismrmrdschema.ismrmrd import trajectoryDescriptionType
+from typing_extensions import Self
 
 
 @dataclass(slots=True)

--- a/src/mrpro/data/_kdata/KData.py
+++ b/src/mrpro/data/_kdata/KData.py
@@ -5,13 +5,13 @@ import datetime
 import warnings
 from collections.abc import Callable
 from pathlib import Path
-from typing import Self
 
 import h5py
 import ismrmrd
 import numpy as np
 import torch
 from einops import rearrange
+from typing_extensions import Self
 
 from mrpro.data._kdata.KDataRearrangeMixin import KDataRearrangeMixin
 from mrpro.data._kdata.KDataRemoveOsMixin import KDataRemoveOsMixin

--- a/src/mrpro/data/_kdata/KDataProtocol.py
+++ b/src/mrpro/data/_kdata/KDataProtocol.py
@@ -1,8 +1,9 @@
 """Protocol for KData."""
 
-from typing import Literal, Protocol, Self
+from typing import Literal
 
 import torch
+from typing_extensions import Protocol, Self
 
 from mrpro.data.KHeader import KHeader
 from mrpro.data.KTrajectory import KTrajectory

--- a/src/mrpro/data/_kdata/KDataRearrangeMixin.py
+++ b/src/mrpro/data/_kdata/KDataRearrangeMixin.py
@@ -1,9 +1,9 @@
 """Rearrange KData."""
 
 import copy
-from typing import Self
 
 from einops import rearrange
+from typing_extensions import Self
 
 from mrpro.data._kdata.KDataProtocol import _KDataProtocol
 from mrpro.data.AcqInfo import AcqInfo

--- a/src/mrpro/data/_kdata/KDataRemoveOsMixin.py
+++ b/src/mrpro/data/_kdata/KDataRemoveOsMixin.py
@@ -1,9 +1,9 @@
 """Remove oversampling along readout dimension."""
 
 from copy import deepcopy
-from typing import Self
 
 import torch
+from typing_extensions import Self
 
 from mrpro.data._kdata.KDataProtocol import _KDataProtocol
 from mrpro.data.KTrajectory import KTrajectory
@@ -49,7 +49,7 @@ class KDataRemoveOsMixin(_KDataProtocol):
         start_cropped_readout = (self.header.encoding_matrix.x - self.header.recon_matrix.x) // 2
         end_cropped_readout = start_cropped_readout + self.header.recon_matrix.x
 
-        def crop_readout(data_to_crop: torch.Tensor):
+        def crop_readout(data_to_crop: torch.Tensor) -> torch.Tensor:
             # returns a cropped copy
             return data_to_crop[..., start_cropped_readout:end_cropped_readout].clone()
 
@@ -61,7 +61,7 @@ class KDataRemoveOsMixin(_KDataProtocol):
         ks = [self.traj.kz, self.traj.ky, self.traj.kx]
         # only cropped ks that are not broadcasted/singleton along k0
         cropped_ks = [crop_readout(k) if k.shape[-1] > 1 else k.clone() for k in ks]
-        cropped_traj = KTrajectory(*cropped_ks)
+        cropped_traj = KTrajectory(cropped_ks[0], cropped_ks[1], cropped_ks[2])
 
         # Adapt header parameters
         header = deepcopy(self.header)

--- a/src/mrpro/data/_kdata/KDataSelectMixin.py
+++ b/src/mrpro/data/_kdata/KDataSelectMixin.py
@@ -1,9 +1,10 @@
 """Select subset along other dimensions of KData."""
 
 import copy
-from typing import Literal, Self
+from typing import Literal
 
 import torch
+from typing_extensions import Self
 
 from mrpro.data._kdata.KDataProtocol import _KDataProtocol
 from mrpro.utils import modify_acq_info

--- a/src/mrpro/data/_kdata/KDataSplitMixin.py
+++ b/src/mrpro/data/_kdata/KDataSplitMixin.py
@@ -1,10 +1,11 @@
 """Mixin class to split KData into other subsets."""
 
 import copy
-from typing import Literal, Self
+from typing import Literal
 
 import torch
 from einops import rearrange, repeat
+from typing_extensions import Self
 
 from mrpro.data._kdata.KDataProtocol import _KDataProtocol
 from mrpro.data.EncodingLimits import Limits

--- a/src/mrpro/operators/EndomorphOperator.py
+++ b/src/mrpro/operators/EndomorphOperator.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Callable
-from typing import Any, ParamSpec, Protocol, TypeAlias, TypeVar, TypeVarTuple, cast, overload
+from typing import TypeAlias, cast
 
 import torch
+from typing_extensions import Any, ParamSpec, Protocol, TypeVar, TypeVarTuple, Unpack, overload
 
 import mrpro.operators
 from mrpro.operators.Operator import Operator
@@ -172,7 +173,7 @@ class _EndomorphCallable(Protocol):
         torch.Tensor,
         torch.Tensor,
         torch.Tensor,
-        *tuple[torch.Tensor, ...],
+        Unpack[tuple[torch.Tensor, ...]],
     ]: ...
 
     @overload
@@ -191,7 +192,7 @@ def endomorph(f: F, /) -> _EndomorphCallable:
     return f
 
 
-class EndomorphOperator(Operator[*tuple[torch.Tensor, ...], tuple[torch.Tensor, ...]]):
+class EndomorphOperator(Operator[Unpack[tuple[torch.Tensor, ...]], tuple[torch.Tensor, ...]]):
     """Endomorph Operator.
 
     Endomorph Operators have N tensor inputs and exactly N outputs.
@@ -211,9 +212,11 @@ class EndomorphOperator(Operator[*tuple[torch.Tensor, ...], tuple[torch.Tensor, 
     @overload
     def __matmul__(self, other: EndomorphOperator) -> EndomorphOperator: ...
     @overload
-    def __matmul__(self, other: Operator[*Tin, Tout]) -> Operator[*Tin, Tout]: ...
+    def __matmul__(self, other: Operator[Unpack[Tin], Tout]) -> Operator[Unpack[Tin], Tout]: ...
 
-    def __matmul__(self, other: Operator[*Tin, Tout] | EndomorphOperator) -> Operator[*Tin, Tout] | EndomorphOperator:
+    def __matmul__(
+        self, other: Operator[Unpack[Tin], Tout] | EndomorphOperator
+    ) -> Operator[Unpack[Tin], Tout] | EndomorphOperator:
         """Operator composition."""
         if isinstance(other, mrpro.operators.MultiIdentityOp):
             return self
@@ -224,8 +227,8 @@ class EndomorphOperator(Operator[*tuple[torch.Tensor, ...], tuple[torch.Tensor, 
         if isinstance(other, EndomorphOperator):
             return cast(EndomorphOperator, res)
         else:
-            return cast(Operator[*Tin, Tout], res)
+            return cast(Operator[Unpack[Tin], Tout], res)
 
-    def __rmatmul__(self, other: Operator[*Tin, Tout]) -> Operator[*Tin, Tout]:
+    def __rmatmul__(self, other: Operator[Unpack[Tin], Tout]) -> Operator[Unpack[Tin], Tout]:
         """Operator composition."""
-        return other.__matmul__(cast(Operator[*Tin, tuple[*Tin]], self))
+        return other.__matmul__(cast(Operator[Unpack[Tin], tuple[Unpack[Tin]]], self))

--- a/src/mrpro/operators/FourierOp.py
+++ b/src/mrpro/operators/FourierOp.py
@@ -1,11 +1,11 @@
 """Fourier Operator."""
 
 from collections.abc import Sequence
-from typing import Self
 
 import numpy as np
 import torch
 from torchkbnufft import KbNufft, KbNufftAdjoint
+from typing_extensions import Self
 
 from mrpro.data._kdata.KData import KData
 from mrpro.data.enums import TrajType

--- a/src/mrpro/operators/LinearOperator.py
+++ b/src/mrpro/operators/LinearOperator.py
@@ -6,9 +6,10 @@ import operator
 from abc import abstractmethod
 from collections.abc import Callable, Sequence
 from functools import reduce
-from typing import Any, cast, no_type_check, overload
+from typing import cast, no_type_check
 
 import torch
+from typing_extensions import Any, Unpack, overload
 
 import mrpro.operators
 from mrpro.operators.Operator import (
@@ -194,11 +195,13 @@ class LinearOperator(Operator[torch.Tensor, tuple[torch.Tensor]]):
     def __matmul__(self, other: LinearOperator) -> LinearOperator: ...
 
     @overload
-    def __matmul__(self, other: Operator[*Tin2, tuple[torch.Tensor,]]) -> Operator[*Tin2, tuple[torch.Tensor,]]: ...
+    def __matmul__(
+        self, other: Operator[Unpack[Tin2], tuple[torch.Tensor,]]
+    ) -> Operator[Unpack[Tin2], tuple[torch.Tensor,]]: ...
 
     def __matmul__(
-        self, other: Operator[*Tin2, tuple[torch.Tensor,]] | LinearOperator
-    ) -> Operator[*Tin2, tuple[torch.Tensor,]] | LinearOperator:
+        self, other: Operator[Unpack[Tin2], tuple[torch.Tensor,]] | LinearOperator
+    ) -> Operator[Unpack[Tin2], tuple[torch.Tensor,]] | LinearOperator:
         """Operator composition.
 
         Returns lambda x: self(other(x))
@@ -213,7 +216,7 @@ class LinearOperator(Operator[torch.Tensor, tuple[torch.Tensor]]):
             return LinearOperatorComposition(self, other)
         elif isinstance(other, Operator):
             # cast due to https://github.com/python/mypy/issues/16335
-            return OperatorComposition(self, cast(Operator[*Tin2, tuple[torch.Tensor,]], other))
+            return OperatorComposition(self, cast(Operator[Unpack[Tin2], tuple[torch.Tensor,]], other))
         return NotImplemented  # type: ignore[unreachable]
 
     def __radd__(self, other: torch.Tensor) -> LinearOperator:

--- a/src/mrpro/operators/MultiIdentityOp.py
+++ b/src/mrpro/operators/MultiIdentityOp.py
@@ -1,8 +1,7 @@
 """Identity Operator with arbitrary number of inputs."""
 
-from typing import Self
-
 import torch
+from typing_extensions import Self
 
 from mrpro.operators.EndomorphOperator import EndomorphOperator, endomorph
 

--- a/src/mrpro/operators/Operator.py
+++ b/src/mrpro/operators/Operator.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from functools import reduce
-from typing import Generic, TypeVar, TypeVarTuple, cast, overload
+from typing import Generic, TypeAlias, cast
 
 import torch
+from typing_extensions import TypeVar, TypeVarTuple, Unpack, overload
 
 import mrpro.operators
 
@@ -15,26 +16,30 @@ Tin2 = TypeVarTuple('Tin2')  # TODO: bind to torch.Tensors
 Tout = TypeVar('Tout', bound=tuple, covariant=True)  # TODO: bind to torch.Tensors
 
 
-class Operator(Generic[*Tin, Tout], ABC, torch.nn.Module):
+class Operator(Generic[Unpack[Tin], Tout], ABC, torch.nn.Module):
     """The general Operator class."""
 
     @abstractmethod
-    def forward(self, *args: *Tin) -> Tout:
+    def forward(self, *args: Unpack[Tin]) -> Tout:
         """Apply forward operator."""
         ...
 
-    def __call__(self, *args: *Tin) -> Tout:
+    def __call__(self, *args: Unpack[Tin]) -> Tout:
         """Apply the forward operator."""
         return super().__call__(*args)
 
-    def __matmul__(self: Operator[*Tin, Tout], other: Operator[*Tin2, tuple[*Tin]]) -> Operator[*Tin2, Tout]:
+    def __matmul__(
+        self: Operator[Unpack[Tin], Tout], other: Operator[Unpack[Tin2], tuple[Unpack[Tin]]]
+    ) -> Operator[Unpack[Tin2], Tout]:
         """Operator composition.
 
         Returns lambda x: self(other(x))
         """
         return OperatorComposition(self, other)
 
-    def __radd__(self: Operator[*Tin, tuple[*Tin]], other: torch.Tensor) -> Operator[*Tin, tuple[*Tin]]:
+    def __radd__(
+        self: Operator[Unpack[Tin], tuple[Unpack[Tin]]], other: torch.Tensor
+    ) -> Operator[Unpack[Tin], tuple[Unpack[Tin]]]:
         """Operator right addition.
 
         Returns lambda x: other*x + self(x)
@@ -42,38 +47,40 @@ class Operator(Generic[*Tin, Tout], ABC, torch.nn.Module):
         return self + other
 
     @overload
-    def __add__(self, other: Operator[*Tin, Tout]) -> Operator[*Tin, Tout]: ...
+    def __add__(self, other: Operator[Unpack[Tin], Tout]) -> Operator[Unpack[Tin], Tout]: ...
     @overload
-    def __add__(self: Operator[*Tin, tuple[*Tin]], other: torch.Tensor) -> Operator[*Tin, tuple[*Tin]]: ...
+    def __add__(
+        self: Operator[Unpack[Tin], tuple[Unpack[Tin]]], other: torch.Tensor
+    ) -> Operator[Unpack[Tin], tuple[Unpack[Tin]]]: ...
 
     def __add__(
-        self, other: Operator[*Tin, Tout] | torch.Tensor | mrpro.operators.ZeroOp
-    ) -> Operator[*Tin, Tout] | Operator[*Tin, tuple[*Tin]]:
+        self, other: Operator[Unpack[Tin], Tout] | torch.Tensor | mrpro.operators.ZeroOp
+    ) -> Operator[Unpack[Tin], Tout] | Operator[Unpack[Tin], tuple[Unpack[Tin]]]:
         """Operator addition.
 
         Returns lambda x: self(x) + other(x) if other is a operator,
         lambda x: self(x) + other*x if other is a tensor
         """
         if isinstance(other, torch.Tensor):
-            s = cast(Operator[*Tin, tuple[*Tin]], self)
-            o = cast(Operator[*Tin, tuple[*Tin]], mrpro.operators.MultiIdentityOp() * other)
+            s = cast(Operator[Unpack[Tin], tuple[Unpack[Tin]]], self)
+            o = cast(Operator[Unpack[Tin], tuple[Unpack[Tin]]], mrpro.operators.MultiIdentityOp() * other)
             return OperatorSum(s, o)
         elif isinstance(other, mrpro.operators.ZeroOp):
             return self
         elif isinstance(other, Operator):
             return OperatorSum(
-                cast(Operator[*Tin, Tout], other), self
+                cast(Operator[Unpack[Tin], Tout], other), self
             )  # cast due to https://github.com/python/mypy/issues/16335
         return NotImplemented  # type: ignore[unreachable]
 
-    def __mul__(self, other: torch.Tensor | complex) -> Operator[*Tin, Tout]:
+    def __mul__(self, other: torch.Tensor | complex) -> Operator[Unpack[Tin], Tout]:
         """Operator multiplication with tensor.
 
         Returns lambda x: self(x*other)
         """
         return OperatorElementwiseProductLeft(self, other)
 
-    def __rmul__(self, other: torch.Tensor | complex) -> Operator[*Tin, Tout]:
+    def __rmul__(self, other: torch.Tensor | complex) -> Operator[Unpack[Tin], Tout]:
         """Operator multiplication with tensor.
 
         Returns lambda x: other*self(x)
@@ -81,10 +88,10 @@ class Operator(Generic[*Tin, Tout], ABC, torch.nn.Module):
         return OperatorElementwiseProductRight(self, other)
 
 
-class OperatorComposition(Operator[*Tin2, Tout]):
+class OperatorComposition(Operator[Unpack[Tin2], Tout]):
     """Operator composition."""
 
-    def __init__(self, operator1: Operator[*Tin, Tout], operator2: Operator[*Tin2, tuple[*Tin]]):
+    def __init__(self, operator1: Operator[Unpack[Tin], Tout], operator2: Operator[Unpack[Tin2], tuple[Unpack[Tin]]]):
         """Operator composition initialization.
 
         Returns lambda x: operator1(operator2(x))
@@ -100,28 +107,28 @@ class OperatorComposition(Operator[*Tin2, Tout]):
         self._operator1 = operator1
         self._operator2 = operator2
 
-    def forward(self, *args: *Tin2) -> Tout:
+    def forward(self, *args: Unpack[Tin2]) -> Tout:
         """Operator composition."""
         return self._operator1(*self._operator2(*args))
 
 
-class OperatorSum(Operator[*Tin, Tout]):
+class OperatorSum(Operator[Unpack[Tin], Tout]):
     """Operator addition."""
 
-    _operators: list[Operator[*Tin, Tout]]  # actually a torch.nn.ModuleList
+    _operators: list[Operator[Unpack[Tin], Tout]]  # actually a torch.nn.ModuleList
 
-    def __init__(self, operator1: Operator[*Tin, Tout], /, *other_operators: Operator[*Tin, Tout]):
+    def __init__(self, operator1: Operator[Unpack[Tin], Tout], /, *other_operators: Operator[Unpack[Tin], Tout]):
         """Operator addition initialization."""
         super().__init__()
-        ops: list[Operator[*Tin, Tout]] = []
+        ops: list[Operator[Unpack[Tin], Tout]] = []
         for op in (operator1, *other_operators):
             if isinstance(op, OperatorSum):
                 ops.extend(op._operators)
             else:
                 ops.append(op)
-        self._operators = cast(list[Operator[*Tin, Tout]], torch.nn.ModuleList(ops))
+        self._operators = cast(list[Operator[Unpack[Tin], Tout]], torch.nn.ModuleList(ops))
 
-    def forward(self, *args: *Tin) -> Tout:
+    def forward(self, *args: Unpack[Tin]) -> Tout:
         """Operator addition."""
 
         def _add(a: tuple[torch.Tensor, ...], b: tuple[torch.Tensor, ...]) -> Tout:
@@ -131,38 +138,41 @@ class OperatorSum(Operator[*Tin, Tout]):
         return result
 
 
-class OperatorElementwiseProductRight(Operator[*Tin, Tout]):
+class OperatorElementwiseProductRight(Operator[Unpack[Tin], Tout]):
     """Operator elementwise right multiplication with a tensor.
 
     Performs Tensor*Operator(x)
     """
 
-    def __init__(self, operator: Operator[*Tin, Tout], scalar: torch.Tensor | complex):
+    def __init__(self, operator: Operator[Unpack[Tin], Tout], scalar: torch.Tensor | complex):
         """Operator elementwise right multiplication initialization."""
         super().__init__()
         self._operator = operator
         self._scalar = scalar
 
-    def forward(self, *args: *Tin) -> Tout:
+    def forward(self, *args: Unpack[Tin]) -> Tout:
         """Operator elementwise right multiplication."""
         out = self._operator(*args)
         return cast(Tout, tuple(a * self._scalar for a in out))
 
 
-class OperatorElementwiseProductLeft(Operator[*Tin, Tout]):
+class OperatorElementwiseProductLeft(Operator[Unpack[Tin], Tout]):
     """Operator elementwise left multiplication  with a tensor.
 
     Performs Operator(x*Tensor)
     """
 
-    def __init__(self, operator: Operator[*Tin, Tout], scalar: torch.Tensor | complex):
+    def __init__(self, operator: Operator[Unpack[Tin], Tout], scalar: torch.Tensor | complex):
         """Operator elementwise left multiplication initialization."""
         super().__init__()
         self._operator = operator
         self._scalar = scalar
 
-    def forward(self, *args: *Tin) -> Tout:
+    def forward(self, *args: Unpack[Tin]) -> Tout:
         """Operator elementwise left multiplication."""
-        multiplied = cast(tuple[*Tin], tuple(a * self._scalar for a in args if isinstance(a, torch.Tensor)))
+        multiplied = cast(tuple[Unpack[Tin]], tuple(a * self._scalar for a in args if isinstance(a, torch.Tensor)))
         out = self._operator(*multiplied)
         return cast(Tout, out)
+
+
+OperatorType: TypeAlias = Operator[Unpack[tuple[torch.Tensor, ...]], tuple[torch.Tensor, ...]]

--- a/src/mrpro/operators/ProximableFunctionalSeparableSum.py
+++ b/src/mrpro/operators/ProximableFunctionalSeparableSum.py
@@ -5,15 +5,16 @@ from __future__ import annotations
 import operator
 from collections.abc import Iterator
 from functools import reduce
-from typing import Self, cast
+from typing import cast
 
 import torch
+from typing_extensions import Self, Unpack
 
 from mrpro.operators.Functional import ProximableFunctional
 from mrpro.operators.Operator import Operator
 
 
-class ProximableFunctionalSeparableSum(Operator[*tuple[torch.Tensor, ...], tuple[torch.Tensor]]):
+class ProximableFunctionalSeparableSum(Operator[Unpack[tuple[torch.Tensor, ...]], tuple[torch.Tensor]]):
     r"""Separabke Sum of Proximable Functionals.
 
     This is a separable sum of the functionals. The forward method returns the sum of the functionals

--- a/src/mrpro/operators/SignalModel.py
+++ b/src/mrpro/operators/SignalModel.py
@@ -1,8 +1,7 @@
 """Signal Model Operators."""
 
-from typing import TypeVarTuple
-
 import torch
+from typing_extensions import TypeVarTuple, Unpack
 
 from mrpro.operators.Operator import Operator
 
@@ -10,5 +9,5 @@ Tin = TypeVarTuple('Tin')
 
 
 # SignalModel has multiple inputs and one output
-class SignalModel(Operator[*Tin, tuple[torch.Tensor,]]):
+class SignalModel(Operator[Unpack[Tin], tuple[torch.Tensor,]]):
     """Signal Model Operator."""

--- a/src/mrpro/utils/typing.py
+++ b/src/mrpro/utils/typing.py
@@ -1,13 +1,16 @@
 """Some type hints that are used in multiple places in the codebase but not part of mrpro's public API."""
 
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, TypeAlias
+
+from typing_extensions import Any
 
 if TYPE_CHECKING:
     from types import EllipsisType
-    from typing import SupportsIndex, TypeAlias
+    from typing import TypeAlias
 
     import torch
     from torch._C import _NestedSequence as NestedSequence
+    from typing_extensions import SupportsIndex
 
     # This matches the torch.Tensor indexer typehint
     _IndexerTypeInner: TypeAlias = None | bool | int | slice | EllipsisType | torch.Tensor

--- a/tests/data/test_movedatamixin.py
+++ b/tests/data/test_movedatamixin.py
@@ -1,11 +1,11 @@
 """Tests the MoveDataMixin class."""
 
 from dataclasses import dataclass, field
-from typing import Any
 
 import pytest
 import torch
 from mrpro.data import MoveDataMixin
+from typing_extensions import Any
 
 
 class SharedModule(torch.nn.Module):

--- a/tests/operators/functionals/test_functionals.py
+++ b/tests/operators/functionals/test_functionals.py
@@ -1,10 +1,11 @@
 from copy import deepcopy
-from typing import Literal, TypedDict
+from typing import Literal
 
 import pytest
 import torch
 from mrpro.operators.Functional import ElementaryFunctional, ElementaryProximableFunctional
 from mrpro.operators.functionals import L1Norm, L1NormViewAsReal, L2NormSquared, ZeroFunctional
+from typing_extensions import TypedDict
 
 from tests import RandomGenerator
 from tests.operators.functionals.conftest import (

--- a/tests/operators/test_identity_op.py
+++ b/tests/operators/test_identity_op.py
@@ -1,10 +1,9 @@
 """Tests for Identity Linear Operator and MultiIdentity Operator."""
 
-from typing import assert_type
-
 import torch
 from mrpro.operators import IdentityOp, MagnitudeOp, MultiIdentityOp
 from mrpro.operators.LinearOperator import LinearOperator
+from typing_extensions import assert_type
 
 from tests import RandomGenerator
 

--- a/tests/operators/test_operators.py
+++ b/tests/operators/test_operators.py
@@ -1,10 +1,11 @@
 """Tests for the operators module."""
 
-from typing import Any, assert_type, cast
+from typing import cast
 
 import pytest
 import torch
 from mrpro.operators import LinearOperator, Operator
+from typing_extensions import Any, assert_type
 
 from tests import RandomGenerator
 from tests.helper import dotproduct_adjointness_test

--- a/tests/operators/test_zero_op.py
+++ b/tests/operators/test_zero_op.py
@@ -1,8 +1,7 @@
-from typing import assert_type
-
 import torch
 from mrpro.operators import IdentityOp, LinearOperator, MagnitudeOp, Operator, ZeroOp
 from mrpro.operators.LinearOperator import LinearOperatorSum
+from typing_extensions import assert_type
 
 from tests import RandomGenerator
 from tests.helper import dotproduct_adjointness_test


### PR DESCRIPTION
Change our code to support python3.10 again --> colab!

Import all typing stuff from `typing_extension` which backports typing features and in current python versions, reexports from typing.

Replace tuple unpacking in typehints by `Unpack`. This look a bit less nice but might be an ok trade-off.
We can revert this commit if we want to drop python3.10 support again


Add a docker container for python 3.10

Refactor docker files: installing from github via clone will created chicken and egg problem as main was not installable in python 3.10. docker containers are now split in steps that might be cached. 

Biggest difference is, our dependencies in the docker container will only update if we touch the pyproject.toml.
If we want to, we can also update them on updates to VERSION, for example.

Closes #456 