### PR TITLE
Hotfix Python3.10 support

### DIFF
--- a/src/mrpro/data/Rotation.py
+++ b/src/mrpro/data/Rotation.py
@@ -53,7 +53,7 @@ import torch
 import torch.nn.functional as F  # noqa: N812
 from einops import rearrange
 from scipy._lib._util import check_random_state
-from typing_extensions import Self, overload
+from typing_extensions import Self, Unpack, overload
 
 from mrpro.data.SpatialDimension import SpatialDimension
 from mrpro.utils.typing import IndexerType, NestedSequence
@@ -601,7 +601,7 @@ class Rotation(torch.nn.Module):
 
     @classmethod
     def from_directions(
-        cls, *basis: *tuple[SpatialDimension, SpatialDimension, SpatialDimension], allow_improper: bool = True
+        cls, *basis: Unpack[tuple[SpatialDimension, SpatialDimension, SpatialDimension]], allow_improper: bool = True
     ):
         """Initialize from basis vectors as SpatialDimensions.
 


### PR DESCRIPTION
I messed up merging the Rotation-stuff (#441) and the python3.10 backport (#461) :
I did not set pytest-3.10 as a requiered check for merging after adding the python 3.10 support back in.
Also, I used auto-merge on the Rotation-PR. 
Thus, after fixing the merge conflict (without switching back to a 3.10 compativle syntax in Rotation.py) it got auto merged as all requiered checks succeeded. 

Fix:
- I made python3.10 a requiered check for PRs
- This fixes main to pass the check

Without this PR, all following PRs will not be mergable.
