### PR TITLE
Add pandoc to docker for docs build

### DIFF
--- a/docker/install_system.sh
+++ b/docker/install_system.sh
@@ -8,7 +8,7 @@ apt-get update -qq
 ${APT_GET_INSTALL} --reinstall ca-certificates
 
 # base utilities
-${APT_GET_INSTALL} git software-properties-common gpg-agent
+${APT_GET_INSTALL} git software-properties-common gpg-agent pandoc
 
 # add repo for python installation
 add-apt-repository ppa:deadsnakes/ppa


### PR DESCRIPTION
Sphinx docs build with `nbsphinx` requires `pandoc` to be installed.

Unfortunely, in contrary to `conda`, it's not possible get the `pandoc` binary directly via `pip`.

I guess that dealing with `apt` installation in GitHub actions for docs would not considered as good practice and here is the right place.  