### PR TITLE
Add pre-commit check for __all__

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,13 @@ repos:
     hooks:
       - id: typos
 
+  - repo: https://github.com/fzimmermann89/check_all
+    rev: v1.0
+    hooks:
+      - id: check-init-all
+        args: [--double-quotes]
+        exclude: ^tests/
+
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.11.2
     hooks:
@@ -45,6 +52,7 @@ repos:
           - xsdata
           - "--index-url=https://download.pytorch.org/whl/cpu"
           - "--extra-index-url=https://pypi.python.org/simple"
+
 ci:
     autofix_commit_msg: |
         [pre-commit] auto fixes from pre-commit hooks

--- a/src/mrpro/__init__.py
+++ b/src/mrpro/__init__.py
@@ -1,4 +1,10 @@
 from mrpro._version import __version__
 from mrpro import algorithms, operators, data, phantoms, utils
-__all__ = ["algorithms", "operators", "data", "phantoms", "utils"]
-
+__all__ = [
+    "__version__",
+    "algorithms",
+    "data",
+    "operators",
+    "phantoms",
+    "utils"
+]

--- a/src/mrpro/algorithms/__init__.py
+++ b/src/mrpro/algorithms/__init__.py
@@ -1,3 +1,3 @@
 from mrpro.algorithms import csm, optimizers, reconstruction
 from mrpro.algorithms.prewhiten_kspace import prewhiten_kspace
-__all__ = ["csm", "optimizers", "reconstruction", "prewhiten_kspace"]
+__all__ = ["csm", "optimizers", "prewhiten_kspace", "reconstruction"]

--- a/src/mrpro/algorithms/csm/__init__.py
+++ b/src/mrpro/algorithms/csm/__init__.py
@@ -1,3 +1,3 @@
 from mrpro.algorithms.csm.walsh import walsh
 from mrpro.algorithms.csm.inati import inati
-__all__ = ["walsh", "inati"]
+__all__ = ["inati", "walsh"]

--- a/src/mrpro/algorithms/reconstruction/__init__.py
+++ b/src/mrpro/algorithms/reconstruction/__init__.py
@@ -1,4 +1,8 @@
 from mrpro.algorithms.reconstruction.Reconstruction import Reconstruction
 from mrpro.algorithms.reconstruction.DirectReconstruction import DirectReconstruction
 from mrpro.algorithms.reconstruction.IterativeSENSEReconstruction import IterativeSENSEReconstruction
-__all__ = ["Reconstruction", "DirectReconstruction", "IterativeSENSEReconstruction"]
+__all__ = [
+    "DirectReconstruction",
+    "IterativeSENSEReconstruction",
+    "Reconstruction"
+]

--- a/src/mrpro/data/__init__.py
+++ b/src/mrpro/data/__init__.py
@@ -17,4 +17,28 @@ from mrpro.data.QHeader import QHeader
 from mrpro.data.Rotation import Rotation
 from mrpro.data.SpatialDimension import SpatialDimension
 from mrpro.data.TrajectoryDescription import TrajectoryDescription
-__all__ = ["enums", "traj_calculators", "acq_filters", "AcqIdx", "AcqInfo", "CsmData", "Data", "DcfData", "EncodingLimits", "Limits", "IData", "IHeader", "KData", "KHeader", "KNoise", "KTrajectory", "KTrajectoryRawShape", "MoveDataMixin", "QData", "QHeader", "Rotation", "SpatialDimension", "TrajectoryDescription"]
+__all__ = [
+    "AcqIdx",
+    "AcqInfo",
+    "CsmData",
+    "Data",
+    "DcfData",
+    "EncodingLimits",
+    "IData",
+    "IHeader",
+    "KData",
+    "KHeader",
+    "KNoise",
+    "KTrajectory",
+    "KTrajectoryRawShape",
+    "Limits",
+    "MoveDataMixin",
+    "QData",
+    "QHeader",
+    "Rotation",
+    "SpatialDimension",
+    "TrajectoryDescription",
+    "acq_filters",
+    "enums",
+    "traj_calculators"
+]

--- a/src/mrpro/data/traj_calculators/__init__.py
+++ b/src/mrpro/data/traj_calculators/__init__.py
@@ -5,4 +5,12 @@ from mrpro.data.traj_calculators.KTrajectoryRadial2D import KTrajectoryRadial2D
 from mrpro.data.traj_calculators.KTrajectoryIsmrmrd import KTrajectoryIsmrmrd
 from mrpro.data.traj_calculators.KTrajectoryPulseq import KTrajectoryPulseq
 from mrpro.data.traj_calculators.KTrajectoryCartesian import KTrajectoryCartesian
-__all__ = ["KTrajectoryCalculator", "KTrajectoryRpe", "KTrajectorySunflowerGoldenRpe", "KTrajectoryRadial2D", "KTrajectoryIsmrmrd", "KTrajectoryPulseq", "KTrajectoryCartesian"]
+__all__ = [
+    "KTrajectoryCalculator",
+    "KTrajectoryCartesian",
+    "KTrajectoryIsmrmrd",
+    "KTrajectoryPulseq",
+    "KTrajectoryRadial2D",
+    "KTrajectoryRpe",
+    "KTrajectorySunflowerGoldenRpe"
+]

--- a/src/mrpro/operators/__init__.py
+++ b/src/mrpro/operators/__init__.py
@@ -23,8 +23,6 @@ from mrpro.operators.ZeroPadOp import ZeroPadOp
 from mrpro.operators.ZeroOp import ZeroOp
 
 __all__ = [
-    "functionals",
-    "models",
     "CartesianSamplingOp",
     "ConstraintsOp",
     "DensityCompensationOp",
@@ -39,14 +37,19 @@ __all__ = [
     "IdentityOp",
     "LinearOperator",
     "MagnitudeOp",
+    "MultiIdentityOp",
     "Operator",
     "PhaseOp",
     "ProximableFunctional",
     "ProximableFunctionalSeparableSum",
+    "ScaledFunctional",
+    "ScaledProximableFunctional",
     "SensitivityOp",
     "SignalModel",
     "SliceProjectionOp",
     "WaveletOp",
     "ZeroOp",
     "ZeroPadOp",
+    "functionals",
+    "models"
 ]

--- a/src/mrpro/operators/models/__init__.py
+++ b/src/mrpro/operators/models/__init__.py
@@ -5,4 +5,12 @@ from mrpro.operators.models.WASABI import WASABI
 from mrpro.operators.models.WASABITI import WASABITI
 from mrpro.operators.models.MonoExponentialDecay import MonoExponentialDecay
 from mrpro.operators.models.TransientSteadyStateWithPreparation import TransientSteadyStateWithPreparation
-__all__ = ["SaturationRecovery", "InversionRecovery", "MOLLI", "WASABI", "WASABITI", "MonoExponentialDecay", "TransientSteadyStateWithPreparation"]
+__all__ = [
+    "InversionRecovery",
+    "MOLLI",
+    "MonoExponentialDecay",
+    "SaturationRecovery",
+    "TransientSteadyStateWithPreparation",
+    "WASABI",
+    "WASABITI"
+]

--- a/src/mrpro/phantoms/__init__.py
+++ b/src/mrpro/phantoms/__init__.py
@@ -1,3 +1,3 @@
 from mrpro.phantoms.EllipsePhantom import EllipsePhantom
 from mrpro.phantoms.phantom_elements import EllipseParameters
-__all__ = ["EllipsePhantom", "EllipseParameters"]
+__all__ = ["EllipseParameters", "EllipsePhantom"]

--- a/src/mrpro/utils/__init__.py
+++ b/src/mrpro/utils/__init__.py
@@ -6,4 +6,15 @@ from mrpro.utils.zero_pad_or_crop import zero_pad_or_crop
 from mrpro.utils.modify_acq_info import modify_acq_info
 from mrpro.utils.split_idx import split_idx
 from mrpro.utils.reshape import broadcast_right, unsqueeze_left, unsqueeze_right
-__all__ = ["slice_profiles", "typing", "smap", "remove_repeat", "zero_pad_or_crop", "modify_acq_info", "split_idx", "broadcast_right", "unsqueeze_left", "unsqueeze_right"]
+__all__ = [
+    "broadcast_right",
+    "modify_acq_info",
+    "remove_repeat",
+    "slice_profiles",
+    "smap",
+    "split_idx",
+    "typing",
+    "unsqueeze_left",
+    "unsqueeze_right",
+    "zero_pad_or_crop"
+]


### PR DESCRIPTION
_Somebody_ wrote a pre-commit check for `__all__`
This now solves the issue of _somebody_ forgetting to add to `__all__`.
The logic now is, that everything imported in an` __init__,py ` will be added alphabetically sorted to `__all__`
There is a` #noqa:ALL[symbol1, symbol2]` option to exclude certain symbols.