### PR TITLE
Remove superfluous .forward

### DIFF
--- a/examples/pulseq_2d_radial_golden_angle.ipynb
+++ b/examples/pulseq_2d_radial_golden_angle.ipynb
@@ -76,7 +76,7 @@
     "\n",
     "# Reconstruct image\n",
     "direct_reconstruction = DirectReconstruction(kdata)\n",
-    "img_using_ismrmrd_traj = direct_reconstruction.forward(kdata)"
+    "img_using_ismrmrd_traj = direct_reconstruction(kdata)"
    ]
   },
   {
@@ -100,7 +100,7 @@
     "\n",
     "# Reconstruct image\n",
     "direct_reconstruction = DirectReconstruction(kdata)\n",
-    "img_using_rad2d_traj = direct_reconstruction.forward(kdata)"
+    "img_using_rad2d_traj = direct_reconstruction(kdata)"
    ]
   },
   {
@@ -143,7 +143,7 @@
     "\n",
     "# Reconstruct image\n",
     "direct_reconstruction = DirectReconstruction(kdata)\n",
-    "img_using_pulseq_traj = direct_reconstruction.forward(kdata)"
+    "img_using_pulseq_traj = direct_reconstruction(kdata)"
    ]
   },
   {

--- a/examples/pulseq_2d_radial_golden_angle.py
+++ b/examples/pulseq_2d_radial_golden_angle.py
@@ -37,7 +37,7 @@ kdata = KData.from_file(data_file.name, KTrajectoryIsmrmrd())
 
 # Reconstruct image
 direct_reconstruction = DirectReconstruction(kdata)
-img_using_ismrmrd_traj = direct_reconstruction.forward(kdata)
+img_using_ismrmrd_traj = direct_reconstruction(kdata)
 
 # %% [markdown]
 # ### Image reconstruction using KTrajectoryRadial2D
@@ -49,7 +49,7 @@ kdata = KData.from_file(data_file.name, KTrajectoryRadial2D())
 
 # Reconstruct image
 direct_reconstruction = DirectReconstruction(kdata)
-img_using_rad2d_traj = direct_reconstruction.forward(kdata)
+img_using_rad2d_traj = direct_reconstruction(kdata)
 
 # %% [markdown]
 # ### Image reconstruction using KTrajectoryPulseq
@@ -73,7 +73,7 @@ kdata = KData.from_file(data_file.name, KTrajectoryPulseq(seq_path=seq_file.name
 
 # Reconstruct image
 direct_reconstruction = DirectReconstruction(kdata)
-img_using_pulseq_traj = direct_reconstruction.forward(kdata)
+img_using_pulseq_traj = direct_reconstruction(kdata)
 
 # %% [markdown]
 # ### Plot the different reconstructed images

--- a/src/mrpro/operators/FourierOp.py
+++ b/src/mrpro/operators/FourierOp.py
@@ -148,7 +148,7 @@ class FourierOp(LinearOperator):
         """
         if len(self._fft_dims):
             # FFT
-            (x,) = self._fast_fourier_op.forward(x)
+            (x,) = self._fast_fourier_op(x)
 
         if self._nufft_dims:
             # we need to move the nufft-dimensions to the end and flatten all other dimensions

--- a/tests/operators/models/test_inversion_recovery.py
+++ b/tests/operators/models/test_inversion_recovery.py
@@ -21,7 +21,7 @@ def test_inversion_recovery(ti, result):
     """
     model = InversionRecovery(ti)
     m0, t1 = create_parameter_tensor_tuples()
-    (image,) = model.forward(m0, t1)
+    (image,) = model(m0, t1)
 
     # Assert closeness to -m0 for ti=0
     if result == '-m0':
@@ -37,5 +37,5 @@ def test_inversion_recovery_shape(parameter_shape, contrast_dim_shape, signal_sh
     (ti,) = create_parameter_tensor_tuples(contrast_dim_shape, number_of_tensors=1)
     model_op = InversionRecovery(ti)
     m0, t1 = create_parameter_tensor_tuples(parameter_shape, number_of_tensors=2)
-    (signal,) = model_op.forward(m0, t1)
+    (signal,) = model_op(m0, t1)
     assert signal.shape == signal_shape

--- a/tests/operators/models/test_molli.py
+++ b/tests/operators/models/test_molli.py
@@ -27,7 +27,7 @@ def test_molli(ti, result):
 
     # Generate signal model and torch tensor for comparison
     model = MOLLI(ti)
-    (image,) = model.forward(a, c, t1)
+    (image,) = model(a, c, t1)
 
     # Assert closeness to a(1-c) for large ti
     if result == 'a(1-c)':
@@ -43,5 +43,5 @@ def test_molli_shape(parameter_shape, contrast_dim_shape, signal_shape):
     (ti,) = create_parameter_tensor_tuples(contrast_dim_shape, number_of_tensors=1)
     model_op = MOLLI(ti)
     a, c, t1 = create_parameter_tensor_tuples(parameter_shape, number_of_tensors=3)
-    (signal,) = model_op.forward(a, c, t1)
+    (signal,) = model_op(a, c, t1)
     assert signal.shape == signal_shape

--- a/tests/operators/models/test_mono_exponential_decay.py
+++ b/tests/operators/models/test_mono_exponential_decay.py
@@ -21,7 +21,7 @@ def test_mono_exponential_decay(decay_time, result):
     """
     model = MonoExponentialDecay(decay_time)
     m0, decay_constant = create_parameter_tensor_tuples()
-    (image,) = model.forward(m0, decay_constant)
+    (image,) = model(m0, decay_constant)
 
     zeros = torch.zeros_like(m0)
 
@@ -39,5 +39,5 @@ def test_mono_exponential_decay_shape(parameter_shape, contrast_dim_shape, signa
     (decay_time,) = create_parameter_tensor_tuples(contrast_dim_shape, number_of_tensors=1)
     model_op = MonoExponentialDecay(decay_time)
     m0, decay_constant = create_parameter_tensor_tuples(parameter_shape, number_of_tensors=2)
-    (signal,) = model_op.forward(m0, decay_constant)
+    (signal,) = model_op(m0, decay_constant)
     assert signal.shape == signal_shape

--- a/tests/operators/models/test_saturation_recovery.py
+++ b/tests/operators/models/test_saturation_recovery.py
@@ -21,7 +21,7 @@ def test_saturation_recovery(ti, result):
     """
     model = SaturationRecovery(ti)
     m0, t1 = create_parameter_tensor_tuples()
-    (image,) = model.forward(m0, t1)
+    (image,) = model(m0, t1)
 
     zeros = torch.zeros_like(m0)
 
@@ -39,5 +39,5 @@ def test_saturation_recovery_shape(parameter_shape, contrast_dim_shape, signal_s
     (ti,) = create_parameter_tensor_tuples(contrast_dim_shape, number_of_tensors=1)
     model_op = SaturationRecovery(ti)
     m0, t1 = create_parameter_tensor_tuples(parameter_shape, number_of_tensors=2)
-    (signal,) = model_op.forward(m0, t1)
+    (signal,) = model_op(m0, t1)
     assert signal.shape == signal_shape

--- a/tests/operators/models/test_transient_steady_state_with_preparation.py
+++ b/tests/operators/models/test_transient_steady_state_with_preparation.py
@@ -23,7 +23,7 @@ def test_transient_steady_state(sampling_time, m0_scaling_preparation, result):
     repetition_time = 5
     model = TransientSteadyStateWithPreparation(sampling_time, repetition_time, m0_scaling_preparation)
     m0, t1, flip_angle = create_parameter_tensor_tuples(number_of_tensors=3)
-    (signal,) = model.forward(m0, t1, flip_angle)
+    (signal,) = model(m0, t1, flip_angle)
 
     # Assert closeness to m0
     if result == 'm0':
@@ -56,7 +56,7 @@ def test_transient_steady_state_inversion_recovery():
     analytical_signal = m0 * (1 - 2 * torch.exp(-(sampling_time / t1)))
 
     model = TransientSteadyStateWithPreparation(sampling_time, repetition_time=100, m0_scaling_preparation=-1)
-    (signal,) = model.forward(m0, t1, flip_angle)
+    (signal,) = model(m0, t1, flip_angle)
 
     torch.testing.assert_close(signal, analytical_signal)
 
@@ -77,5 +77,5 @@ def test_transient_steady_state_shape(parameter_shape, contrast_dim_shape, signa
         sampling_time, repetition_time, m0_scaling_preparation, delay_after_preparation
     )
     m0, t1, flip_angle = create_parameter_tensor_tuples(parameter_shape, number_of_tensors=3)
-    (signal,) = model_op.forward(m0, t1, flip_angle)
+    (signal,) = model_op(m0, t1, flip_angle)
     assert signal.shape == signal_shape

--- a/tests/operators/models/test_wasabi.py
+++ b/tests/operators/models/test_wasabi.py
@@ -14,11 +14,11 @@ def test_WASABI_shift():
     """Test symmetry property of shifted and unshifted WASABI spectra."""
     offsets_unshifted, b0_shift, rb1, c, d = create_data()
     wasabi_model = WASABI(offsets=offsets_unshifted)
-    (signal,) = wasabi_model.forward(b0_shift, rb1, c, d)
+    (signal,) = wasabi_model(b0_shift, rb1, c, d)
 
     offsets_shifted, b0_shift, rb1, c, d = create_data(b0_shift=100)
     wasabi_model = WASABI(offsets=offsets_shifted)
-    (signal_shifted,) = wasabi_model.forward(b0_shift, rb1, c, d)
+    (signal_shifted,) = wasabi_model(b0_shift, rb1, c, d)
 
     lower_index = (offsets_shifted == -300).nonzero()[0][0].item()
     upper_index = (offsets_shifted == 500).nonzero()[0][0].item()
@@ -30,7 +30,7 @@ def test_WASABI_shift():
 def test_WASABI_extreme_offset():
     offset, b0_shift, rb1, c, d = create_data(offset_max=30000, n_offsets=1)
     wasabi_model = WASABI(offsets=offset)
-    (signal,) = wasabi_model.forward(b0_shift, rb1, c, d)
+    (signal,) = wasabi_model(b0_shift, rb1, c, d)
 
     assert torch.isclose(signal, torch.tensor([1.0])), 'For an extreme offset, the signal should be unattenuated'
 
@@ -41,5 +41,5 @@ def test_WASABI_shape(parameter_shape, contrast_dim_shape, signal_shape):
     (offsets,) = create_parameter_tensor_tuples(contrast_dim_shape, number_of_tensors=1)
     model_op = WASABI(offsets)
     b0_shift, rb1, c, d = create_parameter_tensor_tuples(parameter_shape, number_of_tensors=4)
-    (signal,) = model_op.forward(b0_shift, rb1, c, d)
+    (signal,) = model_op(b0_shift, rb1, c, d)
     assert signal.shape == signal_shape

--- a/tests/operators/models/test_wasabiti.py
+++ b/tests/operators/models/test_wasabiti.py
@@ -15,7 +15,7 @@ def test_WASABITI_symmetry():
     """Test symmetry property of complete WASABITI spectra."""
     offsets, b0_shift, rb1, t1 = create_data()
     wasabiti_model = WASABITI(offsets=offsets, trec=torch.ones_like(offsets))
-    (signal,) = wasabiti_model.forward(b0_shift, rb1, t1)
+    (signal,) = wasabiti_model(b0_shift, rb1, t1)
 
     # check that all values are symmetric around the center
     assert torch.allclose(signal, signal.flipud(), rtol=1e-15), 'Result should be symmetric around center'
@@ -26,7 +26,7 @@ def test_WASABITI_symmetry_after_shift():
     offsets_shifted, b0_shift, rb1, t1 = create_data(b0_shift=100)
     trec = torch.ones_like(offsets_shifted)
     wasabiti_model = WASABITI(offsets=offsets_shifted, trec=trec)
-    (signal_shifted,) = wasabiti_model.forward(b0_shift, rb1, t1)
+    (signal_shifted,) = wasabiti_model(b0_shift, rb1, t1)
 
     lower_index = (offsets_shifted == -300).nonzero()[0][0].item()
     upper_index = (offsets_shifted == 500).nonzero()[0][0].item()
@@ -42,7 +42,7 @@ def test_WASABITI_asymmetry_for_non_unique_trec():
     trec[: len(offsets_unshifted) // 2] = 2.0
 
     wasabiti_model = WASABITI(offsets=offsets_unshifted, trec=trec)
-    (signal,) = wasabiti_model.forward(b0_shift, rb1, t1)
+    (signal,) = wasabiti_model(b0_shift, rb1, t1)
 
     assert not torch.allclose(signal, signal.flipud(), rtol=1e-8), 'Result should not be symmetric around center'
 
@@ -53,7 +53,7 @@ def test_WASABITI_relaxation_term(t1):
     offset, b0_shift, rb1, t1 = create_data(offset_max=50000, n_offsets=1, t1=t1)
     trec = torch.ones_like(offset) * t1
     wasabiti_model = WASABITI(offsets=offset, trec=trec)
-    sig = wasabiti_model.forward(b0_shift, rb1, t1)
+    sig = wasabiti_model(b0_shift, rb1, t1)
 
     assert torch.isclose(sig[0], torch.FloatTensor([1 - torch.exp(torch.FloatTensor([-1]))]), rtol=1e-8)
 
@@ -72,5 +72,5 @@ def test_WASABITI_shape(parameter_shape, contrast_dim_shape, signal_shape):
     ti, trec = create_parameter_tensor_tuples(contrast_dim_shape, number_of_tensors=2)
     model_op = WASABITI(ti, trec)
     b0_shift, rb1, t1 = create_parameter_tensor_tuples(parameter_shape, number_of_tensors=3)
-    (signal,) = model_op.forward(b0_shift, rb1, t1)
+    (signal,) = model_op(b0_shift, rb1, t1)
     assert signal.shape == signal_shape

--- a/tests/operators/test_sensitivity_op.py
+++ b/tests/operators/test_sensitivity_op.py
@@ -90,7 +90,7 @@ def test_sensitivity_op_other_dim_compatibility_fail(n_other_csm, n_other_img):
     # Apply to n_other_img shape
     u = random_generator.complex64_tensor(size=(n_other_img, 1, *n_zyx))
     with pytest.raises(RuntimeError, match='The size of tensor'):
-        sensitivity_op.forward(u)
+        sensitivity_op(u)
 
     v = random_generator.complex64_tensor(size=(n_other_img, n_coils, *n_zyx))
     with pytest.raises(RuntimeError, match='The size of tensor'):

--- a/tests/operators/test_zero_pad_op.py
+++ b/tests/operators/test_zero_pad_op.py
@@ -20,7 +20,7 @@ def test_zero_pad_op_content():
         original_shape=tuple([original_shape[d] for d in padding_dimensions]),
         padded_shape=tuple([padded_shape[d] for d in padding_dimensions]),
     )
-    (padded_data,) = zero_padding_op.forward(original_data)
+    (padded_data,) = zero_padding_op(original_data)
 
     # Compare overlapping region
     torch.testing.assert_close(original_data[:, 10:90, :, 50:150, :, :], padded_data[:, :, :, :, 95:145, :])


### PR DESCRIPTION
In some few cases we use `Operator.forward(x)` instead of` Operator(x)`.
To be consistent (and consistent with pytorch usage), we should call the Operator and let pytorch handle the` .forward `call.