### PR TITLE
Add apply_ to dataclasses

### DIFF
--- a/src/mrpro/data/AcqInfo.py
+++ b/src/mrpro/data/AcqInfo.py
@@ -1,6 +1,6 @@
 """Acquisition information dataclass."""
 
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 import ismrmrd

--- a/src/mrpro/data/AcqInfo.py
+++ b/src/mrpro/data/AcqInfo.py
@@ -264,9 +264,7 @@ class AcqInfo(MoveDataMixin):
                 raise ValueError('Spatial dimension is expected to be of shape (N,3)')
             data = data[:, None, :]
             # all spatial dimensions are float32
-            return (
-                SpatialDimension[torch.Tensor].from_array_xyz(torch.tensor(data.astype(np.float32))).apply_(conversion)
-            )
+            return SpatialDimension[torch.Tensor].from_array_xyz(torch.tensor(data.astype(np.float32)))
 
         acq_idx = AcqIdx(
             k1=tensor(idx['kspace_encode_step_1']),
@@ -320,10 +318,10 @@ class AcqInfo(MoveDataMixin):
             flags=tensor_2d(headers['flags']),
             measurement_uid=tensor_2d(headers['measurement_uid']),
             number_of_samples=tensor_2d(headers['number_of_samples']),
-            patient_table_position=spatialdimension_2d(headers['patient_table_position'], mm_to_m),
+            patient_table_position=spatialdimension_2d(headers['patient_table_position']).apply_(mm_to_m),
             phase_dir=spatialdimension_2d(headers['phase_dir']),
             physiology_time_stamp=tensor_2d(headers['physiology_time_stamp']),
-            position=spatialdimension_2d(headers['position'], mm_to_m),
+            position=spatialdimension_2d(headers['position']).apply_(mm_to_m),
             read_dir=spatialdimension_2d(headers['read_dir']),
             sample_time_us=tensor_2d(headers['sample_time_us']),
             scan_counter=tensor_2d(headers['scan_counter']),

--- a/src/mrpro/data/AcqInfo.py
+++ b/src/mrpro/data/AcqInfo.py
@@ -82,6 +82,59 @@ class AcqIdx(MoveDataMixin):
 
 
 @dataclass(slots=True)
+class UserValues(MoveDataMixin):
+    """User-defined values for each readout."""
+
+    float0: torch.Tensor
+    """User float 0."""
+
+    float1: torch.Tensor
+    """User float 1."""
+
+    float2: torch.Tensor
+    """User float 2."""
+
+    float3: torch.Tensor
+    """User float 3."""
+
+    float4: torch.Tensor
+    """User float 4."""
+
+    float5: torch.Tensor
+    """User float 5."""
+
+    float6: torch.Tensor
+    """User float 6."""
+
+    float7: torch.Tensor
+    """User float 7."""
+
+    int0: torch.Tensor
+    """User int 0."""
+
+    int1: torch.Tensor
+    """User int 1."""
+
+    int2: torch.Tensor
+    """User int 2."""
+
+    int3: torch.Tensor
+    """User int 3."""
+
+    int4: torch.Tensor
+    """User int 4."""
+
+    int5: torch.Tensor
+    """User int 5."""
+
+    int6: torch.Tensor
+    """User int 6."""
+
+    int7: torch.Tensor
+    """User int 7."""
+
+
+@dataclass(slots=True)
 class AcqInfo(MoveDataMixin):
     """Acquisition information for each readout."""
 
@@ -148,11 +201,8 @@ class AcqInfo(MoveDataMixin):
     trajectory_dimensions: torch.Tensor  # =3. We only support 3D Trajectories: kz always exists.
     """Dimensionality of the k-space trajectory vector."""
 
-    user_float: torch.Tensor
-    """User-defined float parameters."""
-
-    user_int: torch.Tensor
-    """User-defined int parameters."""
+    user: UserValues
+    """User-defined values."""
 
     version: torch.Tensor
     """Major version number."""
@@ -238,6 +288,25 @@ class AcqInfo(MoveDataMixin):
             user7=tensor(idx['user'][:, 7]),
         )
 
+        user_values = UserValues(
+            float0=tensor_2d(headers['user_float'][:, 0]),
+            float1=tensor_2d(headers['user_float'][:, 1]),
+            float2=tensor_2d(headers['user_float'][:, 2]),
+            float3=tensor_2d(headers['user_float'][:, 3]),
+            float4=tensor_2d(headers['user_float'][:, 4]),
+            float5=tensor_2d(headers['user_float'][:, 5]),
+            float6=tensor_2d(headers['user_float'][:, 6]),
+            float7=tensor_2d(headers['user_float'][:, 7]),
+            int0=tensor_2d(headers['user_int'][:, 0]),
+            int1=tensor_2d(headers['user_int'][:, 1]),
+            int2=tensor_2d(headers['user_int'][:, 2]),
+            int3=tensor_2d(headers['user_int'][:, 3]),
+            int4=tensor_2d(headers['user_int'][:, 4]),
+            int5=tensor_2d(headers['user_int'][:, 5]),
+            int6=tensor_2d(headers['user_int'][:, 6]),
+            int7=tensor_2d(headers['user_int'][:, 7]),
+        )
+
         acq_info = cls(
             idx=acq_idx,
             acquisition_time_stamp=tensor_2d(headers['acquisition_time_stamp']),
@@ -260,8 +329,7 @@ class AcqInfo(MoveDataMixin):
             scan_counter=tensor_2d(headers['scan_counter']),
             slice_dir=spatialdimension_2d(headers['slice_dir']),
             trajectory_dimensions=tensor_2d(headers['trajectory_dimensions']).fill_(3),  # see above
-            user_float=tensor_2d(headers['user_float']),
-            user_int=tensor_2d(headers['user_int']),
+            user=user_values,
             version=tensor_2d(headers['version']),
         )
         return acq_info

--- a/src/mrpro/data/AcqInfo.py
+++ b/src/mrpro/data/AcqInfo.py
@@ -256,9 +256,7 @@ class AcqInfo(MoveDataMixin):
                 data_tensor = data_tensor[None, None]
             return data_tensor
 
-        def spatialdimension_2d(
-            data: np.ndarray, conversion: Callable[[torch.Tensor], torch.Tensor] | None = None
-        ) -> SpatialDimension[torch.Tensor]:
+        def spatialdimension_2d(data: np.ndarray) -> SpatialDimension[torch.Tensor]:
             # Ensure spatial dimension is (k1*k2*other, 1, 3)
             if data.ndim != 2:
                 raise ValueError('Spatial dimension is expected to be of shape (N,3)')

--- a/src/mrpro/data/MoveDataMixin.py
+++ b/src/mrpro/data/MoveDataMixin.py
@@ -225,7 +225,9 @@ class MoveDataMixin:
         new.apply_(_convert, memo=memo)
         return new
 
-    def apply_(self: Self, function: Callable[T, T], memo: dict[int, Any] | None = None, recurse: bool = True) -> Self:
+    def apply_(
+        self: Self, function: Callable[[T], T], memo: dict[int, Any] | None = None, recurse: bool = True
+    ) -> Self:
         """Apply a function to all children in-place.
 
         Parameters

--- a/src/mrpro/data/SpatialDimension.py
+++ b/src/mrpro/data/SpatialDimension.py
@@ -134,21 +134,6 @@ class SpatialDimension(MoveDataMixin, Generic[T_co]):
         self.y[idx] = other.y
         self.x[idx] = other.x
 
-    def apply_(self: SpatialDimension[T_co], func: Callable[[T_co], T_co] | None = None) -> SpatialDimension[T_co]:
-        """Apply function to each of x,y,z in-place.
-
-        Parameters
-        ----------
-        func
-            function to apply to each of x,y,z
-            None is interpreted as the identity function.
-        """
-        if func is not None:
-            self.z = func(self.z)
-            self.y = func(self.y)
-            self.x = func(self.x)
-        return self
-
     def apply(self: SpatialDimension[T_co], func: Callable[[T_co], T_co] | None = None) -> SpatialDimension[T_co]:
         """Apply function to each of x,y,z.
 

--- a/tests/data/test_kdata.py
+++ b/tests/data/test_kdata.py
@@ -229,8 +229,8 @@ def test_KData_to_complex128_header(ismrmrd_cart):
     """Change KData dtype complex128: test header"""
     kdata = KData.from_file(ismrmrd_cart.filename, DummyTrajectory())
     kdata_complex128 = kdata.to(dtype=torch.complex128)
-    assert kdata_complex128.header.acq_info.user_float.dtype == torch.float64
-    assert kdata_complex128.header.acq_info.user_int.dtype == torch.int32
+    assert kdata_complex128.header.acq_info.user.float0.dtype == torch.float64
+    assert kdata_complex128.header.acq_info.user.int0.dtype == torch.int32
 
 
 @pytest.mark.cuda
@@ -254,7 +254,7 @@ def test_KData_cuda(ismrmrd_cart):
     assert kdata_cuda.traj.kz.is_cuda
     assert kdata_cuda.traj.ky.is_cuda
     assert kdata_cuda.traj.kx.is_cuda
-    assert kdata_cuda.header.acq_info.user_int.is_cuda
+    assert kdata_cuda.header.acq_info.user.int0.is_cuda
     assert kdata_cuda.device == torch.device(torch.cuda.current_device())
     assert kdata_cuda.header.acq_info.device == torch.device(torch.cuda.current_device())
     assert kdata_cuda.is_cuda
@@ -270,7 +270,7 @@ def test_KData_cpu(ismrmrd_cart):
     assert kdata_cpu.traj.kz.is_cpu
     assert kdata_cpu.traj.ky.is_cpu
     assert kdata_cpu.traj.kx.is_cpu
-    assert kdata_cpu.header.acq_info.user_int.is_cpu
+    assert kdata_cpu.header.acq_info.user.int0.is_cpu
     assert kdata_cpu.device == torch.device('cpu')
     assert kdata_cpu.header.acq_info.device == torch.device('cpu')
 


### PR DESCRIPTION
We will need an apply on our dataclasses, both for @ckolbPTB's work as well, and for the rearrangeind und indexing.
As the _to already basically does an recursive apply with memorization, this refactors it such that the _apply can also be used with different functions.