### PR TITLE
Fix unrolled CG autograd

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ testpaths = ["tests"]
 filterwarnings = [
     "error",
     "ignore:'write_like_original':DeprecationWarning:pydicom:",
+    "ignore:Anomaly Detection has been enabled:UserWarning", #torch.autograd
 ]
 addopts = "-n auto"
 markers = ["cuda : Tests only to be run when cuda device is available"]

--- a/src/mrpro/algorithms/optimizers/cg.py
+++ b/src/mrpro/algorithms/optimizers/cg.py
@@ -81,11 +81,6 @@ def cg(
     if torch.vdot(residual.flatten(), residual.flatten()) == 0:
         return solution
 
-    # squared tolerance;
-    # (we will check ||residual||^2 < tolerance^2 instead of ||residual|| < tol
-    # to avoid the computation of the root for the norm)
-    tolerance_squared = tolerance**2
-
     # dummy value. new value will be set in loop before first usage
     residual_norm_squared_previous = None
 
@@ -95,7 +90,7 @@ def cg(
         residual_norm_squared = torch.vdot(residual_flat, residual_flat).real
 
         # check if the solution is already accurate enough
-        if tolerance != 0 and (residual_norm_squared < tolerance_squared):
+        if tolerance != 0 and (residual_norm_squared < tolerance**2):
             return solution
 
         if iteration > 0:
@@ -105,8 +100,8 @@ def cg(
         # update estimates of the solution and the residual
         (operator_conjugate_vector,) = operator(conjugate_vector)
         alpha = residual_norm_squared / (torch.vdot(conjugate_vector.flatten(), operator_conjugate_vector.flatten()))
-        solution += alpha * conjugate_vector
-        residual -= alpha * operator_conjugate_vector
+        solution = solution + alpha * conjugate_vector
+        residual = residual - alpha * operator_conjugate_vector
 
         residual_norm_squared_previous = residual_norm_squared
 

--- a/tests/algorithms/test_cg.py
+++ b/tests/algorithms/test_cg.py
@@ -146,6 +146,7 @@ def test_callback(system):
 
     cg(h_operator, right_hand_side, callback=callback)
 
+
 def test_autograd(system):
     """Test autograd through cg"""
     h_operator, right_hand_side, _ = system
@@ -154,6 +155,3 @@ def test_autograd(system):
         result = cg(h_operator, right_hand_side, tolerance=0, max_iterations=5)
         result.backward()
     assert right_hand_side is not None
-
-
-

--- a/tests/algorithms/test_cg.py
+++ b/tests/algorithms/test_cg.py
@@ -145,3 +145,15 @@ def test_callback(system):
         assert True
 
     cg(h_operator, right_hand_side, callback=callback)
+
+def test_autograd(system):
+    """Test autograd through cg"""
+    h_operator, right_hand_side, _ = system
+    right_hand_side.requires_grad_(True)
+    with torch.autograd.detect_anomaly():
+        result = cg(h_operator, right_hand_side, tolerance=0, max_iterations=5)
+        result.backward()
+    assert right_hand_side is not None
+
+
+

--- a/tests/algorithms/test_cg.py
+++ b/tests/algorithms/test_cg.py
@@ -153,5 +153,5 @@ def test_autograd(system):
     right_hand_side.requires_grad_(True)
     with torch.autograd.detect_anomaly():
         result = cg(h_operator, right_hand_side, tolerance=0, max_iterations=5)
-        result.backward()
-    assert right_hand_side is not None
+        result.sum().backward()
+    assert right_hand_side.grad is not None

--- a/tests/algorithms/test_cg.py
+++ b/tests/algorithms/test_cg.py
@@ -153,5 +153,5 @@ def test_autograd(system):
     right_hand_side.requires_grad_(True)
     with torch.autograd.detect_anomaly():
         result = cg(h_operator, right_hand_side, tolerance=0, max_iterations=5)
-        result.sum().backward()
+        result.abs().sum().backward()
     assert right_hand_side.grad is not None


### PR DESCRIPTION
@Stef-Martin wants to backpropagate through cg 🙈
This makes it possible.
Even though it is strictly better to always avoid doing this and instead use a proper gradient for the CG solution, we might still want to support this.

Before, there were in-place modifications of tensors, resulting in anomaly detection.