### PR TITLE
fix test installation from TestPyPi workflow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -94,7 +94,15 @@ jobs:
         run: |
           VERSION=${{ needs.build-testpypi-package.outputs.version }}
           SUFFIX=${{ needs.build-testpypi-package.outputs.suffix }}
-          python -m pip install mrpro==$VERSION$SUFFIX --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/
+          for i in {1..3}; do
+            if python -m pip install mrpro==$VERSION$SUFFIX --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/; then
+              echo "Package installed successfully."
+              break
+            else
+              echo "Attempt $i failed. Retrying in 10 seconds..."
+              sleep 10
+            fi
+          done
 
   build-pypi-package:
     name: Build Package for PyPI


### PR DESCRIPTION
I added a retry loop in the installation from TestPyPi step to avoid the workflow to fail because the deployed package from the previous step is not yet fully available for download / installation.

As far as I know, there is no status / availability check available. 