### PR TITLE
Revert NamedTemporaryFile ContextManager in example notebooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
       - id: check-docstring-first
@@ -15,14 +15,14 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.2
+    rev: v0.6.9
     hooks:
       - id: ruff # linter
         args: [--fix]
       - id: ruff-format # formatter
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.27.0
+    rev: v1.25.0
     hooks:
       - id: typos
 
@@ -34,7 +34,7 @@ repos:
         exclude: ^tests/
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v1.11.2
     hooks:
       - id: mypy
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-docstring-first
@@ -15,14 +15,14 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.7.2
     hooks:
       - id: ruff # linter
         args: [--fix]
       - id: ruff-format # formatter
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.25.0
+    rev: v1.27.0
     hooks:
       - id: typos
 
@@ -34,7 +34,7 @@ repos:
         exclude: ^tests/
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
+    rev: v1.13.0
     hooks:
       - id: mypy
         pass_filenames: false
@@ -54,11 +54,11 @@ repos:
           - "--extra-index-url=https://pypi.python.org/simple"
 
 ci:
-    autofix_commit_msg: |
-        [pre-commit] auto fixes from pre-commit hooks
-    autofix_prs: false
-    autoupdate_branch: ''
-    autoupdate_commit_msg: '[pre-commit] pre-commit autoupdate'
-    autoupdate_schedule: monthly
-    skip: [mypy]
-    submodules: false
+  autofix_commit_msg: |
+    [pre-commit] auto fixes from pre-commit hooks
+  autofix_prs: false
+  autoupdate_branch: ""
+  autoupdate_commit_msg: "[pre-commit] pre-commit autoupdate"
+  autoupdate_schedule: monthly
+  skip: [mypy]
+  submodules: false

--- a/examples/direct_reconstruction.ipynb
+++ b/examples/direct_reconstruction.ipynb
@@ -37,10 +37,10 @@
     "\n",
     "import requests\n",
     "\n",
-    "with tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.h5') as data_file:\n",
-    "    response = requests.get(zenodo_url + fname, timeout=30)\n",
-    "    data_file.write(response.content)\n",
-    "    data_file.flush()"
+    "data_file = tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.h5')\n",
+    "response = requests.get(zenodo_url + fname, timeout=30)\n",
+    "data_file.write(response.content)\n",
+    "data_file.flush()"
    ]
   },
   {

--- a/examples/direct_reconstruction.py
+++ b/examples/direct_reconstruction.py
@@ -11,10 +11,10 @@ import tempfile
 
 import requests
 
-with tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.h5') as data_file:
-    response = requests.get(zenodo_url + fname, timeout=30)
-    data_file.write(response.content)
-    data_file.flush()
+data_file = tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.h5')
+response = requests.get(zenodo_url + fname, timeout=30)
+data_file.write(response.content)
+data_file.flush()
 
 # %% [markdown]
 # ### Image reconstruction

--- a/examples/iterative_sense_reconstruction.ipynb
+++ b/examples/iterative_sense_reconstruction.ipynb
@@ -37,10 +37,10 @@
     "\n",
     "import requests\n",
     "\n",
-    "with tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.h5') as data_file:\n",
-    "    response = requests.get(zenodo_url + fname, timeout=30)\n",
-    "    data_file.write(response.content)\n",
-    "    data_file.flush()"
+    "data_file = tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.h5')\n",
+    "response = requests.get(zenodo_url + fname, timeout=30)\n",
+    "data_file.write(response.content)\n",
+    "data_file.flush()"
    ]
   },
   {

--- a/examples/iterative_sense_reconstruction.py
+++ b/examples/iterative_sense_reconstruction.py
@@ -11,10 +11,10 @@ import tempfile
 
 import requests
 
-with tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.h5') as data_file:
-    response = requests.get(zenodo_url + fname, timeout=30)
-    data_file.write(response.content)
-    data_file.flush()
+data_file = tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.h5')
+response = requests.get(zenodo_url + fname, timeout=30)
+data_file.write(response.content)
+data_file.flush()
 
 # %% [markdown]
 # ### Image reconstruction

--- a/examples/pulseq_2d_radial_golden_angle.ipynb
+++ b/examples/pulseq_2d_radial_golden_angle.ipynb
@@ -33,14 +33,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d16f41f1",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# define zenodo records URL and create a temporary directory and h5-file\n",
     "zenodo_url = 'https://zenodo.org/records/10854057/files/'\n",
-    "fname = 'pulseq_radial_2D_402spokes_golden_angle_with_traj.h5'"
+    "fname = 'pulseq_radial_2D_402spokes_golden_angle_with_traj.h5'\n",
+    "data_file = tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.h5')"
    ]
   },
   {
@@ -51,10 +50,9 @@
    "outputs": [],
    "source": [
     "# Download raw data using requests\n",
-    "with tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.h5') as data_file:\n",
-    "    response = requests.get(zenodo_url + fname, timeout=30)\n",
-    "    data_file.write(response.content)\n",
-    "    data_file.flush()"
+    "response = requests.get(zenodo_url + fname, timeout=30)\n",
+    "data_file.write(response.content)\n",
+    "data_file.flush()"
    ]
   },
   {
@@ -127,10 +125,10 @@
     "# download the sequence file from zenodo\n",
     "zenodo_url = 'https://zenodo.org/records/10868061/files/'\n",
     "seq_fname = 'pulseq_radial_2D_402spokes_golden_angle.seq'\n",
-    "with tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.seq') as seq_file:\n",
-    "    response = requests.get(zenodo_url + seq_fname, timeout=30)\n",
-    "    seq_file.write(response.content)\n",
-    "    seq_file.flush()"
+    "seq_file = tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.seq')\n",
+    "response = requests.get(zenodo_url + seq_fname, timeout=30)\n",
+    "seq_file.write(response.content)\n",
+    "seq_file.flush()"
    ]
   },
   {

--- a/examples/pulseq_2d_radial_golden_angle.py
+++ b/examples/pulseq_2d_radial_golden_angle.py
@@ -19,14 +19,13 @@ from mrpro.data.traj_calculators import KTrajectoryIsmrmrd, KTrajectoryPulseq, K
 # define zenodo records URL and create a temporary directory and h5-file
 zenodo_url = 'https://zenodo.org/records/10854057/files/'
 fname = 'pulseq_radial_2D_402spokes_golden_angle_with_traj.h5'
-
+data_file = tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.h5')
 
 # %%
 # Download raw data using requests
-with tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.h5') as data_file:
-    response = requests.get(zenodo_url + fname, timeout=30)
-    data_file.write(response.content)
-    data_file.flush()
+response = requests.get(zenodo_url + fname, timeout=30)
+data_file.write(response.content)
+data_file.flush()
 
 # %% [markdown]
 # ### Image reconstruction using KTrajectoryIsmrmrd
@@ -63,10 +62,10 @@ img_using_rad2d_traj = direct_reconstruction(kdata)
 # download the sequence file from zenodo
 zenodo_url = 'https://zenodo.org/records/10868061/files/'
 seq_fname = 'pulseq_radial_2D_402spokes_golden_angle.seq'
-with tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.seq') as seq_file:
-    response = requests.get(zenodo_url + seq_fname, timeout=30)
-    seq_file.write(response.content)
-    seq_file.flush()
+seq_file = tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.seq')
+response = requests.get(zenodo_url + seq_fname, timeout=30)
+seq_file.write(response.content)
+seq_file.flush()
 
 # %%
 # Read raw data and calculate trajectory using KTrajectoryPulseq

--- a/examples/regularized_iterative_sense_reconstruction.ipynb
+++ b/examples/regularized_iterative_sense_reconstruction.ipynb
@@ -37,10 +37,10 @@
     "\n",
     "import requests\n",
     "\n",
-    "with tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.h5') as data_file:\n",
-    "    response = requests.get(zenodo_url + fname, timeout=30)\n",
-    "    data_file.write(response.content)\n",
-    "    data_file.flush()"
+    "data_file = tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.h5')\n",
+    "response = requests.get(zenodo_url + fname, timeout=30)\n",
+    "data_file.write(response.content)\n",
+    "data_file.flush()"
    ]
   },
   {

--- a/examples/regularized_iterative_sense_reconstruction.py
+++ b/examples/regularized_iterative_sense_reconstruction.py
@@ -11,10 +11,10 @@ import tempfile
 
 import requests
 
-with tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.h5') as data_file:
-    response = requests.get(zenodo_url + fname, timeout=30)
-    data_file.write(response.content)
-    data_file.flush()
+data_file = tempfile.NamedTemporaryFile(mode='wb', delete=False, suffix='.h5')
+response = requests.get(zenodo_url + fname, timeout=30)
+data_file.write(response.content)
+data_file.flush()
 
 # %% [markdown]
 # ### Image reconstruction

--- a/examples/ruff.toml
+++ b/examples/ruff.toml
@@ -5,4 +5,5 @@ lint.extend-ignore = [
     "T20",    #print
     "E402",   #module-import-not-at-top-of-file
     "S101",   #assert
+    "SIM115", #context manager for opening files
 ]


### PR DESCRIPTION
Reverts changes to examples from PTB-MR/mrpro#498 because we decided NOT to use a context manager to open the data files and just ignore the RUFF rule in our example notebooks.