### PR TITLE
Update .ipynb notebooks from .py in pre-commit hook

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,51 +14,6 @@ defaults:
     shell: bash
 
 jobs:
-  convert_scripts:
-    name: Translate scripts to notebooks
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
-    outputs:
-      commit_hash: ${{ steps.add-commit-push.outputs.commit_hash }}
-    container:
-      image: ghcr.io/ptb-mr/mrpro_py311:latest
-      options: --user runner
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.commit }}
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 0
-
-      - name: Install mrpro and dependencies
-        run: pip install --upgrade --upgrade-strategy "eager" .[notebook]
-
-      - name: Translate scripts to notebooks
-        run: |
-          scripts=$(ls ./examples/*.py)
-          for script in $scripts
-            do jupytext --set-kernel "python3" --update --output ${script//.py/.ipynb} $script
-          done
-
-      - name: Check if any notebooks have been changed
-        uses: tj-actions/verify-changed-files@v20
-        id: verify-changed-notebooks
-        with:
-          files: ./examples/*.ipynb
-
-      - name: Commit notebooks
-        if: steps.verify-changed-notebooks.outputs.files_changed == 'true'
-        uses: actions4git/add-commit-push@v1
-        with:
-          commit-message: Notebooks updated
-
-      - name: Get hash of last commit
-        id: add-commit-push
-        run: echo "commit_hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-
   get_notebooks:
     name: Get list of notebooks
     needs: convert_scripts
@@ -66,8 +21,6 @@ jobs:
     steps:
       - name: Checkout mrpro repo
         uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.convert_scripts.outputs.commit_hash }}
 
       - id: set-matrix
         run: |
@@ -195,7 +148,7 @@ jobs:
         with:
           name: Documentation
           path: docs/build/html/
-      
+
       - run: echo 'Artifact url ${{ steps.save_docu.outputs.artifact-url }}'
 
       - run: echo 'Event number ${{ github.event.number }}'
@@ -225,7 +178,7 @@ jobs:
   deploy:
     if: github.ref == 'refs/heads/main'
     permissions:
-        pages: write   
+        pages: write
         id-token: write
     environment:
       name: github-pages

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,22 @@ repos:
           - "--index-url=https://download.pytorch.org/whl/cpu"
           - "--extra-index-url=https://pypi.python.org/simple"
 
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.8.0
+    hooks:
+    # cleans the .ipynbs (removes outputs, resets all cell-ids to 0..N, cleans steps)
+    - id: nbstripout
+      files: examples\/.*\.ipynb
+
+  - repo: https://github.com/mwouts/jupytext
+    rev: v1.16.4
+    # converts (--to ipynb) the .py to the .ipynb and preserves (--update) the assigned
+    # "clear" cells' ids from the nbstripout
+    hooks:
+     - id: jupytext
+       args: [--to, ipynb, --update]
+       files: examples\/.*\.py
+
 ci:
     autofix_commit_msg: |
         [pre-commit] auto fixes from pre-commit hooks

--- a/examples/direct_reconstruction.ipynb
+++ b/examples/direct_reconstruction.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7ce284e1",
+   "id": "0",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -14,7 +14,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a203bdc2",
+   "id": "1",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -28,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c08b3fd",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e0126c1e",
+   "id": "3",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -59,7 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f041501b",
+   "id": "4",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4108db0a",
+   "id": "5",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d669bbd9",
+   "id": "6",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -108,7 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a4afe6b9",
+   "id": "7",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b558334f",
+   "id": "8",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -148,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d96152f2",
+   "id": "9",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -180,7 +180,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "564c18d7",
+   "id": "10",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -192,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52d306e3",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/iterative_sense_reconstruction.ipynb
+++ b/examples/iterative_sense_reconstruction.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "97b14e1c",
+   "id": "0",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -14,7 +14,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a554df82",
+   "id": "1",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -28,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f969a53",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b48681af",
+   "id": "3",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca3e27d2",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c3e84bc8",
+   "id": "5",
    "metadata": {},
    "source": [
     "##### Read-in the raw data"
@@ -94,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38fe6ce8",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +108,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c6c1975b",
+   "id": "7",
    "metadata": {},
    "source": [
     "##### Direct reconstruction for comparison"
@@ -117,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5dafe6fd",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +128,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15833b4b",
+   "id": "9",
    "metadata": {},
    "source": [
     "##### Iterative SENSE reconstruction"
@@ -137,7 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6aee812a",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48f03f8c",
+   "id": "11",
    "metadata": {},
    "source": [
     "### Behind the scenes"
@@ -158,7 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78a39ad8",
+   "id": "12",
    "metadata": {},
    "source": [
     "##### Set-up the density compensation operator $W$"
@@ -167,7 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2b25396e",
+   "id": "13",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -179,7 +179,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fd634152",
+   "id": "14",
    "metadata": {},
    "source": [
     "##### Set-up the acquisition model $A$"
@@ -188,7 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adfcbd02",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,7 +207,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a9dd464",
+   "id": "16",
    "metadata": {},
    "source": [
     "##### Calculate the right-hand-side of the linear system $b = A^H W y$"
@@ -216,7 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "330c39dc",
+   "id": "17",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -227,7 +227,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c9aaa40",
+   "id": "18",
    "metadata": {},
    "source": [
     "##### Set-up the linear self-adjoint operator $H = A^H W A$"
@@ -236,7 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c65f82b1",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +245,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41d178f6",
+   "id": "20",
    "metadata": {},
    "source": [
     "##### Run conjugate gradient"
@@ -254,7 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f262a76",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +266,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cbc7849c",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -285,7 +285,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fcc1810b",
+   "id": "23",
    "metadata": {},
    "source": [
     "### Check for equal results\n",
@@ -295,7 +295,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f5f825f",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/pulseq_2d_radial_golden_angle.ipynb
+++ b/examples/pulseq_2d_radial_golden_angle.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "e0d2a142",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Reconstruction of 2D golden angle radial data from pulseq sequence\n",
@@ -15,7 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6946769e",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,7 +32,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d16f41f1",
+   "id": "2",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -46,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d614298",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "240859bb",
+   "id": "4",
    "metadata": {},
    "source": [
     "### Image reconstruction using KTrajectoryIsmrmrd\n",
@@ -69,7 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e3c53094",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f8c6eb31",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Image reconstruction using KTrajectoryRadial2D\n",
@@ -93,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f8426ea",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "facf122a",
+   "id": "8",
    "metadata": {},
    "source": [
     "### Image reconstruction using KTrajectoryPulseq\n",
@@ -120,7 +120,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fec370a5",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49dee7ad",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a39ce534",
+   "id": "11",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -166,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11beee85",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/qmri_sg_challenge_2024_t1.ipynb
+++ b/examples/qmri_sg_challenge_2024_t1.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0f82262f",
+   "id": "0",
    "metadata": {},
    "source": [
     "# QMRI Challenge ISMRM 2024 - T1 mapping"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b22eb134",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8ad2180c",
+   "id": "2",
    "metadata": {},
    "source": [
     "### Overview\n",
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a409eb2a",
+   "id": "3",
    "metadata": {},
    "source": [
     "### Get data from Zenodo"
@@ -59,7 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "887dafc4",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c1a23dbd",
+   "id": "5",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -83,7 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83fbaeed",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,7 +97,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62fb28e2",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "be24eb8c",
+   "id": "8",
    "metadata": {},
    "source": [
     "### Signal model and loss function\n",
@@ -125,7 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "be6401ce",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +134,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3108b57f",
+   "id": "10",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -146,7 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69966a91",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,7 +155,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56c2b77e",
+   "id": "12",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -168,7 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01255b5f",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +177,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61ec6cda",
+   "id": "14",
    "metadata": {},
    "source": [
     "### Starting values for the fit\n",
@@ -199,7 +199,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fe7624e7",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -223,7 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b4cce759",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0d69c2a3",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -251,7 +251,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32270769",
+   "id": "18",
    "metadata": {},
    "source": [
     "### Carry out fit"
@@ -260,7 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f457f649",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,7 +277,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74e236e4",
+   "id": "20",
    "metadata": {},
    "source": [
     "### Visualize the final results\n",
@@ -291,7 +291,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "934e1423",
+   "id": "21",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -317,7 +317,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97ea6e61",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/qmri_sg_challenge_2024_t2_star.ipynb
+++ b/examples/qmri_sg_challenge_2024_t2_star.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "5efa18e9",
+   "id": "0",
    "metadata": {},
    "source": [
     "# QMRI Challenge ISMRM 2024 - T2* mapping"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0ff5b166",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0141573c",
+   "id": "2",
    "metadata": {},
    "source": [
     "### Overview\n",
@@ -52,7 +52,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0d96cff3",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88f3c8c4",
+   "id": "4",
    "metadata": {},
    "source": [
     "### Get data from Zenodo"
@@ -70,7 +70,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ee6894e1",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "09005fc6",
+   "id": "6",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -94,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5b43a84c",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1b567ec5",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e8ce841d",
+   "id": "9",
    "metadata": {},
    "source": [
     "### Signal model and loss function\n",
@@ -139,7 +139,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ad47d48a",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,7 +148,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aec6a1e0",
+   "id": "11",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -160,7 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36520147",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +169,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce7b901a",
+   "id": "13",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -182,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ee5863a7",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +191,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c928a357",
+   "id": "15",
    "metadata": {},
    "source": [
     "### Carry out fit"
@@ -200,7 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d3a4e2f8",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,7 +227,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "848dbf87",
+   "id": "17",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -243,7 +243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "077b3bc3",
+   "id": "18",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -272,7 +272,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ac804997",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/regularized_iterative_sense_reconstruction.ipynb
+++ b/examples/regularized_iterative_sense_reconstruction.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "af432293",
+   "id": "0",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -14,7 +14,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2a7a6ce3",
+   "id": "1",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -28,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0cd8486b",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a9defa1",
+   "id": "3",
    "metadata": {},
    "source": [
     "### Image reconstruction\n",
@@ -89,7 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c4da15c2",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de055070",
+   "id": "5",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -109,7 +109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3ac1d89f",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f389140",
+   "id": "7",
    "metadata": {},
    "source": [
     "##### Image $x_{reg}$ from fully sampled data"
@@ -133,7 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "212b915c",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +152,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bec6b712",
+   "id": "9",
    "metadata": {},
    "source": [
     "##### Image $x$ from undersampled data"
@@ -161,7 +161,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f6740447",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5fbfd664",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "041ffe72",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,7 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3d5bbec1",
+   "id": "13",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -227,7 +227,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2bd49c87",
+   "id": "14",
    "metadata": {},
    "source": [
     "### Behind the scenes"
@@ -235,7 +235,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53779251",
+   "id": "15",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -249,7 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e985a4f3",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -261,7 +261,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2daa0fee",
+   "id": "17",
    "metadata": {},
    "source": [
     "##### Calculate the right-hand-side of the linear system $b = A^H W y + l x_{reg}$"
@@ -270,7 +270,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ac1d5fb4",
+   "id": "18",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -283,7 +283,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76a0b153",
+   "id": "19",
    "metadata": {},
    "source": [
     "##### Set-up the linear self-adjoint operator $H = A^H W A + l$"
@@ -292,7 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5effb592",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -305,7 +305,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f24a8588",
+   "id": "21",
    "metadata": {},
    "source": [
     "##### Run conjugate gradient"
@@ -314,7 +314,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96827838",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,7 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18c065a7",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -341,7 +341,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6d7efdf",
+   "id": "24",
    "metadata": {},
    "source": [
     "### Check for equal results\n",
@@ -351,7 +351,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f59b6015",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -361,7 +361,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ecd6e70",
+   "id": "26",
    "metadata": {},
    "source": [
     "### Next steps\n",

--- a/examples/t1_mapping_with_grad_acq.ipynb
+++ b/examples/t1_mapping_with_grad_acq.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "83bfb574",
+   "id": "0",
    "metadata": {},
    "source": [
     "# T1 mapping from a continuous Golden radial acquisition"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a2f53a0",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f7c1229",
+   "id": "2",
    "metadata": {},
    "source": [
     "### Overview\n",
@@ -74,7 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94484d00",
+   "id": "3",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dbc75fbb",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Reconstruct average image\n",
@@ -98,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4b1514c5",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "be81720e",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a0930f07",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Split the data into dynamics and reconstruct dynamic images\n",
@@ -137,7 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16fdbcbb",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "417eff6c",
+   "id": "9",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -166,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82f87630",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +179,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87260553",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Estimate T1 map"
@@ -187,7 +187,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7153f06b",
+   "id": "12",
    "metadata": {},
    "source": [
     "### Signal model\n",
@@ -205,7 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2235a00a",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d9711d3",
+   "id": "14",
    "metadata": {},
    "source": [
     "We also need the repetition time between two RF-pulses. There is a parameter `tr` in the header, but this describes\n",
@@ -231,7 +231,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d006738e",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +243,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42a19af3",
+   "id": "16",
    "metadata": {},
    "source": [
     "Finally, we have to specify the duration of the spoiler gradient. Unfortunately, we cannot get this information from\n",
@@ -253,7 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6bf4023a",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,7 +264,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42026962",
+   "id": "18",
    "metadata": {},
    "source": [
     "The reconstructed image data is complex-valued. We could fit a complex $M_0$ to the data, but in this case it is more\n",
@@ -275,7 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0ec8ecd1",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +284,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba8433ab",
+   "id": "20",
    "metadata": {},
    "source": [
     "### Constraints\n",
@@ -297,7 +297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57bafca9",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -311,7 +311,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df2a7d2f",
+   "id": "22",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -324,7 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3bf4779b",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,7 +333,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "534f05d2",
+   "id": "24",
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -346,7 +346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "579b0f42",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -355,7 +355,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71c02cca",
+   "id": "26",
    "metadata": {},
    "source": [
     "### Carry out fit"
@@ -364,7 +364,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b16dda3f",
+   "id": "27",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -381,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ebbc4ac7",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,7 +398,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3143204f",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -418,7 +418,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8b8b4c32",
+   "id": "30",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -434,7 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e83ba68",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
Hey,

I guess this feature was discussed previously in order to get rid of the additional commit from bot and directly "sync" the `.ipynb` notebooks with the `.py` files.

In this commit I add two `pre-commit` hooks:
1. [jupytext](https://github.com/mwouts/jupytext) with the `--update` argument writes to the cell content and does not modify the cell-id and output. The fact that cell-id is not modified makes the changes independent from time or pc. However, the `--update` also preserves the cell output. Therefore the 2nd hook below is required.
2. [nbstripout](https://github.com/kynan/nbstripout) is resposible for clean-up the output of `.ipynb` notebooks. This check is needed for correct work of `jupytext` but will also be a sign for a user before commit that all changes in the notebooks will be deleted.

This allows further delete the whole action section dedicated to the pip env setup, conversion, commit and push of the notebooks. I believe that this will make the procedure much more transparent and easier. As far as I understand we are also secured with the `pre-commit` tests running in CI to be sure that nobody will possibly commit to the project without necessary `pre-commit` hooks executed.

Cheers
Leonid    