### PR TITLE
Remove check-docstring-first pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,6 @@ repos:
     rev: v5.0.0
     hooks:
       - id: check-added-large-files
-      - id: check-docstring-first
       - id: check-merge-conflict
       - id: check-yaml
       - id: check-toml


### PR DESCRIPTION
This hook does not support attribute docstrings.

The bugreport from 2016 got closed as `won't fix,` as the author does not use attribute docstring.

https://github.com/pre-commit/pre-commit-hooks/issues/159

This hook only enforces that if there is a "module docstring", which it defines as any docstring without indent, it must be before any code. This does not follow [PEP257](https://peps.python.org/pep-0257/#id15).
