### PR TITLE
Switch to adjoint as backward in FourierOP

### DIFF
--- a/src/mrpro/operators/FourierOp.py
+++ b/src/mrpro/operators/FourierOp.py
@@ -16,7 +16,7 @@ from mrpro.operators.FastFourierOp import FastFourierOp
 from mrpro.operators.LinearOperator import LinearOperator
 
 
-class FourierOp(LinearOperator):
+class FourierOp(LinearOperator, adjoint_as_backward=True):
     """Fourier Operator class."""
 
     def __init__(


### PR DESCRIPTION
We forgot to enable it, or it got lost in a merge or a dead PR.

required for @guastinimara to finish #293 