### PR TITLE
Swap order of target and weight in functionals

### DIFF
--- a/src/mrpro/operators/Functional.py
+++ b/src/mrpro/operators/Functional.py
@@ -50,8 +50,8 @@ class ElementaryFunctional(Functional):
 
     def __init__(
         self,
-        weight: torch.Tensor | complex = 1.0,
         target: torch.Tensor | None | complex = None,
+        weight: torch.Tensor | complex = 1.0,
         dim: int | Sequence[int] | None = None,
         divide_by_n: bool = False,
         keepdim: bool = False,
@@ -64,10 +64,10 @@ class ElementaryFunctional(Functional):
 
         Parameters
         ----------
-        weight
-            weight parameter (see above)
         target
             target element - often data tensor (see above)
+        weight
+            weight parameter (see above)
         dim
             dimension(s) over which functional is reduced.
             All other dimensions of  `weight ( x - target)` will be treated as batch dimensions.

--- a/src/mrpro/operators/functionals/MSE.py
+++ b/src/mrpro/operators/functionals/MSE.py
@@ -12,8 +12,8 @@ class MSE(L2NormSquared):
 
     def __init__(
         self,
-        weight: torch.Tensor | complex = 1.0,
         target: torch.Tensor | None | complex = None,
+        weight: torch.Tensor | complex = 1.0,
         dim: int | Sequence[int] | None = None,
         divide_by_n: bool = True,
         keepdim: bool = False,
@@ -28,10 +28,10 @@ class MSE(L2NormSquared):
 
         Parameters
         ----------
-        weight
-            weight parameter (see above)
         target
             target element - often data tensor (see above)
+        weight
+            weight parameter (see above)
         dim
             dimension(s) over which functional is reduced.
             All other dimensions of  `weight ( x - target)` will be treated as batch dimensions.
@@ -44,4 +44,6 @@ class MSE(L2NormSquared):
             else they are removed from the result.
 
         """
+        if target is None:
+            raise ValueError("Please specify a target or consider using L2NormSquared.")
         super().__init__(weight=weight, target=target, dim=dim, divide_by_n=divide_by_n, keepdim=keepdim)

--- a/src/mrpro/operators/functionals/MSE.py
+++ b/src/mrpro/operators/functionals/MSE.py
@@ -44,6 +44,4 @@ class MSE(L2NormSquared):
             else they are removed from the result.
 
         """
-        if target is None:
-            raise ValueError('Please specify a target or consider using L2NormSquared.')
         super().__init__(weight=weight, target=target, dim=dim, divide_by_n=divide_by_n, keepdim=keepdim)

--- a/src/mrpro/operators/functionals/MSE.py
+++ b/src/mrpro/operators/functionals/MSE.py
@@ -45,5 +45,5 @@ class MSE(L2NormSquared):
 
         """
         if target is None:
-            raise ValueError("Please specify a target or consider using L2NormSquared.")
+            raise ValueError('Please specify a target or consider using L2NormSquared.')
         super().__init__(weight=weight, target=target, dim=dim, divide_by_n=divide_by_n, keepdim=keepdim)


### PR DESCRIPTION
I believe this is the more natural use, especially for MSE.

Also, forces a target in MSE.
We cant change the default or the type hints though, due to substitution principle.


Lets see if that fixes the notebooks, where @ckolbPTB, @rkcatarina and @fzimmermann89 all missed this bug.