### PR TITLE
Fix gram and adjoint of adjoint linear operator

### DIFF
--- a/src/mrpro/operators/LinearOperator.py
+++ b/src/mrpro/operators/LinearOperator.py
@@ -415,4 +415,4 @@ class AdjointLinearOperator(LinearOperator):
     @property
     def H(self) -> LinearOperator:  # noqa: N802
         """Adjoint of adjoint operator, i.e. original LinearOperator."""
-        return self.operator
+        return self._operator

--- a/src/mrpro/operators/LinearOperator.py
+++ b/src/mrpro/operators/LinearOperator.py
@@ -416,8 +416,3 @@ class AdjointLinearOperator(LinearOperator):
     def H(self) -> LinearOperator:  # noqa: N802
         """Adjoint of adjoint operator, i.e. original LinearOperator."""
         return self.operator
-
-    @property
-    def gram(self) -> LinearOperator:
-        """Gram operator."""
-        return self._operator.gram.H

--- a/tests/operators/test_operators.py
+++ b/tests/operators/test_operators.py
@@ -337,6 +337,12 @@ def test_sum_operator_multiple_adjoint():
     dotproduct_adjointness_test(linear_op_sum, u, v)
 
 
+def test_adjoint_of_adjoint():
+    """Test that the adjoint of the adjoint is the original operator"""
+    a = DummyLinearOperator(RandomGenerator(7).complex64_tensor((3, 10)))
+    assert a.H.H is a
+
+
 def test_gram_shortcuts():
     """Test that .gram for composition and scalar multiplication results in shortcuts."""
 


### PR DESCRIPTION
Gram of Adjoint is
A@A^H

Adjoint of Gram is
A^H@A


I made the mistake of implementing the first as the second.



Also, not sure why mypy did not catch the error in AdjointLinearOperator.H. I added a test for it.

