### PR TITLE
FourierOp Norm

### DIFF
--- a/src/mrpro/data/SpatialDimension.py
+++ b/src/mrpro/data/SpatialDimension.py
@@ -414,3 +414,7 @@ class SpatialDimension(MoveDataMixin, Generic[T_co]):
             return self.x.shape
         else:
             raise ValueError('Inconsistent shapes')
+
+    def prod(self: SpatialDimension[T_co]) -> T_co:
+        """Calculate the product x*y*z."""
+        return self.x * self.y * self.z

--- a/src/mrpro/operators/DensityCompensationOp.py
+++ b/src/mrpro/operators/DensityCompensationOp.py
@@ -1,6 +1,7 @@
 """Class for Density Compensation Operator."""
 
 import torch
+from typing_extensions import Self
 
 from mrpro.data.DcfData import DcfData
 from mrpro.operators.EinsumOp import EinsumOp
@@ -25,3 +26,9 @@ class DensityCompensationOp(EinsumOp):
         else:
             dcf_tensor = dcf
         super().__init__(dcf_tensor, '... k2 k1 k0 ,... coil k2 k1 k0 ->... coil k2 k1 k0')
+
+    def __pow__(self, exponent: float) -> Self:
+        """Raise the operator to a power."""
+        if not exponent > 0:
+            raise NotImplementedError('Can only raise to positive powers')
+        return type(self)(dcf=self.matrix**exponent)

--- a/src/mrpro/operators/FastFourierOp.py
+++ b/src/mrpro/operators/FastFourierOp.py
@@ -132,10 +132,10 @@ class FastFourierOp(LinearOperator):
         -------
             IFFT of y
         """
-        # FFT
-        return self._pad_op.adjoint(
+        (x,) = self._pad_op.adjoint(
             torch.fft.fftshift(
                 torch.fft.ifftn(torch.fft.ifftshift(y, dim=self._dim), dim=self._dim, norm='ortho'),
                 dim=self._dim,
             ),
         )
+        return (x,)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -240,7 +240,7 @@ def create_traj(k_shape, nkx, nky, nkz, type_kx, type_ky, type_kz):
     k_list = []
     for spacing, nk in zip([type_kz, type_ky, type_kx], [nkz, nky, nkx], strict=True):
         if spacing == 'non-uniform':
-            k = random_generator.float32_tensor(size=nk, low=-1, high=1) * max(nk)
+            k = random_generator.float32_tensor(size=nk, low=-max(nk) // 2, high=max(nk) // 2)
         elif spacing == 'uniform':
             k = create_uniform_traj(nk, k_shape=k_shape)
         elif spacing == 'zero':
@@ -293,10 +293,10 @@ COMMON_MR_TRAJECTORIES = pytest.mark.parametrize(
             'zero',  # type_k2
         ),
         (  # (2) 2d non-Cartesian mri with 2 coils
-            (1, 2, 1, 96, 128),  # im_shape
-            (1, 2, 1, 16, 192),  # k_shape
-            (1, 1, 16, 192),  # nkx
-            (1, 1, 16, 192),  # nky
+            (1, 2, 1, 128, 128),  # im_shape
+            (1, 2, 1, 16, 128),  # k_shape
+            (1, 1, 16, 128),  # nkx
+            (1, 1, 16, 128),  # nky
             (1, 1, 1, 1),  # nkz
             'non-uniform',  # type_kx
             'non-uniform',  # type_ky
@@ -306,7 +306,7 @@ COMMON_MR_TRAJECTORIES = pytest.mark.parametrize(
             'zero',  # type_k2
         ),
         (  # (3) 2d Cartesian with irregular sampling
-            (1, 1, 1, 96, 128),  # im_shape
+            (1, 1, 1, 192, 192),  # im_shape
             (1, 1, 1, 1, 192),  # k_shape
             (1, 1, 1, 192),  # nkx
             (1, 1, 1, 192),  # nky
@@ -344,12 +344,12 @@ COMMON_MR_TRAJECTORIES = pytest.mark.parametrize(
             'non-uniform',  # type_k1
             'non-uniform',  # type_k2
         ),
-        (  # (6) 2d non-uniform cine with 8 cardiac phases, 5 coils
-            (8, 5, 1, 64, 64),  # im_shape
-            (8, 5, 1, 18, 128),  # k_shape
-            (8, 1, 18, 128),  # nkx
-            (8, 1, 18, 128),  # nky
-            (8, 1, 1, 1),  # nkz
+        (  # (6) 2d non-uniform cine with 2 cardiac phases, 3 coils
+            (2, 3, 1, 64, 64),  # im_shape
+            (2, 3, 1, 18, 128),  # k_shape
+            (2, 1, 18, 128),  # nkx
+            (2, 1, 18, 128),  # nky
+            (2, 1, 1, 1),  # nkz
             'non-uniform',  # type_kx
             'non-uniform',  # type_ky
             'zero',  # type_kz
@@ -357,12 +357,12 @@ COMMON_MR_TRAJECTORIES = pytest.mark.parametrize(
             'non-uniform',  # type_k1
             'zero',  # type_k2
         ),
-        (  # (7) 2d cartesian cine with 9 cardiac phases, 6 coils
-            (9, 6, 1, 96, 128),  # im_shape
-            (9, 6, 1, 128, 192),  # k_shape
-            (9, 1, 1, 192),  # nkx
-            (9, 1, 128, 1),  # nky
-            (9, 1, 1, 1),  # nkz
+        (  # (7) 2d cartesian cine with 2 cardiac phases, 3 coils
+            (2, 3, 1, 96, 128),  # im_shape
+            (2, 3, 1, 128, 192),  # k_shape
+            (2, 1, 1, 192),  # nkx
+            (2, 1, 128, 1),  # nky
+            (2, 1, 1, 1),  # nkz
             'uniform',  # type_kx
             'uniform',  # type_ky
             'zero',  # type_kz
@@ -370,12 +370,12 @@ COMMON_MR_TRAJECTORIES = pytest.mark.parametrize(
             'uniform',  # type_k1
             'zero',  # type_k2
         ),
-        (  # (8) radial phase encoding (RPE), 8 coils, with oversampling in both FFT and non-uniform directions
-            (2, 8, 64, 32, 48),  # im_shape
-            (2, 8, 8, 64, 96),  # k_shape
+        (  # (8) radial phase encoding (RPE), 3 coils, with oversampling in both FFT and non-uniform directions
+            (2, 3, 64, 32, 48),  # im_shape
+            (2, 3, 8, 64, 96),  # k_shape
             (2, 1, 1, 96),  # nkx
-            (2, 8, 64, 1),  # nky
-            (2, 8, 64, 1),  # nkz
+            (2, 3, 64, 1),  # nky
+            (2, 3, 64, 1),  # nkz
             'uniform',  # type_kx
             'non-uniform',  # type_ky
             'non-uniform',  # type_kz
@@ -383,12 +383,12 @@ COMMON_MR_TRAJECTORIES = pytest.mark.parametrize(
             'non-uniform',  # type_k1
             'non-uniform',  # type_k2
         ),
-        (  # (9) radial phase encoding (RPE), 8 coils with non-Cartesian sampling along readout
-            (2, 8, 64, 32, 48),  # im_shape
-            (2, 8, 8, 64, 96),  # k_shape
+        (  # (9) radial phase encoding (RPE), 3 coils with non-Cartesian sampling along readout
+            (2, 3, 64, 32, 48),  # im_shape
+            (2, 3, 8, 64, 96),  # k_shape
             (2, 1, 1, 96),  # nkx
-            (2, 8, 64, 1),  # nky
-            (2, 8, 64, 1),  # nkz
+            (2, 3, 64, 1),  # nky
+            (2, 3, 64, 1),  # nkz
             'non-uniform',  # type_kx
             'non-uniform',  # type_ky
             'non-uniform',  # type_kz
@@ -396,18 +396,31 @@ COMMON_MR_TRAJECTORIES = pytest.mark.parametrize(
             'non-uniform',  # type_k1
             'non-uniform',  # type_k2
         ),
-        (  # (10) stack of stars, 5 other, 3 coil, oversampling in both FFT and non-uniform directions
-            (5, 3, 48, 16, 32),  # im_shape
-            (5, 3, 96, 18, 64),  # k_shape
-            (5, 1, 18, 64),  # nkx
-            (5, 1, 18, 64),  # nky
-            (5, 96, 1, 1),  # nkz
+        (  # (10) stack of stars, 2 other, 3 coil, oversampling in both FFT and non-uniform directions
+            (2, 3, 48, 16, 32),  # im_shape
+            (2, 3, 96, 18, 64),  # k_shape
+            (2, 1, 18, 64),  # nkx
+            (2, 1, 18, 64),  # nky
+            (2, 96, 1, 1),  # nkz
             'non-uniform',  # type_kx
             'non-uniform',  # type_ky
             'uniform',  # type_kz
             'non-uniform',  # type_k0
             'non-uniform',  # type_k1
             'uniform',  # type_k2
+        ),
+        (  # (11) 2d Cartesian with irregular sampling, oversampling
+            (1, 1, 1, 96, 128),  # im_shape
+            (1, 1, 1, 1, 192),  # k_shape
+            (1, 1, 1, 192),  # nkx
+            (1, 1, 1, 192),  # nky
+            (1, 1, 1, 1),  # nkz
+            'uniform',  # type_kx
+            'uniform',  # type_ky
+            'zero',  # type_kz
+            'uniform',  # type_k0
+            'zero',  # type_k1
+            'zero',  # type_k2
         ),
     ],
     ids=[
@@ -417,10 +430,11 @@ COMMON_MR_TRAJECTORIES = pytest.mark.parametrize(
         '2d_cartesian_irregular_sampling',
         '2d_single_shot_spiral',
         '3d_nonuniform_4_coils_2_other',
-        '2d_nonuniform_cine_mri_8_cardiac_phases_5_coils',
-        '2d_cartesian_cine_9_cardiac_phases_6_coils',
-        'radial_phase_encoding_8_coils_with_oversampling',
-        'radial_phase_encoding_8_coils_non_cartesian_sampling',
-        'stack_of_stars_5_other_3_coil_with_oversampling',
+        '2d_nonuniform_cine_mri_2_cardiac_phases_3_coils',
+        '2d_cartesian_cine_2_cardiac_phases_3_coils',
+        'radial_phase_encoding_3_coils_with_oversampling',
+        'radial_phase_encoding_3_coils_non_cartesian_sampling',
+        'stack_of_stars_2_other_3_coil_with_oversampling',
+        '2d_cartesian_irregular_sampling_with_oversampling',
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -417,7 +417,7 @@ COMMON_MR_TRAJECTORIES = pytest.mark.parametrize(
         '2d_cartesian_irregular_sampling',
         '2d_single_shot_spiral',
         '3d_nonuniform_4_coils_2_other',
-        '2d_nnonuniform_cine_mri_8_cardiac_phases_5_coils',
+        '2d_nonuniform_cine_mri_8_cardiac_phases_5_coils',
         '2d_cartesian_cine_9_cardiac_phases_6_coils',
         'radial_phase_encoding_8_coils_with_oversampling',
         'radial_phase_encoding_8_coils_non_cartesian_sampling',

--- a/tests/operators/test_fourier_op.py
+++ b/tests/operators/test_fourier_op.py
@@ -49,6 +49,26 @@ def test_fourier_op_fwd_adj_property(
 
 
 @COMMON_MR_TRAJECTORIES
+def test_fourier_op_norm(im_shape, k_shape, nkx, nky, nkz, type_kx, type_ky, type_kz, type_k0, type_k1, type_k2):
+    """Test operator norm of Fourier Operator, should be 1."""
+
+    # generate random images and k-space trajectories
+    img, trajectory = create_data(im_shape, k_shape, nkx, nky, nkz, type_kx, type_ky, type_kz)
+
+    # create operator
+    recon_matrix = SpatialDimension(im_shape[-3], im_shape[-2], im_shape[-1])
+    encoding_matrix = SpatialDimension(
+        int(trajectory.kz.max() - trajectory.kz.min() + 1),
+        int(trajectory.ky.max() - trajectory.ky.min() + 1),
+        int(trajectory.kx.max() - trajectory.kx.min() + 1),
+    )
+    fourier_op = FourierOp(recon_matrix=recon_matrix, encoding_matrix=encoding_matrix, traj=trajectory)
+    # only do few iterations to speed up the test
+    norm = fourier_op.operator_norm(img, dim=None, max_iterations=4)
+    torch.testing.assert_close(norm.squeeze(), torch.tensor(1.0), atol=0.1, rtol=0.0)
+
+
+@COMMON_MR_TRAJECTORIES
 def test_fourier_op_gram(im_shape, k_shape, nkx, nky, nkz, type_kx, type_ky, type_kz, type_k0, type_k1, type_k2):
     """Test gram of Fourier operator."""
     img, trajectory = create_data(im_shape, k_shape, nkx, nky, nkz, type_kx, type_ky, type_kz)


### PR DESCRIPTION
At least two potential issues with Fourier Op:
- I thought to norm of FourierOp should always be 1?
- Forcing use of nufft should result in the same as using the cartesian operator -- just slower, or?

Currently, the answer two both is "No" 
This adds the tests showcasing the potential problems





