### PR TITLE
Add apply (out of place)

### DIFF
--- a/src/mrpro/data/MoveDataMixin.py
+++ b/src/mrpro/data/MoveDataMixin.py
@@ -239,6 +239,24 @@ class MoveDataMixin:
         new.apply_(_convert, memo=memo, recurse=False)
         return new
 
+    def apply(
+        self: Self,
+        function: Callable[[Any], Any] | None = None,
+        *,
+        recurse: bool = True,
+    ) -> Self:
+        """Apply a function to all children. Returns a new object.
+
+        Parameters
+        ----------
+        function
+            The function to apply to all fields. None is interpreted as a no-op.
+        recurse
+            If True, the function will be applied to all children that are MoveDataMixin instances.
+        """
+        new = self.clone().apply_(function, recurse=recurse)
+        return new
+
     def apply_(
         self: Self,
         function: Callable[[Any], Any] | None = None,

--- a/src/mrpro/data/SpatialDimension.py
+++ b/src/mrpro/data/SpatialDimension.py
@@ -109,6 +109,7 @@ class SpatialDimension(MoveDataMixin, Generic[T_co]):
 
         return SpatialDimension(z, y, x)
 
+    # This function is mainly for type hinting and docstring
     def apply_(self, function: Callable[[T], T] | None = None, **_) -> Self:
         """Apply a function to each z, y, x (in-place).
 
@@ -117,9 +118,9 @@ class SpatialDimension(MoveDataMixin, Generic[T_co]):
         function
             function to apply
         """
-        # This function is mainly used for type hinting
         return super(SpatialDimension, self).apply_(function)
 
+    # This function is mainly for type hinting and docstring
     def apply(self, function: Callable[[T], T] | None = None, **_) -> Self:
         """Apply a function to each z, y, x (returning a new object).
 
@@ -128,7 +129,6 @@ class SpatialDimension(MoveDataMixin, Generic[T_co]):
         function
             function to apply
         """
-        # This function is mainly used for type hinting
         return super(SpatialDimension, self).apply(function)
 
     @property

--- a/src/mrpro/data/SpatialDimension.py
+++ b/src/mrpro/data/SpatialDimension.py
@@ -18,6 +18,7 @@ from mrpro.data.MoveDataMixin import MoveDataMixin
 VectorTypes = torch.Tensor
 ScalarTypes = int | float
 T = TypeVar('T', torch.Tensor, int, float)
+
 # Covariant types, as SpatialDimension is a Container
 # and we want, for example, SpatialDimension[int] to also be a SpatialDimension[float]
 T_co = TypeVar('T_co', torch.Tensor, int, float, covariant=True)
@@ -116,7 +117,19 @@ class SpatialDimension(MoveDataMixin, Generic[T_co]):
         function
             function to apply
         """
+        # This function is mainly used for type hinting
         return super(SpatialDimension, self).apply_(function)
+
+    def apply(self, function: Callable[[T], T] | None = None, **_) -> Self:
+        """Apply a function to each z, y, x (returning a new object).
+
+        Parameters
+        ----------
+        function
+            function to apply
+        """
+        # This function is mainly used for type hinting
+        return super(SpatialDimension, self).apply(function)
 
     @property
     def zyx(self) -> tuple[T_co, T_co, T_co]:

--- a/tests/data/test_movedatamixin.py
+++ b/tests/data/test_movedatamixin.py
@@ -207,7 +207,7 @@ def test_movedatamixin_cuda(already_moved: bool, copy: bool):
     assert new.module.module1.weight is new.module.module1.weight, 'shared module parameters should remain shared'
 
 
-def test_movedatamixin_apply():
+def test_movedatamixin_apply_():
     """Tests apply_ method of MoveDataMixin."""
     data = B()
     # make one of the parameters shared to test memo behavior
@@ -223,3 +223,24 @@ def test_movedatamixin_apply():
     torch.testing.assert_close(data.floattensor, original.floattensor * 2)
     torch.testing.assert_close(data.child.floattensor2, original.child.floattensor2 * 2)
     assert data.child.floattensor is data.child.floattensor2, 'shared module parameters should remain shared'
+
+
+def test_movedatamixin_apply():
+    """Tests apply method of MoveDataMixin."""
+    data = B()
+    # make one of the parameters shared to test memo behavior
+    data.child.floattensor2 = data.child.floattensor
+    original = data.clone()
+
+    def multiply_by_2(obj):
+        if isinstance(obj, torch.Tensor):
+            return obj * 2
+        return obj
+
+    new = data.apply(multiply_by_2)
+    torch.testing.assert_close(data.floattensor, original.floattensor)
+    torch.testing.assert_close(data.child.floattensor2, original.child.floattensor2)
+    torch.testing.assert_close(new.floattensor, original.floattensor * 2)
+    torch.testing.assert_close(new.child.floattensor2, original.child.floattensor2 * 2)
+    assert data.child.floattensor is data.child.floattensor2, 'shared module parameters should remain shared'
+    assert new is not data, 'new object should be different from the original'

--- a/tests/data/test_spatial_dimension.py
+++ b/tests/data/test_spatial_dimension.py
@@ -93,7 +93,7 @@ def test_spatial_dimension_broadcasting():
 
 
 def test_spatial_dimension_apply_():
-    """Test apply_ (inplace)"""
+    """Test apply_ (in place)"""
 
     def conversion(x: torch.Tensor) -> torch.Tensor:
         assert isinstance(x, torch.Tensor), 'The argument to the conversion function should be a tensor'
@@ -113,6 +113,34 @@ def test_spatial_dimension_apply_():
     assert torch.equal(spatial_dimension_inplace.x, x)
     assert torch.equal(spatial_dimension_inplace.y, y)
     assert torch.equal(spatial_dimension_inplace.z, z)
+
+
+def test_spatial_dimension_apply():
+    """Test apply (out of place)"""
+
+    def conversion(x: torch.Tensor) -> torch.Tensor:
+        assert isinstance(x, torch.Tensor), 'The argument to the conversion function should be a tensor'
+        return x.swapaxes(0, 1).square()
+
+    xyz = RandomGenerator(0).float32_tensor((1, 2, 3))
+    spatial_dimension = SpatialDimension.from_array_xyz(xyz.numpy())
+    spatial_dimension_outofplace = spatial_dimension.apply(conversion)
+
+    assert spatial_dimension_outofplace is not spatial_dimension
+
+    assert isinstance(spatial_dimension_outofplace.x, torch.Tensor)
+    assert isinstance(spatial_dimension_outofplace.y, torch.Tensor)
+    assert isinstance(spatial_dimension_outofplace.z, torch.Tensor)
+
+    x, y, z = conversion(xyz).unbind(-1)
+    assert torch.equal(spatial_dimension_outofplace.x, x)
+    assert torch.equal(spatial_dimension_outofplace.y, y)
+    assert torch.equal(spatial_dimension_outofplace.z, z)
+
+    x, y, z = xyz.unbind(-1)  # original should be unmodified
+    assert torch.equal(spatial_dimension.x, x)
+    assert torch.equal(spatial_dimension.y, y)
+    assert torch.equal(spatial_dimension.z, z)
 
 
 def test_spatial_dimension_zyx():


### PR DESCRIPTION
Copies a dataclass, then applies.

@ckolbPTB made a mistake of using .apply_ to get a converted value in #421, changing the original value (if I am not mistaken)
Maybe also having a not-in-place version of apply makes this mistake less likely