### PR TITLE
Fix DCF and FourierOp edgecase bugs

### DIFF
--- a/src/mrpro/data/DcfData.py
+++ b/src/mrpro/data/DcfData.py
@@ -56,7 +56,7 @@ class DcfData(MoveDataMixin):
 
         if ks_needing_voronoi:
             # Handle full dimensions needing voronoi
-            dcfs.append(smap(dcf_2d3d_voronoi, torch.stack(list(ks_needing_voronoi), -4), 4))
+            dcfs.append(smap(dcf_2d3d_voronoi, torch.stack(torch.broadcast_tensors(*ks_needing_voronoi), -4), 4))
 
         if dcfs:
             # Multiply all dcfs together

--- a/src/mrpro/operators/FourierOp.py
+++ b/src/mrpro/operators/FourierOp.py
@@ -108,17 +108,17 @@ class FourierOp(LinearOperator, adjoint_as_backward=True):
             # Broadcast shapes not always needed but also does not hurt
             omega = [k.expand(*np.broadcast_shapes(*[k.shape for k in omega])) for k in omega]
             self.register_buffer('_omega', torch.stack(omega, dim=-4))  # use the 'coil' dim for the direction
-
+            numpoints = [min(img_size, nufft_numpoints) for img_size in self._nufft_im_size]
             self._fwd_nufft_op: KbNufftAdjoint | None = KbNufft(
                 im_size=self._nufft_im_size,
                 grid_size=grid_size,
-                numpoints=nufft_numpoints,
+                numpoints=numpoints,
                 kbwidth=nufft_kbwidth,
             )
             self._adj_nufft_op: KbNufftAdjoint | None = KbNufftAdjoint(
                 im_size=self._nufft_im_size,
                 grid_size=grid_size,
-                numpoints=nufft_numpoints,
+                numpoints=numpoints,
                 kbwidth=nufft_kbwidth,
             )
         else:

--- a/tests/data/test_dcf_data.py
+++ b/tests/data/test_dcf_data.py
@@ -5,6 +5,8 @@ import torch
 from einops import repeat
 from mrpro.data import DcfData, KTrajectory
 
+from tests import RandomGenerator
+
 
 def example_traj_rpe(n_kr, n_ka, n_k0, broadcast=True):
     """Create RPE trajectory with uniform angular gap."""
@@ -17,7 +19,7 @@ def example_traj_rpe(n_kr, n_ka, n_k0, broadcast=True):
     return trajectory
 
 
-def example_traj_spiral_2d(n_kr, n_ki, n_ka, broadcast=True) -> KTrajectory:
+def example_traj_spiral_2d(n_kr: int, n_ki: int, n_ka: int, broadcast: bool = True) -> KTrajectory:
     """Create 2D spiral trajectory with n_kr points along each spiral arm, n_ki
     turns per spiral arm and n_ka spiral arms."""
     ang = repeat(torch.linspace(0, 2 * torch.pi * n_ki, n_kr), 'k0 -> other k2 k1 k0', other=1, k2=1, k1=1)
@@ -82,3 +84,15 @@ def test_dcf_rpe_traj_voronoi_cuda(n_kr, n_ka, n_k0):
     trajectory = example_traj_rpe(n_kr, n_ka, n_k0)
     dcf = DcfData.from_traj_voronoi(trajectory.cuda())
     assert dcf.data.is_cuda
+
+
+def test_dcf_broadcast():
+    """Test broadcasting within voronoi dcf calculation."""
+    rng = RandomGenerator(0)
+    # kx and ky force voronoi calculation and need to be broadcasted
+    kx = rng.float32_tensor((1, 1, 4, 4))
+    ky = rng.float32_tensor((1, 4, 1, 4))
+    kz = torch.zeros(1, 1, 1, 1)
+    trajectory = KTrajectory(kz, ky, kx)
+    dcf = DcfData.from_traj_voronoi(trajectory)
+    assert dcf.data.shape == trajectory.broadcasted_shape


### PR DESCRIPTION
This fixes two bugs noticed by @schuenke (only triggered because of another bug):

Our FourierOp did not work for `image_size<nufft_numpoints` -- so you could not to non-uniform sampling with fewer than 6 points (not that common)

Our DCF vornoi assumed that the k dimension requiring vorinoi did not contain singleton dimensions. 