### PR TITLE
Add T2* as outlook

### DIFF
--- a/examples/notebooks/qmri_sg_challenge_2024_t1.ipynb
+++ b/examples/notebooks/qmri_sg_challenge_2024_t1.ipynb
@@ -387,6 +387,30 @@
     "\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25",
+   "metadata": {},
+   "source": [
+    "### Next steps\n",
+    "\n",
+    "The 2024 ISMRM QMRI Challenge also included the estimation of $T_2^*$ maps from multi-echo data. You can find the\n",
+    "the data here: https://zenodo.org/record/10868361. You can download it using the same method as above and then\n",
+    "unpacking the 'T2star.zip' file.\n",
+    "\n",
+    "As a signal model $q$ you can use `~mrpro.operators.models.MonoExponentialDecay` describing the signal decay as\n",
+    "\n",
+    "$q(TE) = M_0 e^{-TE/T_2^*}$\n",
+    "\n",
+    "with the equilibrium magnetization $M_0$, the echo time $TE$, and $T_2^*$\n",
+    "\n",
+    "Give it a try and see if you can obtain good $T_2^*$ maps!\n",
+    "```{note}\n",
+    "The echo times $TE$ can be found in `IData.header.te`. A good starting value for $M_0$ is the signal at the shortest\n",
+    "echo time. A good starting value for $T_2^*$ is 20 ms.\n",
+    "```"
+   ]
   }
  ],
  "metadata": {

--- a/examples/scripts/qmri_sg_challenge_2024_t1.py
+++ b/examples/scripts/qmri_sg_challenge_2024_t1.py
@@ -210,3 +210,22 @@ axes[0, 2].set_axis_off()
 fig.colorbar(im, ax=axes[0, 2])
 
 plt.show()
+
+# %% [markdown]
+# ### Next steps
+#
+# The 2024 ISMRM QMRI Challenge also included the estimation of $T_2^*$ maps from multi-echo data. You can find the
+# the data here: https://zenodo.org/record/10868361. You can download it using the same method as above and then
+# unpacking the 'T2star.zip' file.
+#
+# As a signal model $q$ you can use `~mrpro.operators.models.MonoExponentialDecay` describing the signal decay as
+#
+# $q(TE) = M_0 e^{-TE/T_2^*}$
+#
+# with the equilibrium magnetization $M_0$, the echo time $TE$, and $T_2^*$
+#
+# Give it a try and see if you can obtain good $T_2^*$ maps!
+# ```{note}
+# The echo times $TE$ can be found in `IData.header.te`. A good starting value for $M_0$ is the signal at the shortest
+# echo time. A good starting value for $T_2^*$ is 20 ms.
+# ```


### PR DESCRIPTION
I had a look at the QMRI Challenge ISMRM 2024 T2* notebook and the results are still the same as what we had before. The only problem was the vmax setting in the final plot was too high. So everything is still working as expected.

My suggestion would be to add the T2* part as a "do-it-yourself" part at the end - would be very useful for training courses and practical sessions.