### PR TITLE
Make notebook generation more stable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     hooks:
       - id: check-added-large-files
       - id: check-merge-conflict
+        exclude_types: [rst]
       - id: check-yaml
       - id: check-toml
       - id: check-json
@@ -63,10 +64,21 @@ repos:
           "colab": {"gpuType": "T4","provenance": []},
           "kernelspec": {"display_name": "Python 3 (ipykernel)","language": "python","name": "python3"}
         }'
+        --opt cell_metadata_filter=mystnb,tags,-all
        always_run: true
        pass_filenames: true
        files: ^examples/scripts/.*py
        types_or: [python]
+
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.8.0
+    hooks:
+    # cleans the .ipynbs (removes outputs, resets all cell-ids to 0..N, cleans steps)
+    # also clean any kernel information left after execution
+    - id: nbstripout
+      name: clean .ipynb output
+      args: [--extra-keys, "metadata.language_info"]
+      files: examples/notebooks
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.14.1

--- a/examples/notebooks/cartesian_reconstruction.ipynb
+++ b/examples/notebooks/cartesian_reconstruction.ipynb
@@ -732,7 +732,7 @@
    "provenance": []
   },
   "jupytext": {
-   "cell_metadata_filter": "-all"
+   "cell_metadata_filter": "mystnb,tags,-all"
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",

--- a/examples/notebooks/direct_reconstruction.ipynb
+++ b/examples/notebooks/direct_reconstruction.ipynb
@@ -238,7 +238,7 @@
    "provenance": []
   },
   "jupytext": {
-   "cell_metadata_filter": "-all"
+   "cell_metadata_filter": "mystnb,tags,-all"
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",

--- a/examples/notebooks/iterative_sense_reconstruction.ipynb
+++ b/examples/notebooks/iterative_sense_reconstruction.ipynb
@@ -338,7 +338,7 @@
    "provenance": []
   },
   "jupytext": {
-   "cell_metadata_filter": "-all"
+   "cell_metadata_filter": "mystnb,tags,-all"
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",

--- a/examples/notebooks/pulseq_2d_radial_golden_angle.ipynb
+++ b/examples/notebooks/pulseq_2d_radial_golden_angle.ipynb
@@ -212,7 +212,7 @@
    "provenance": []
   },
   "jupytext": {
-   "cell_metadata_filter": "-all"
+   "cell_metadata_filter": "mystnb,tags,-all"
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",

--- a/examples/notebooks/qmri_sg_challenge_2024_t1.ipynb
+++ b/examples/notebooks/qmri_sg_challenge_2024_t1.ipynb
@@ -360,7 +360,7 @@
    "provenance": []
   },
   "jupytext": {
-   "cell_metadata_filter": "-all"
+   "cell_metadata_filter": "mystnb,tags,-all"
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",

--- a/examples/notebooks/qmri_sg_challenge_2024_t2_star.ipynb
+++ b/examples/notebooks/qmri_sg_challenge_2024_t2_star.ipynb
@@ -317,7 +317,7 @@
    "provenance": []
   },
   "jupytext": {
-   "cell_metadata_filter": "-all"
+   "cell_metadata_filter": "mystnb,tags,-all"
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",

--- a/examples/notebooks/regularized_iterative_sense_reconstruction.ipynb
+++ b/examples/notebooks/regularized_iterative_sense_reconstruction.ipynb
@@ -408,7 +408,7 @@
    "provenance": []
   },
   "jupytext": {
-   "cell_metadata_filter": "-all"
+   "cell_metadata_filter": "mystnb,tags,-all"
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",

--- a/examples/notebooks/t1_mapping_with_grad_acq.ipynb
+++ b/examples/notebooks/t1_mapping_with_grad_acq.ipynb
@@ -532,7 +532,7 @@
    "provenance": []
   },
   "jupytext": {
-   "cell_metadata_filter": "-all"
+   "cell_metadata_filter": "mystnb,tags,-all"
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",


### PR DESCRIPTION
This pulls to small band-aids from #598:
- Run nbstripout again after jupytext modified the notebooks
- Set cell_metadata_filter to a fixed value, otherwise mystnb and tags sometimes randomly change places, causing random failures on pre-commit action