### PR TITLE
Remove unused WASABI(TI) parameter

### DIFF
--- a/src/mrpro/operators/models/WASABI.py
+++ b/src/mrpro/operators/models/WASABI.py
@@ -5,6 +5,7 @@ from torch import nn
 
 from mrpro.operators.SignalModel import SignalModel
 from mrpro.utils import unsqueeze_right
+from mrpro.utils.unit_conversion import GYROMAGNETIC_RATIO_PROTON
 
 
 class WASABI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]):
@@ -15,7 +16,7 @@ class WASABI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
         offsets: torch.Tensor,
         rf_duration: float | torch.Tensor = 0.005,
         b1_nominal: float | torch.Tensor = 3.70e-6,
-        gamma: float | torch.Tensor = 42.5764e6,
+        gamma: float | torch.Tensor = GYROMAGNETIC_RATIO_PROTON,
     ) -> None:
         """Initialize WASABI signal model for mapping of B0 and B1 [SCHU2016]_.
 
@@ -46,7 +47,7 @@ class WASABI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
         self.offsets = nn.Parameter(offsets, requires_grad=offsets.requires_grad)
         self.rf_duration = nn.Parameter(rf_duration, requires_grad=rf_duration.requires_grad)
         self.b1_nominal = nn.Parameter(b1_nominal, requires_grad=b1_nominal.requires_grad)
-        self.gamma = nn.Parameter(gamma, requires_grad=gamma.requires_grad)
+        self.gamma = gamma
 
     def forward(
         self,

--- a/src/mrpro/operators/models/WASABI.py
+++ b/src/mrpro/operators/models/WASABI.py
@@ -16,7 +16,6 @@ class WASABI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
         rf_duration: float | torch.Tensor = 0.005,
         b1_nominal: float | torch.Tensor = 3.70,
         gamma: float | torch.Tensor = 42.5764,
-        larmor_frequency: float | torch.Tensor = 127.7292,
     ) -> None:
         """Initialize WASABI signal model for mapping of B0 and B1 [SCHU2016]_.
 
@@ -31,8 +30,6 @@ class WASABI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
             nominal B1 amplitude [µT]
         gamma
             gyromagnetic ratio [MHz/T]
-        larmor_frequency
-            larmor frequency [MHz]
 
         References
         ----------
@@ -44,14 +41,12 @@ class WASABI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
         rf_duration = torch.as_tensor(rf_duration)
         b1_nominal = torch.as_tensor(b1_nominal)
         gamma = torch.as_tensor(gamma)
-        larmor_frequency = torch.as_tensor(larmor_frequency)
 
         # nn.Parameters allow for grad calculation
         self.offsets = nn.Parameter(offsets, requires_grad=offsets.requires_grad)
         self.rf_duration = nn.Parameter(rf_duration, requires_grad=rf_duration.requires_grad)
         self.b1_nominal = nn.Parameter(b1_nominal, requires_grad=b1_nominal.requires_grad)
         self.gamma = nn.Parameter(gamma, requires_grad=gamma.requires_grad)
-        self.larmor_frequency = nn.Parameter(larmor_frequency, requires_grad=larmor_frequency.requires_grad)
 
     def forward(
         self,

--- a/src/mrpro/operators/models/WASABITI.py
+++ b/src/mrpro/operators/models/WASABITI.py
@@ -5,6 +5,7 @@ from torch import nn
 
 from mrpro.operators.SignalModel import SignalModel
 from mrpro.utils import unsqueeze_right
+from mrpro.utils.unit_conversion import GYROMAGNETIC_RATIO_PROTON
 
 
 class WASABITI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
@@ -16,7 +17,7 @@ class WASABITI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
         recovery_time: torch.Tensor,
         rf_duration: float | torch.Tensor = 0.005,
         b1_nominal: float | torch.Tensor = 3.75e-6,
-        gamma: float | torch.Tensor = 42.5764e6,
+        gamma: float | torch.Tensor = GYROMAGNETIC_RATIO_PROTON,
     ) -> None:
         """Initialize WASABITI signal model for mapping of B0, B1 and T1 [SCH2023]_.
 
@@ -55,7 +56,7 @@ class WASABITI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
         self.recovery_time = nn.Parameter(recovery_time, requires_grad=recovery_time.requires_grad)
         self.rf_duration = nn.Parameter(rf_duration, requires_grad=rf_duration.requires_grad)
         self.b1_nominal = nn.Parameter(b1_nominal, requires_grad=b1_nominal.requires_grad)
-        self.gamma = nn.Parameter(gamma, requires_grad=gamma.requires_grad)
+        self.gamma = gamma
 
     def forward(self, b0_shift: torch.Tensor, relative_b1: torch.Tensor, t1: torch.Tensor) -> tuple[torch.Tensor,]:
         """Apply WASABITI signal model.

--- a/src/mrpro/operators/models/WASABITI.py
+++ b/src/mrpro/operators/models/WASABITI.py
@@ -17,7 +17,6 @@ class WASABITI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
         rf_duration: float | torch.Tensor = 0.005,
         b1_nominal: float | torch.Tensor = 3.75,
         gamma: float | torch.Tensor = 42.5764,
-        larmor_frequency: float | torch.Tensor = 127.7292,
     ) -> None:
         """Initialize WASABITI signal model for mapping of B0, B1 and T1 [SCH2023]_.
 
@@ -33,8 +32,6 @@ class WASABITI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
             nominal B1 amplitude [µT]
         gamma
             gyromagnetic ratio [MHz/T]
-        larmor_frequency
-            larmor frequency [MHz]
 
         References
         ----------
@@ -47,7 +44,6 @@ class WASABITI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
         rf_duration = torch.as_tensor(rf_duration)
         b1_nominal = torch.as_tensor(b1_nominal)
         gamma = torch.as_tensor(gamma)
-        larmor_frequency = torch.as_tensor(larmor_frequency)
 
         if recovery_time.shape != offsets.shape:
             raise ValueError(
@@ -60,7 +56,6 @@ class WASABITI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
         self.rf_duration = nn.Parameter(rf_duration, requires_grad=rf_duration.requires_grad)
         self.b1_nominal = nn.Parameter(b1_nominal, requires_grad=b1_nominal.requires_grad)
         self.gamma = nn.Parameter(gamma, requires_grad=gamma.requires_grad)
-        self.larmor_frequency = nn.Parameter(larmor_frequency, requires_grad=larmor_frequency.requires_grad)
 
     def forward(self, b0_shift: torch.Tensor, relative_b1: torch.Tensor, t1: torch.Tensor) -> tuple[torch.Tensor,]:
         """Apply WASABITI signal model.

--- a/src/mrpro/utils/unit_conversion.py
+++ b/src/mrpro/utils/unit_conversion.py
@@ -17,7 +17,7 @@ __all__ = [
     's_to_ms',
 ]
 
-GYROMAGNETIC_RATIO_PROTON = 42.58 * 1e6
+GYROMAGNETIC_RATIO_PROTON = 42.5764 * 1e6
 r"""The gyromagnetic ratio :math:`\frac{\gamma}{2\pi}` of 1H in H2O in Hz/T."""
 
 # Conversion functions for units


### PR DESCRIPTION
Seems `larmor_frequency` is not used in the signal model or am I missing something?