### PR TITLE
typing fixes for torch 2.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,7 +89,7 @@ repos:
         args: [src, tests, examples]
         additional_dependencies:
           - numpy
-          - torch>=2.4.0
+          - torch>=2.6.0
           - types-requests
           - typing-extensions
           - einops

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ filterwarnings = [
     "error",
     "ignore:'write_like_original':DeprecationWarning:pydicom:",
     "ignore:Anomaly Detection has been enabled:UserWarning",    #torch.autograd
+    "ignore:allow_ops_in_compiled_graph failed to import torch:ImportWarning", # einops and dynamo<2.5
 ]
 addopts = "-n auto"
 markers = ["cuda : Tests only to be run when cuda device is available"]

--- a/src/mrpro/data/Rotation.py
+++ b/src/mrpro/data/Rotation.py
@@ -45,7 +45,7 @@ from __future__ import annotations
 import math
 import re
 import warnings
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from typing import Literal, cast
 
 import numpy as np
@@ -378,7 +378,7 @@ def _axisangle_to_matrix(axis: torch.Tensor, angle: torch.Tensor) -> torch.Tenso
     return matrix
 
 
-class Rotation(torch.nn.Module):
+class Rotation(torch.nn.Module, Iterable['Rotation']):
     """A container for Rotations.
 
     A pytorch implementation of scipy.spatial.transform.Rotation.
@@ -1611,6 +1611,16 @@ class Rotation(torch.nn.Module):
         else:
             indexer_quat = (indexer, slice(None))
         return self.__class__(self._quaternions[indexer_quat], normalize=False, inversion=self._is_improper[indexer])
+
+    def __iter__(self) -> Iterator[Self]:
+        """Provide an explicit iterator."""
+        index = 0
+        while True:
+            try:
+                yield self[index]
+                index += 1
+            except IndexError:
+                break
 
     @property
     def quaternion_x(self) -> torch.Tensor:

--- a/src/mrpro/operators/CartesianSamplingOp.py
+++ b/src/mrpro/operators/CartesianSamplingOp.py
@@ -84,12 +84,12 @@ class CartesianSamplingOp(LinearOperator):
             inside_encoding_matrix = rearrange(inside_encoding_matrix, '... kz ky kx -> ... 1 (kz ky kx)')
             inside_encoding_matrix_idx = inside_encoding_matrix.nonzero(as_tuple=True)[-1]
             inside_encoding_matrix_idx = torch.reshape(inside_encoding_matrix_idx, (*kidx.shape[:-1], -1))
-            self._inside_encoding_matrix_idx: torch.Tensor | None = torch.nn.Buffer(inside_encoding_matrix_idx)
+            self._inside_encoding_matrix_idx: torch.Tensor | None = inside_encoding_matrix_idx
             kidx = torch.take_along_dim(kidx, inside_encoding_matrix_idx, dim=-1)
         else:
             self._inside_encoding_matrix_idx = None
 
-        self._fft_idx = torch.nn.Buffer(kidx)
+        self._fft_idx = kidx
 
         # we can skip the indexing if the data is already sorted
         self._needs_indexing = (
@@ -245,7 +245,7 @@ class CartesianSamplingGramOp(LinearOperator):
         if sampling_op._needs_indexing:
             ones = torch.ones(*sampling_op._trajectory_shape[:-3], 1, *sampling_op._sorted_grid_shape.zyx)
             (mask,) = sampling_op.adjoint(*sampling_op.forward(ones))
-            self._mask: torch.Tensor | None = torch.nn.Buffer(mask)
+            self._mask: torch.Tensor | None = mask
         else:
             self._mask = None
 

--- a/src/mrpro/operators/CartesianSamplingOp.py
+++ b/src/mrpro/operators/CartesianSamplingOp.py
@@ -84,12 +84,12 @@ class CartesianSamplingOp(LinearOperator):
             inside_encoding_matrix = rearrange(inside_encoding_matrix, '... kz ky kx -> ... 1 (kz ky kx)')
             inside_encoding_matrix_idx = inside_encoding_matrix.nonzero(as_tuple=True)[-1]
             inside_encoding_matrix_idx = torch.reshape(inside_encoding_matrix_idx, (*kidx.shape[:-1], -1))
-            self.register_buffer('_inside_encoding_matrix_idx', inside_encoding_matrix_idx)
+            self._inside_encoding_matrix_idx: torch.Tensor | None = torch.nn.Buffer(inside_encoding_matrix_idx)
             kidx = torch.take_along_dim(kidx, inside_encoding_matrix_idx, dim=-1)
         else:
-            self._inside_encoding_matrix_idx: torch.Tensor | None = None
+            self._inside_encoding_matrix_idx = None
 
-        self.register_buffer('_fft_idx', kidx)
+        self._fft_idx = torch.nn.Buffer(kidx)
 
         # we can skip the indexing if the data is already sorted
         self._needs_indexing = (
@@ -245,9 +245,9 @@ class CartesianSamplingGramOp(LinearOperator):
         if sampling_op._needs_indexing:
             ones = torch.ones(*sampling_op._trajectory_shape[:-3], 1, *sampling_op._sorted_grid_shape.zyx)
             (mask,) = sampling_op.adjoint(*sampling_op.forward(ones))
-            self.register_buffer('_mask', mask)
+            self._mask: torch.Tensor | None = torch.nn.Buffer(mask)
         else:
-            self._mask: torch.Tensor | None = None
+            self._mask = None
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
         """Apply the Gram operator.

--- a/src/mrpro/operators/FiniteDifferenceOp.py
+++ b/src/mrpro/operators/FiniteDifferenceOp.py
@@ -60,7 +60,7 @@ class FiniteDifferenceOp(LinearOperator):
         super().__init__()
         self.dim = dim
         self.pad_mode: Literal['constant', 'circular'] = 'constant' if pad_mode == 'zeros' else pad_mode
-        self.register_buffer('kernel', self.finite_difference_kernel(mode))
+        self.kernel = torch.nn.Buffer(self.finite_difference_kernel(mode))
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
         """Forward of finite differences.

--- a/src/mrpro/operators/FiniteDifferenceOp.py
+++ b/src/mrpro/operators/FiniteDifferenceOp.py
@@ -60,7 +60,7 @@ class FiniteDifferenceOp(LinearOperator):
         super().__init__()
         self.dim = dim
         self.pad_mode: Literal['constant', 'circular'] = 'constant' if pad_mode == 'zeros' else pad_mode
-        self.kernel = torch.nn.Buffer(self.finite_difference_kernel(mode))
+        self.kernel = self.finite_difference_kernel(mode)
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
         """Forward of finite differences.

--- a/src/mrpro/operators/FourierOp.py
+++ b/src/mrpro/operators/FourierOp.py
@@ -118,9 +118,8 @@ class FourierOp(LinearOperator, adjoint_as_backward=True):
 
             # Broadcast shapes not always needed but also does not hurt
             omega = [k.expand(*np.broadcast_shapes(*[k.shape for k in omega])) for k in omega]
-            self._omega: torch.Tensor | None = torch.nn.Buffer(
-                torch.stack(omega, dim=-4)
-            )  # use the 'coil' dim for the direction
+            self._omega: torch.Tensor | None = torch.stack(omega, dim=-4)
+            # use the 'coil' dim for the direction
             numpoints = [min(img_size, nufft_numpoints) for img_size in self._nufft_im_size]
             self._fwd_nufft_op: KbNufftAdjoint | None = KbNufft(
                 im_size=self._nufft_im_size,

--- a/src/mrpro/operators/FourierOp.py
+++ b/src/mrpro/operators/FourierOp.py
@@ -118,7 +118,9 @@ class FourierOp(LinearOperator, adjoint_as_backward=True):
 
             # Broadcast shapes not always needed but also does not hurt
             omega = [k.expand(*np.broadcast_shapes(*[k.shape for k in omega])) for k in omega]
-            self.register_buffer('_omega', torch.stack(omega, dim=-4))  # use the 'coil' dim for the direction
+            self._omega: torch.Tensor | None = torch.nn.Buffer(
+                torch.stack(omega, dim=-4)
+            )  # use the 'coil' dim for the direction
             numpoints = [min(img_size, nufft_numpoints) for img_size in self._nufft_im_size]
             self._fwd_nufft_op: KbNufftAdjoint | None = KbNufft(
                 im_size=self._nufft_im_size,
@@ -133,7 +135,7 @@ class FourierOp(LinearOperator, adjoint_as_backward=True):
                 kbwidth=nufft_kbwidth,
             )
         else:
-            self._omega: torch.Tensor | None = None
+            self._omega = None
             self._fwd_nufft_op = None
             self._adj_nufft_op = None
         self._kshape = traj.broadcasted_shape

--- a/src/mrpro/operators/Functional.py
+++ b/src/mrpro/operators/Functional.py
@@ -81,10 +81,10 @@ class ElementaryFunctional(Functional):
 
         """
         super().__init__()
-        self.weight = torch.nn.Buffer(torch.as_tensor(weight))
+        self.weight = torch.as_tensor(weight)
         if target is None:
             target = torch.tensor(0, dtype=torch.float32)
-        self.target = torch.nn.Buffer(torch.as_tensor(target))
+        self.target = torch.as_tensor(target)
         if isinstance(dim, int):
             dim = (dim,)
         elif isinstance(dim, Sequence):
@@ -225,7 +225,7 @@ class ScaledFunctional(Functional):
         """
         super().__init__()
         self.functional = functional
-        self.scale = torch.nn.Buffer(torch.as_tensor(scale))
+        self.scale = torch.as_tensor(scale)
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor]:
         """Forward method.
@@ -260,7 +260,7 @@ class ScaledProximableFunctional(ProximableFunctional):
         """
         super().__init__()
         self.functional = functional
-        self.scale = torch.nn.Buffer(torch.as_tensor(scale))
+        self.scale = torch.as_tensor(scale)
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor]:
         """Forward method.

--- a/src/mrpro/operators/GridSamplingOp.py
+++ b/src/mrpro/operators/GridSamplingOp.py
@@ -191,7 +191,7 @@ class GridSamplingOp(LinearOperator):
         Parameters
         ----------
         grid
-            sampling grid. Shape `\*batchdim, z,y,x,3 / \*batchdim, y,x,2`.
+            sampling grid. Shape `*batchdim, z,y,x,3` / `*batchdim, y,x,2`.
             Values should be in ``[-1, 1.]``.
         input_shape
             Used in the adjoint. The z, y, x shape of the domain of the operator.
@@ -230,7 +230,7 @@ class GridSamplingOp(LinearOperator):
 
         self.interpolation_mode = interpolation_mode
         self.padding_mode = padding_mode
-        self.grid = torch.nn.Buffer(grid)
+        self.grid = grid
         self.input_shape = input_shape
         self.align_corners = align_corners
 

--- a/src/mrpro/operators/GridSamplingOp.py
+++ b/src/mrpro/operators/GridSamplingOp.py
@@ -230,7 +230,7 @@ class GridSamplingOp(LinearOperator):
 
         self.interpolation_mode = interpolation_mode
         self.padding_mode = padding_mode
-        self.register_buffer('grid', grid)
+        self.grid = torch.nn.Buffer(grid)
         self.input_shape = input_shape
         self.align_corners = align_corners
 

--- a/src/mrpro/operators/LinearOperator.py
+++ b/src/mrpro/operators/LinearOperator.py
@@ -384,7 +384,7 @@ class LinearOperatorComposition(LinearOperator):
         self._operator2 = operator2
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor]:
-        """Operator composition."""
+        """Linear operator composition."""
         return self._operator1(*self._operator2(x))
 
     def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
@@ -400,12 +400,12 @@ class LinearOperatorComposition(LinearOperator):
 
 
 class LinearOperatorSum(LinearOperator):
-    """Operator addition."""
+    """Linear operator addition."""
 
     _operators: list[LinearOperator]
 
     def __init__(self, operator1: LinearOperator, /, *other_operators: LinearOperator):
-        """Operator addition initialization."""
+        """Linear operator addition initialization."""
         super().__init__()
         ops: list[LinearOperator] = []
         for op in (operator1, *other_operators):
@@ -416,11 +416,11 @@ class LinearOperatorSum(LinearOperator):
         self._operators = cast(list[LinearOperator], torch.nn.ModuleList(ops))
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor]:
-        """Operator addition."""
+        """Linear operator addition."""
         return (functools.reduce(operator.add, (op(x)[0] for op in self._operators)),)
 
     def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
-        """Adjoint of the operator addition."""
+        """Adjoint of the linear operator addition."""
         # (A+B)^H = A^H + B^H
         return (functools.reduce(operator.add, (op.adjoint(x)[0] for op in self._operators)),)
 
@@ -438,7 +438,7 @@ class LinearOperatorElementwiseProductRight(LinearOperator):
         self._scalar = scalar
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
-        """Operator elementwise right multiplication."""
+        """Linear operator elementwise right multiplication."""
         (out,) = self._operator(x)
         return (out * self._scalar,)
 

--- a/src/mrpro/operators/LinearOperator.py
+++ b/src/mrpro/operators/LinearOperator.py
@@ -362,7 +362,7 @@ class LinearOperator(Operator[torch.Tensor, tuple[torch.Tensor]]):
 
 
 class LinearOperatorComposition(LinearOperator):
-    """LinearOperator composition.
+    """Linear operator composition.
 
     Performs operator1(operator2(x))
     """
@@ -388,7 +388,7 @@ class LinearOperatorComposition(LinearOperator):
         return self._operator1(*self._operator2(x))
 
     def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
-        """Adjoint of the operator composition."""
+        """Adjoint of the linear operator composition."""
         # (AB)^H = B^H A^H
         return self._operator2.adjoint(*self._operator1.adjoint(x))
 
@@ -426,7 +426,7 @@ class LinearOperatorSum(LinearOperator):
 
 
 class LinearOperatorElementwiseProductRight(LinearOperator):
-    """Operator elementwise right multiplication with a tensor.
+    """Linear operator elementwise right multiplication with a tensor.
 
     Performs Tensor*LinearOperator(x)
     """

--- a/src/mrpro/operators/LinearOperatorMatrix.py
+++ b/src/mrpro/operators/LinearOperatorMatrix.py
@@ -200,7 +200,8 @@ class LinearOperatorMatrix(Operator[Unpack[tuple[torch.Tensor, ...]], tuple[torc
     def __matmul__(self, other: LinearOperator | Self) -> Self:  # type: ignore[override]
         """Composition of operators."""
         if isinstance(other, LinearOperator):
-            return self._binary_operation(other, '__matmul__')
+            operators = [[other @ op for op in row] for row in self._operators]
+            return self.__class__(operators)
         elif isinstance(other, LinearOperatorMatrix):
             if self.shape[1] != other.shape[0]:
                 raise ValueError('OperatorMatrix shapes do not match.')

--- a/src/mrpro/operators/LinearOperatorMatrix.py
+++ b/src/mrpro/operators/LinearOperatorMatrix.py
@@ -197,6 +197,11 @@ class LinearOperatorMatrix(Operator[Unpack[tuple[torch.Tensor, ...]], tuple[torc
             operators.append([cast(LinearOperator, o * op) for op in row])
         return self.__class__(operators)
 
+    def __rmatmul__(self, other: LinearOperator) -> Self:  # type: ignore[misc]
+        """Composition of operators."""
+        operators = [[op @ other for op in row] for row in self._operators]
+        return self.__class__(operators)
+
     def __matmul__(self, other: LinearOperator | Self) -> Self:  # type: ignore[override]
         """Composition of operators."""
         if isinstance(other, LinearOperator):

--- a/src/mrpro/operators/Operator.py
+++ b/src/mrpro/operators/Operator.py
@@ -10,13 +10,14 @@ import torch
 from typing_extensions import TypeVar, TypeVarTuple, Unpack, overload
 
 import mrpro.operators
+from mrpro.utils.TensorAttributeMixin import TensorAttributeMixin
 
 Tin = TypeVarTuple('Tin')  # TODO: bind to torch.Tensors
 Tin2 = TypeVarTuple('Tin2')  # TODO: bind to torch.Tensors
 Tout = TypeVar('Tout', bound=tuple, covariant=True)  # TODO: bind to torch.Tensors
 
 
-class Operator(Generic[Unpack[Tin], Tout], ABC, torch.nn.Module):
+class Operator(Generic[Unpack[Tin], Tout], ABC, TensorAttributeMixin, torch.nn.Module):
     """The general Operator class.
 
     An operator is a function that maps one or more input tensors to one or more output tensors.

--- a/src/mrpro/operators/PCACompressionOp.py
+++ b/src/mrpro/operators/PCACompressionOp.py
@@ -38,7 +38,7 @@ class PCACompressionOp(LinearOperator):
         _, _, v = torch.svd(correlation)
         # add joint_dim along which the the compression is the same
         v = repeat(v, '... comp1 comp2 -> ... joint_dim comp1 comp2', joint_dim=1)
-        self.register_buffer('_compression_matrix', v[..., :n_components, :].clone())
+        self._compression_matrix = torch.nn.Buffer(v[..., :n_components, :].clone())
 
     def forward(self, data: torch.Tensor) -> tuple[torch.Tensor,]:
         """Apply the compression to the data.

--- a/src/mrpro/operators/PCACompressionOp.py
+++ b/src/mrpro/operators/PCACompressionOp.py
@@ -38,7 +38,7 @@ class PCACompressionOp(LinearOperator):
         _, _, v = torch.svd(correlation)
         # add joint_dim along which the the compression is the same
         v = repeat(v, '... comp1 comp2 -> ... joint_dim comp1 comp2', joint_dim=1)
-        self._compression_matrix = torch.nn.Buffer(v[..., :n_components, :].clone())
+        self._compression_matrix = v[..., :n_components, :].clone()
 
     def forward(self, data: torch.Tensor) -> tuple[torch.Tensor,]:
         """Apply the compression to the data.

--- a/src/mrpro/operators/SensitivityOp.py
+++ b/src/mrpro/operators/SensitivityOp.py
@@ -25,7 +25,7 @@ class SensitivityOp(LinearOperator):
         if isinstance(csm, CsmData):
             # only tensors can be used as buffers
             csm = csm.data
-        self.csm_tensor = torch.nn.Buffer(csm)
+        self.csm_tensor = csm
 
     def forward(self, img: torch.Tensor) -> tuple[torch.Tensor,]:
         """Apply the forward operator, thus expand the coils dimension.

--- a/src/mrpro/operators/SensitivityOp.py
+++ b/src/mrpro/operators/SensitivityOp.py
@@ -25,7 +25,7 @@ class SensitivityOp(LinearOperator):
         if isinstance(csm, CsmData):
             # only tensors can be used as buffers
             csm = csm.data
-        self.register_buffer('csm_tensor', csm)
+        self.csm_tensor = torch.nn.Buffer(csm)
 
     def forward(self, img: torch.Tensor) -> tuple[torch.Tensor,]:
         """Apply the forward operator, thus expand the coils dimension.

--- a/src/mrpro/operators/SliceProjectionOp.py
+++ b/src/mrpro/operators/SliceProjectionOp.py
@@ -172,8 +172,8 @@ class SliceProjectionOp(LinearOperator):
         rotation_quats = torch.broadcast_to(slice_rotation.as_quat(), (*batch_shapes, 4)).reshape(-1, 4)
         slice_rotation = Rotation(rotation_quats, normalize=False, copy=False)
         slice_shift_tensor = torch.broadcast_to(slice_shift_tensor, batch_shapes).flatten()
-        slice_profile_array = np.broadcast_to(slice_profile_array, batch_shapes).ravel()
         widths = np.broadcast_to(np.vectorize(_find_width)(slice_profile_array), batch_shapes).ravel()
+        slice_profile_array = np.broadcast_to(slice_profile_array, batch_shapes).ravel()
         matrices = [
             SliceProjectionOp.projection_matrix(
                 input_shape,

--- a/src/mrpro/operators/SliceProjectionOp.py
+++ b/src/mrpro/operators/SliceProjectionOp.py
@@ -194,14 +194,14 @@ class SliceProjectionOp(LinearOperator):
             # beta status in pytorch causes a warning to be printed
             warnings.filterwarnings('ignore', category=UserWarning, message='Sparse')
             if optimize_for == 'forward':
-                self.register_buffer('matrix', matrix.to_sparse_csr())
+                self.matrix = torch.nn.Buffer(matrix.to_sparse_csr())
                 self.matrix_adjoint = None
             elif optimize_for == 'adjoint':
-                self.register_buffer('matrix_adjoint', matrix.H.to_sparse_csr())
+                self.matrix_adjoint = torch.nn.Buffer(matrix.H.to_sparse_csr())
                 self.matrix = None
             elif optimize_for == 'both':
-                self.register_buffer('matrix_adjoint', matrix.H.to_sparse_csr())
-                self.register_buffer('matrix', matrix.to_sparse_csr())
+                self.matrix_adjoint = torch.nn.Buffer(matrix.H.to_sparse_csr())
+                self.matrix = torch.nn.Buffer(matrix.to_sparse_csr())
 
             else:
                 raise ValueError("optimize_for must be one of 'forward', 'adjoint', 'both'")

--- a/src/mrpro/utils/TensorAttributeMixin.py
+++ b/src/mrpro/utils/TensorAttributeMixin.py
@@ -1,3 +1,5 @@
+"""Mixin for smarter tensor attributes."""
+
 from typing import Any
 
 import torch

--- a/src/mrpro/utils/TensorAttributeMixin.py
+++ b/src/mrpro/utils/TensorAttributeMixin.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+import torch
+
+
+class TensorAttributeMixin(torch.nn.Module):
+    """Create tensor attributes as buffer."""
+
+    def __setattr__(self, name: str, value: Any) -> None:  # noqa: ANN401
+        """Set attribute.
+
+        Set tensors not requiring gradients as buffer.
+
+        Parameters
+        ----------
+        name
+            name of the attribute.
+        value
+            attribute to set.
+        """
+        if (
+            isinstance(value, torch.Tensor)
+            and not isinstance(value, torch.nn.Parameter | torch.nn.Buffer)
+            and not value.requires_grad
+        ):
+            self.register_buffer(name, value)
+        else:
+            super().__setattr__(name, value)

--- a/src/mrpro/utils/TensorAttributeMixin.py
+++ b/src/mrpro/utils/TensorAttributeMixin.py
@@ -20,11 +20,7 @@ class TensorAttributeMixin(torch.nn.Module):
         value
             attribute to set.
         """
-        if (
-            isinstance(value, torch.Tensor)
-            and not isinstance(value, torch.nn.Parameter | torch.nn.Buffer)
-            and not value.requires_grad
-        ):
+        if isinstance(value, torch.Tensor) and not isinstance(value, torch.nn.Parameter) and not value.requires_grad:
             self.register_buffer(name, value)
         else:
             super().__setattr__(name, value)

--- a/src/mrpro/utils/__init__.py
+++ b/src/mrpro/utils/__init__.py
@@ -9,8 +9,9 @@ from mrpro.utils.remove_repeat import remove_repeat
 from mrpro.utils.zero_pad_or_crop import zero_pad_or_crop
 from mrpro.utils.split_idx import split_idx
 from mrpro.utils.reshape import broadcast_right, unsqueeze_left, unsqueeze_right, reduce_view, reshape_broadcasted
-
+from mrpro.utils.TensorAttributeMixin import TensorAttributeMixin
 __all__ = [
+    "TensorAttributeMixin",
     "broadcast_right",
     "fill_range_",
     "reduce_view",

--- a/src/mrpro/utils/slice_profiles.py
+++ b/src/mrpro/utils/slice_profiles.py
@@ -6,20 +6,21 @@ from math import log
 
 import numpy as np
 import torch
-from torch import Tensor
+
+from mrpro.utils.TensorAttributeMixin import TensorAttributeMixin
 
 __all__ = ['SliceGaussian', 'SliceInterpolate', 'SliceProfileBase', 'SliceSmoothedRectangular']
 
 
-class SliceProfileBase(abc.ABC, torch.nn.Module):
+class SliceProfileBase(abc.ABC, TensorAttributeMixin, torch.nn.Module):
     """Base class for slice profiles."""
 
     @abc.abstractmethod
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Evaluate the slice profile at a position."""
         raise NotImplementedError
 
-    def random_sample(self, size: Sequence[int]) -> Tensor:
+    def random_sample(self, size: Sequence[int]) -> torch.Tensor:
         """Sample `n` random positions from the profile.
 
         Use the profile as a probability density function to sample positions.
@@ -41,7 +42,7 @@ class SliceGaussian(SliceProfileBase):
 
     fwhm: torch.Tensor
 
-    def __init__(self, fwhm: float | Tensor):
+    def __init__(self, fwhm: float | torch.Tensor):
         """Initialize the Gaussian slice profile.
 
         Parameters
@@ -50,9 +51,9 @@ class SliceGaussian(SliceProfileBase):
             Full width at half maximum of the Gaussian
         """
         super().__init__()
-        self.fwhm = torch.nn.Buffer(torch.as_tensor(fwhm))
+        self.fwhm = torch.as_tensor(fwhm)
 
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Evaluate the Gaussian slice profile at a position.
 
         Parameters
@@ -74,7 +75,7 @@ class SliceSmoothedRectangular(SliceProfileBase):
     with a Gaussian.
     """
 
-    def __init__(self, fwhm_rect: float | Tensor, fwhm_gauss: float | Tensor):
+    def __init__(self, fwhm_rect: float | torch.Tensor, fwhm_gauss: float | torch.Tensor):
         """Initialize the Rectangular slice profile.
 
         Parameters
@@ -93,7 +94,7 @@ class SliceSmoothedRectangular(SliceProfileBase):
         self.fwhm_rect = torch.nn.Buffer(torch.as_tensor(fwhm_rect))
         self.fwhm_gauss = torch.nn.Buffer(torch.as_tensor(fwhm_gauss))
 
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Evaluate the Gaussian slice profile at a position.
 
         Parameters
@@ -121,7 +122,7 @@ class SliceSmoothedRectangular(SliceProfileBase):
 class SliceInterpolate(SliceProfileBase):
     """slice profile based on interpolation of measured profile."""
 
-    def __init__(self, positions: Tensor, values: Tensor):
+    def __init__(self, positions: torch.Tensor, values: torch.Tensor):
         """Initialize the interpolated slice profile.
 
         Parameters
@@ -135,7 +136,7 @@ class SliceInterpolate(SliceProfileBase):
         self._xs = positions.detach().cpu().float().numpy()
         self._weights = values.detach().cpu().float().numpy()
 
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Evaluate the interpolated slice profile at a position.
 
         Parameters

--- a/src/mrpro/utils/slice_profiles.py
+++ b/src/mrpro/utils/slice_profiles.py
@@ -39,6 +39,8 @@ class SliceProfileBase(abc.ABC, torch.nn.Module):
 class SliceGaussian(SliceProfileBase):
     """Gaussian slice profile."""
 
+    fwhm: torch.Tensor
+
     def __init__(self, fwhm: float | Tensor):
         """Initialize the Gaussian slice profile.
 
@@ -48,7 +50,7 @@ class SliceGaussian(SliceProfileBase):
             Full width at half maximum of the Gaussian
         """
         super().__init__()
-        self.register_buffer('fwhm', torch.as_tensor(fwhm))
+        self.fwhm = torch.nn.Buffer(torch.as_tensor(fwhm))
 
     def forward(self, x: Tensor) -> Tensor:
         """Evaluate the Gaussian slice profile at a position.
@@ -88,8 +90,8 @@ class SliceSmoothedRectangular(SliceProfileBase):
             Value of the profile / intensity at the given position
         """
         super().__init__()
-        self.register_buffer('fwhm_rect', torch.as_tensor(fwhm_rect))
-        self.register_buffer('fwhm_gauss', torch.as_tensor(fwhm_gauss))
+        self.fwhm_rect = torch.nn.Buffer(torch.as_tensor(fwhm_rect))
+        self.fwhm_gauss = torch.nn.Buffer(torch.as_tensor(fwhm_gauss))
 
     def forward(self, x: Tensor) -> Tensor:
         """Evaluate the Gaussian slice profile at a position.

--- a/tests/data/test_movedatamixin.py
+++ b/tests/data/test_movedatamixin.py
@@ -35,7 +35,7 @@ class B(MoveDataMixin):
     """Test class B."""
 
     child: A = field(default_factory=A)
-    module: torch.nn.Module = field(default_factory=SharedModule)
+    module: SharedModule = field(default_factory=SharedModule)
     floattensor: torch.Tensor = field(default_factory=lambda: torch.tensor(1.0))
     complextensor: torch.Tensor = field(default_factory=lambda: torch.tensor(1.0, dtype=torch.complex64))
     inttensor: torch.Tensor = field(default_factory=lambda: torch.tensor(1, dtype=torch.int32))

--- a/tests/operators/functionals/conftest.py
+++ b/tests/operators/functionals/conftest.py
@@ -5,7 +5,7 @@ from typing import Literal
 
 import pytest
 import torch
-from mrpro.operators import ProximableFunctional, functionals
+from mrpro.operators import functionals
 from mrpro.operators.Functional import ElementaryFunctional, ElementaryProximableFunctional
 
 from tests import RandomGenerator
@@ -19,7 +19,7 @@ class FunctionalTestCase:
 
     """
 
-    functional: ProximableFunctional
+    functional: ElementaryProximableFunctional
     x_dtype: torch.dtype
     x_shape: torch.Size
     rng: RandomGenerator

--- a/tests/operators/functionals/test_functional_arithmetic.py
+++ b/tests/operators/functionals/test_functional_arithmetic.py
@@ -3,8 +3,7 @@ from typing import Literal, cast
 import pytest
 import torch
 from mrpro.operators import ElementaryFunctional, ElementaryProximableFunctional, ProximableFunctional
-from mrpro.operators.Functional import ScaledProximableFunctional
-from typing_extensions import assert_type
+from mrpro.operators.Functional import ScaledFunctional, ScaledProximableFunctional
 
 from tests import RandomGenerator
 from tests.operators.functionals.conftest import (
@@ -15,10 +14,10 @@ from tests.operators.functionals.conftest import (
 )
 
 
-@pytest.mark.parametrize('functional', PROXIMABLE_FUNCTIONALS)
+@pytest.mark.parametrize('functional', FUNCTIONALS)
 @pytest.mark.parametrize('scale_type', ['negative', 'positive', 'tensor', 'int'])
 def test_functional_scaling_forward(
-    functional: type[ElementaryProximableFunctional], scale_type: Literal['negative', 'positive', 'tensor', 'int']
+    functional: type[ElementaryFunctional], scale_type: Literal['negative', 'positive', 'tensor', 'int']
 ):
     """Test if forward method is scaled."""
     rng = RandomGenerator(1)
@@ -34,8 +33,7 @@ def test_functional_scaling_forward(
         case 'int':
             scale = 5
     scaled_f = scale * f
-    assert isinstance(scaled_f, ScaledProximableFunctional)
-    assert_type(scaled_f, ScaledProximableFunctional)
+    assert isinstance(scaled_f, ScaledFunctional | ScaledProximableFunctional)
     torch.testing.assert_close(scaled_f(x)[0], scale * f(x)[0])
 
 

--- a/tests/operators/functionals/test_functional_arithmetic.py
+++ b/tests/operators/functionals/test_functional_arithmetic.py
@@ -1,8 +1,9 @@
-from typing import Literal, cast
+from typing import Literal, assert_type, cast
 
 import pytest
 import torch
-from mrpro.operators import ElementaryFunctional, ElementaryProximableFunctional, ProximableFunctional, ScaledFunctional
+from mrpro.operators import ElementaryFunctional, ElementaryProximableFunctional, ProximableFunctional
+from mrpro.operators.Functional import ScaledProximableFunctional
 
 from tests import RandomGenerator
 from tests.operators.functionals.conftest import (
@@ -13,10 +14,10 @@ from tests.operators.functionals.conftest import (
 )
 
 
-@pytest.mark.parametrize('functional', FUNCTIONALS)
+@pytest.mark.parametrize('functional', PROXIMABLE_FUNCTIONALS)
 @pytest.mark.parametrize('scale_type', ['negative', 'positive', 'tensor', 'int'])
 def test_functional_scaling_forward(
-    functional: type[ElementaryFunctional], scale_type: Literal['negative', 'positive', 'tensor', 'int']
+    functional: type[ElementaryProximableFunctional], scale_type: Literal['negative', 'positive', 'tensor', 'int']
 ):
     """Test if forward method is scaled."""
     rng = RandomGenerator(1)
@@ -31,10 +32,9 @@ def test_functional_scaling_forward(
             scale = rng.float32_tensor()
         case 'int':
             scale = 5
-    scaled_f = cast(ProximableFunctional, scale * f)
-    assert isinstance(scaled_f, ScaledFunctional)
-    if isinstance(f, ProximableFunctional):
-        assert isinstance(scaled_f, ProximableFunctional)
+    scaled_f = scale * f
+    assert isinstance(scaled_f, ScaledProximableFunctional)
+    assert_type(scaled_f, ScaledProximableFunctional)
     torch.testing.assert_close(scaled_f(x)[0], scale * f(x)[0])
 
 

--- a/tests/operators/functionals/test_functional_arithmetic.py
+++ b/tests/operators/functionals/test_functional_arithmetic.py
@@ -1,9 +1,10 @@
-from typing import Literal, assert_type, cast
+from typing import Literal, cast
 
 import pytest
 import torch
 from mrpro.operators import ElementaryFunctional, ElementaryProximableFunctional, ProximableFunctional
 from mrpro.operators.Functional import ScaledProximableFunctional
+from typing_extensions import assert_type
 
 from tests import RandomGenerator
 from tests.operators.functionals.conftest import (

--- a/tests/operators/functionals/test_functionals.py
+++ b/tests/operators/functionals/test_functionals.py
@@ -96,7 +96,7 @@ def test_functional_prox_optimality(case: FunctionalTestCase):
 
     (prox,) = functional.prox(x, sigma=case.sigma)
 
-    def prox_criterion(p):
+    def prox_criterion(p: torch.Tensor) -> torch.Tensor:
         diff = x - p
         l2 = torch.sum((diff * diff.conj()).real, dim=functional.dim, keepdim=functional.keepdim)
         return (case.sigma * functional(p)[0] + 1 / 2 * l2).sum()

--- a/tests/operators/functionals/test_separablesum.py
+++ b/tests/operators/functionals/test_separablesum.py
@@ -10,7 +10,7 @@ class Dummy(ProximableFunctional):
 
     def __init__(self, prox_scale: float = 1.0):
         super().__init__()
-        self.dummy = torch.nn.Buffer(torch.tensor(1.0))
+        self.dummy = torch.tensor(1.0)
         self.prox_scale = prox_scale
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor]:

--- a/tests/operators/functionals/test_separablesum.py
+++ b/tests/operators/functionals/test_separablesum.py
@@ -10,7 +10,7 @@ class Dummy(ProximableFunctional):
 
     def __init__(self, prox_scale: float = 1.0):
         super().__init__()
-        self.register_buffer('dummy', torch.tensor(1.0))
+        self.dummy = torch.nn.Buffer(torch.tensor(1.0))
         self.prox_scale = prox_scale
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor]:

--- a/tests/operators/test_operators.py
+++ b/tests/operators/test_operators.py
@@ -320,7 +320,7 @@ def test_adjoint_tensor_sum():
 def test_sum_operator_multiple():
     a = DummyOperator(torch.tensor(2.0))
     op_sum = a + (a + a) + (a + a) + a
-    assert len(op_sum._operators) == 6
+    assert len(op_sum._operators) == 6  # type: ignore[arg-type]
     x = RandomGenerator(0).complex64_tensor(10)
     (actual,) = op_sum(x)
     expected = 6 * a(x)[0]
@@ -331,7 +331,7 @@ def test_sum_operator_multiple_adjoint():
     rng = RandomGenerator(7)
     a = DummyLinearOperator(rng.complex64_tensor((3, 10)))
     linear_op_sum = a + (a + a) + (a + a) + a
-    assert len(linear_op_sum._operators) == 6
+    assert len(linear_op_sum._operators) == 6  # type: ignore[arg-type]
     u = rng.complex64_tensor(10)
     v = rng.complex64_tensor(3)
     dotproduct_adjointness_test(linear_op_sum, u, v)
@@ -368,7 +368,7 @@ def test_gram_shortcuts():
     b = DummyLinearOperator(rng.complex64_tensor((10, 10)))
     a_gram_only = GramOnlyOperator(a)
     # ignore required due to https://github.com/pytorch/pytorch/issues/124015
-    op: LinearOperator = torch.tensor(1) * ((3 + 4j) * a_gram_only @ b) * (1 + 2j)  # type: ignore[assignment]
+    op: LinearOperator = torch.tensor(1) * ((3 + 4j) * a_gram_only @ b) * (1 + 2j)
     gram = op.gram
 
     u = rng.complex64_tensor(10)


### PR DESCRIPTION
new pytorch version gets/got released today.
Some type hints change. This fixes our code to still type check.

Unbreaks github precommit action.

The tensor attribute mixin might need more functionality soon. 
For now, this is the minimal changes to fix typing issues.

Also solves some lsp problems and simplifies some typing stuff at the cost of duplicating some forward functions between operator and linearoperator