### PR TITLE
Use raw.githubusercontent links for logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <h1 align="center">
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="docs/source/_static/logo_white.svg">
-  <source media="(prefers-color-scheme: light)" srcset="docs/source/_static/logo.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/PTB-MR/mrpro/refs/heads/main/docs/source/_static/logo_white.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/PTB-MR/mrpro/refs/heads/main/docs/source/_static/logo.svg">
   <img src="docs/source/_static/logo.svg" alt="MRpro logo" width="50%">
 </picture>
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/PTB-MR/mrpro/refs/heads/main/docs/source/_static/logo_white.svg">
   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/PTB-MR/mrpro/refs/heads/main/docs/source/_static/logo.svg">
-  <img src="docs/source/_static/logo.svg" alt="MRpro logo" width="50%">
+  <img src="https://raw.githubusercontent.com/PTB-MR/mrpro/refs/heads/main/docs/source/_static/logo.svg" alt="MRpro logo" width="50%">
 </picture>
 
 </h1><br>


### PR DESCRIPTION
With the currents relative links the PyPI README fails to display the logotypes:

![image](https://github.com/user-attachments/assets/9131f89c-f273-4c76-839c-0b77964cc1fb)
