### PR TITLE
Make numpy 2.0 compatible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,9 +114,6 @@ filterwarnings = [
     "ignore:'write_like_original':DeprecationWarning:pydicom:",
     "ignore:Anomaly Detection has been enabled:UserWarning",                   # torch.autograd
     "ignore:allow_ops_in_compiled_graph failed to import torch:ImportWarning", # einops and dynamo<2.5
-    "ignore:__array__ implementation doesn't:DeprecationWarning",              # https://github.com/pytorch/pytorch/issues/136264
-    "ignore:__array_wrap__ must accept:DeprecationWarning",                    # https://github.com/pytorch/pytorch/issues/136264
-
 ]
 addopts = "-n auto"
 markers = ["cuda : Tests only to be run when cuda device is available"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
-    "numpy>=1.23, <2.0",
+    "numpy>=1.23, <3.0",
     "torch>=2.3",
     "ismrmrd>=1.14.1",
     "einops",
@@ -112,8 +112,11 @@ testpaths = ["tests"]
 filterwarnings = [
     "error",
     "ignore:'write_like_original':DeprecationWarning:pydicom:",
-    "ignore:Anomaly Detection has been enabled:UserWarning",    #torch.autograd
+    "ignore:Anomaly Detection has been enabled:UserWarning",                   # torch.autograd
     "ignore:allow_ops_in_compiled_graph failed to import torch:ImportWarning", # einops and dynamo<2.5
+    "ignore:__array__ implementation doesn't:DeprecationWarning",              # https://github.com/pytorch/pytorch/issues/136264
+    "ignore:__array_wrap__ must accept:DeprecationWarning",                    # https://github.com/pytorch/pytorch/issues/136264
+
 ]
 addopts = "-n auto"
 markers = ["cuda : Tests only to be run when cuda device is available"]

--- a/src/mrpro/algorithms/dcf/dcf_voronoi.py
+++ b/src/mrpro/algorithms/dcf/dcf_voronoi.py
@@ -108,7 +108,10 @@ def dcf_2d3d_voronoi(traj: torch.Tensor) -> torch.Tensor:
 
     if dim == 2:
         # Shoelace equation for 2d
-        dcf = np.array([np.abs(np.cross(v[:-1], v[1:]).sum(0) + np.cross(v[-1], v[0])) / 2 for v in vertices])
+        def cross2d(x: np.ndarray, y: np.ndarray) -> np.ndarray:
+            return x[..., 0] * y[..., 1] - x[..., 1] * y[..., 0]
+
+        dcf = np.array([np.abs(cross2d(v[:-1], v[1:]).sum(0) + cross2d(v[-1], v[0])) / 2 for v in vertices])
 
     else:
         # Calculate volume/area of voronoi cells using processes, as this is a very time-consuming operation

--- a/src/mrpro/data/KTrajectory.py
+++ b/src/mrpro/data/KTrajectory.py
@@ -185,8 +185,8 @@ class KTrajectory(MoveDataMixin):
 
         # kz should only have flags that are enabled in all columns
         # k2 only flags enabled in all rows, etc
-        type_zyx = [TrajType(i.item()) for i in np.bitwise_and.reduce(traj_type_matrix, axis=1)]
-        type_210 = [TrajType(i.item()) for i in np.bitwise_and.reduce(traj_type_matrix, axis=0)]
+        type_zyx = [TrajType(int(i)) for i in np.bitwise_and.reduce(traj_type_matrix.numpy(), axis=1)]
+        type_210 = [TrajType(int(i)) for i in np.bitwise_and.reduce(traj_type_matrix.numpy(), axis=0)]
 
         # make mypy recognize return  will always have len=3
         return (type_zyx[0], type_zyx[1], type_zyx[2]), (type_210[0], type_210[1], type_210[2])

--- a/src/mrpro/operators/SliceProjectionOp.py
+++ b/src/mrpro/operators/SliceProjectionOp.py
@@ -13,6 +13,7 @@ from torch import Tensor
 from mrpro.data.Rotation import Rotation
 from mrpro.data.SpatialDimension import SpatialDimension
 from mrpro.operators.LinearOperator import LinearOperator
+from mrpro.utils import ravel_multi_index
 from mrpro.utils.slice_profiles import SliceSmoothedRectangular
 from mrpro.utils.typing import NestedSequence
 
@@ -430,9 +431,8 @@ class SliceProjectionOp(LinearOperator):
         # We need this at the edge of the volume to approximate zero padding
         fraction_in_view = (mask * (weight > 0)).sum(-1) / (weight > 0).sum(-1)
 
-        source_index = torch.tensor(
-            np.ravel_multi_index(source[mask].unbind(-1), (input_shape.z, input_shape.y, input_shape.x))
-        )
+        source_index = ravel_multi_index(source[mask].unbind(-1), (input_shape.z, input_shape.y, input_shape.x))
+
         target_index = torch.repeat_interleave(torch.arange(y * x), mask.sum(-1))
 
         with warnings.catch_warnings():

--- a/src/mrpro/operators/SliceProjectionOp.py
+++ b/src/mrpro/operators/SliceProjectionOp.py
@@ -152,8 +152,8 @@ class SliceProjectionOp(LinearOperator):
             test_values = torch.arange(-max_shape, max_shape, max_shape)
             profile = slice_profile(test_values)
             cdf = torch.cumsum(profile, -1) / profile.sum()
-            left = test_values[np.argmax(cdf > 0.01)]
-            right = test_values[np.argmax(cdf > 0.99)]
+            left = test_values[(cdf > 0.01).int().argmax()]
+            right = test_values[(cdf > 0.99).int().argmax()]
             return int(max(left.abs().item(), right.abs().item())) + 1
 
         def _at_least_width_1(slice_profile: TensorFunction):

--- a/src/mrpro/utils/__init__.py
+++ b/src/mrpro/utils/__init__.py
@@ -8,12 +8,13 @@ from mrpro.utils.smap import smap
 from mrpro.utils.remove_repeat import remove_repeat
 from mrpro.utils.zero_pad_or_crop import zero_pad_or_crop
 from mrpro.utils.split_idx import split_idx
-from mrpro.utils.reshape import broadcast_right, unsqueeze_left, unsqueeze_right, reduce_view, reshape_broadcasted
+from mrpro.utils.reshape import broadcast_right, unsqueeze_left, unsqueeze_right, reduce_view, reshape_broadcasted, ravel_multi_index
 from mrpro.utils.TensorAttributeMixin import TensorAttributeMixin
 __all__ = [
     "TensorAttributeMixin",
     "broadcast_right",
     "fill_range_",
+    "ravel_multi_index",
     "reduce_view",
     "remove_repeat",
     "reshape_broadcasted",

--- a/src/mrpro/utils/reshape.py
+++ b/src/mrpro/utils/reshape.py
@@ -216,7 +216,7 @@ def ravel_multi_index(multi_index: Sequence[torch.Tensor], dims: Sequence[int]) 
     Returns
     -------
     index
-        A tensor of shape (n,) with the flattened indices.
+        flattened index
     """
     flat_index = multi_index[0]
     for idx, dim in zip(multi_index[1:], dims[1:], strict=True):

--- a/src/mrpro/utils/reshape.py
+++ b/src/mrpro/utils/reshape.py
@@ -200,3 +200,25 @@ def reshape_broadcasted(tensor: torch.Tensor, *shape: int) -> torch.Tensor:
         # finally, we can expand the broadcasted dimensions to the requested shape
         semicontiguous = semicontiguous.expand(tensor.shape)
         return semicontiguous.view(shape)
+
+
+def ravel_multi_index(multi_index: Sequence[torch.Tensor], dims: Sequence[int]) -> torch.Tensor:
+    """
+    Convert a multi-dimensional index into a flat index.
+
+    Parameters
+    ----------
+    multi_index
+        Sequence of integer index tensors.
+    dims
+        The shape of the tensor being indexed.
+
+    Returns
+    -------
+    index
+        A tensor of shape (n,) with the flattened indices.
+    """
+    flat_index = multi_index[0]
+    for idx, dim in zip(multi_index[1:], dims[1:], strict=True):
+        flat_index = flat_index * dim + idx
+    return flat_index

--- a/src/mrpro/utils/reshape.py
+++ b/src/mrpro/utils/reshape.py
@@ -216,7 +216,7 @@ def ravel_multi_index(multi_index: Sequence[torch.Tensor], dims: Sequence[int]) 
     Returns
     -------
     index
-        flattened index
+        Flattened index.
     """
     flat_index = multi_index[0]
     for idx, dim in zip(multi_index[1:], dims[1:], strict=True):

--- a/tests/_RandomGenerator.py
+++ b/tests/_RandomGenerator.py
@@ -250,6 +250,10 @@ class RandomGenerator:
             tensor = self._randint(shape, low, high, dtype)
         return tensor
 
+    def randn_tensor(self, shape: Sequence[int], dtype: torch.dtype) -> torch.Tensor:
+        """Generate random normal distributed tensor of given shape and dtype."""
+        return torch.randn(size=shape, generator=self.generator, dtype=dtype)
+
     def randperm(self, n, *, dtype=torch.int64) -> torch.Tensor:
         """Generate random permutation of integers from 0 to n-1."""
         return torch.randperm(n, generator=self.generator, dtype=dtype)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,7 @@ def random_acquisition(request):
     trajectory = generate_random_trajectory(generator, (n_samples, 2))
     header = generate_random_acquisition_properties(generator)
     header['flags'] &= ~AcqFlags.ACQ_IS_NOISE_MEASUREMENT.value
-    return ismrmrd.Acquisition.from_array(kdata, trajectory, **header)
+    return ismrmrd.Acquisition.from_array(kdata.numpy(), trajectory.numpy(), **header)
 
 
 @pytest.fixture(params=({'seed': 1, 'n_coils': 32, 'n_samples': 256},))
@@ -96,7 +96,7 @@ def random_noise_acquisition(request):
     trajectory = generate_random_trajectory(generator, (n_samples, 2))
     header = generate_random_acquisition_properties(generator)
     header['flags'] |= AcqFlags.ACQ_IS_NOISE_MEASUREMENT.value
-    return ismrmrd.Acquisition.from_array(kdata, trajectory, **header)
+    return ismrmrd.Acquisition.from_array(kdata.numpy(), trajectory.numpy(), **header)
 
 
 @pytest.fixture(params=({'seed': 0},))

--- a/tests/utils/test_reshape.py
+++ b/tests/utils/test_reshape.py
@@ -1,8 +1,16 @@
 """Tests for reshaping utilities."""
 
+import numpy as np
 import pytest
 import torch
-from mrpro.utils import broadcast_right, reduce_view, reshape_broadcasted, unsqueeze_left, unsqueeze_right
+from mrpro.utils import (
+    broadcast_right,
+    ravel_multi_index,
+    reduce_view,
+    reshape_broadcasted,
+    unsqueeze_left,
+    unsqueeze_right,
+)
 
 from tests import RandomGenerator
 
@@ -83,3 +91,17 @@ def test_reshape_broadcasted_fail():
         reshape_broadcasted(a, -1, -3)
     with pytest.raises(RuntimeError, match='only one dimension'):
         reshape_broadcasted(a, -1, -1)
+
+
+def test_ravel_multidex() -> None:
+    """Test ravel_multiindex"""
+    rng = RandomGenerator(1)
+    dims = [5, 1, 6]
+    indices = [
+        rng.int64_tensor((2, 3), low=0, high=dims[0]),
+        rng.int64_tensor((1, 1), low=0, high=dims[1]),
+        rng.int64_tensor((2, 1), low=0, high=dims[2]),
+    ]
+    expected = torch.as_tensor(np.ravel_multi_index([idx.numpy() for idx in indices], dims))
+    actual = ravel_multi_index(indices, dims)
+    assert torch.equal(expected, actual)


### PR DESCRIPTION
Two issues requiered fixing

- Pytorch 2.3-2.6 results in an deprecation warning about a change in the array interface https://github.com/pytorch/pytorch/issues/136264 . Thus calling ufuncs on torch tensors wll result in a warning. I replaced all uses.

- np.cross no longer works for 2D. I replaced it with a manual version.
