### PR TITLE
Fix PR github actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -105,16 +105,12 @@ jobs:
     container:
       image: ghcr.io/ptb-mr/mrpro_py311:latest
       options: --user runner
-    permissions:
-      pull-requests: write
-      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # fetch history for github links
           fetch-tags: true
-
 
       - name: Install mrpro and dependencies
         run: pip install --upgrade --upgrade-strategy "eager" -e .[docs]

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -53,9 +53,6 @@ jobs:
     name: Run Tests and Coverage Report
     needs: get_dockerfiles
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/report_docs.yml
+++ b/.github/workflows/report_docs.yml
@@ -11,6 +11,7 @@ jobs:
   docs_report:
     name: Docs report
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
     permissions:
       actions: read
       pull-requests: write
@@ -29,16 +30,37 @@ jobs:
         run: |
           echo "artifact-url=$(cat artifact_url)" >> $GITHUB_ENV
 
+      - name: Get PR number
+        id: pr-context
+        env:
+          # Token required for GH CLI:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Best practice for scripts is to reference via ENV at runtime. Avoid using the expression syntax in the script content directly:
+          PR_TARGET_REPO: ${{ github.repository }}
+          # If the PR is from a fork, prefix it with `<owner-login>:`, otherwise only the PR branch name is relevant:
+          PR_BRANCH: |-
+            ${{
+              (github.event.workflow_run.head_repository.owner.login != github.event.workflow_run.repository.owner.login)
+                && format('{0}:{1}', github.event.workflow_run.head_repository.owner.login, github.event.workflow_run.head_branch)
+                || github.event.workflow_run.head_branch
+            }}
+        # Query the PR number by repo + branch, then assign to step output:
+        run: |
+          gh pr view --repo "${PR_TARGET_REPO}" "${PR_BRANCH}" \
+              --json 'number' --jq '"number=\(.number)"' \
+              >> "${GITHUB_OUTPUT}"
+  
+
       # if the build of docs was successful the "artifact-url" will be non-empty
       - name: Update PR with link to summary
-        if: ${{ env.artifact-url != '' && github.event.workflow_run.event.event_name == 'pull_request' }}
+        if: ${{ env.artifact-url != '' }}
         uses: edumserrano/find-create-or-update-comment@v3
         with:
-          issue-number: ${{ github.event.workflow_run.event.pull_request.number }}
-          body-includes: '<!-- documentation build ${{ github.event.workflow_run.event.pull_request.number }} -->'
+          issue-number: ${{ steps.pr-context.outputs.number }}
+          body-includes: '<!-- documentation build ${{ gsteps.pr-context.outputs.number }} -->'
           comment-author: 'github-actions[bot]'
           body: |
-            <!-- documentation build ${{ github.event.workflow_run.event.number }} -->
+            <!-- documentation build ${{ steps.pr-context.outputs.number }} -->
             ### :books: Documentation
             :file_folder: [Download as zip](${{ env.artifact-url }})
             :mag: [View online](https://zimf.de/zipserve/${{ env.artifact-url }}/)
@@ -46,14 +68,14 @@ jobs:
 
       # if the build of docs failed the "artifact-url" will be an empty string
       - name: Report failure of docs build
-        if: ${{ env.artifact-url == '' && github.event.workflow_run.event.event_name == 'pull_request' }}
+        if: ${{ env.artifact-url == '' }}
         uses: edumserrano/find-create-or-update-comment@v3
         with:
-          issue-number: ${{ github.event.workflow_run.event.pull_request.number }}
-          body-includes: '<!-- documentation build ${{ github.event.workflow_run.event.pull_request.number }} -->'
+          issue-number: ${{ steps.pr-context.outputs.number }}
+          body-includes: '<!-- documentation build ${{ steps.pr-context.outputs.number }} -->'
           comment-author: 'github-actions[bot]'
           body: |
-            <!-- documentation build ${{ github.event.workflow_run.event.number }} -->
+            <!-- documentation build ${{ steps.pr-context.outputs.number }} -->
             ### :books: Documentation
             :x: Documentation build failed
 
@@ -63,8 +85,7 @@ jobs:
   deploy:
     name: Deploy docs
     runs-on: ubuntu-latest
-    needs: docs_report
-    if: ${{ github.event.workflow_run.event.event_name == 'push' && github.event.workflow_run.event.ref == 'refs/heads/main' }}
+    if: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' }}
     permissions:
         actions: read
         pages: write

--- a/.github/workflows/report_docs.yml
+++ b/.github/workflows/report_docs.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           run-id: ${{ github.event.workflow_run.id }}
+          # needs to be explicitly set
           github-token: ${{ secrets.GITHUB_TOKEN }}
           name: artifact_url
 

--- a/.github/workflows/report_pytest.yml
+++ b/.github/workflows/report_pytest.yml
@@ -8,8 +8,9 @@ on:
       - completed
 
 jobs:
-  coverage_report:
+  coverage_report_pr:
     name: Coverage report
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -23,11 +24,31 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get PR number
+        id: pr-context
+        env:
+          # Token required for GH CLI:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Best practice for scripts is to reference via ENV at runtime. Avoid using the expression syntax in the script content directly:
+          PR_TARGET_REPO: ${{ github.repository }}
+          # If the PR is from a fork, prefix it with `<owner-login>:`, otherwise only the PR branch name is relevant:
+          PR_BRANCH: |-
+            ${{
+              (github.event.workflow_run.head_repository.owner.login != github.event.workflow_run.repository.owner.login)
+                && format('{0}:{1}', github.event.workflow_run.head_repository.owner.login, github.event.workflow_run.head_branch)
+                || github.event.workflow_run.head_branch
+            }}
+        # Query the PR number by repo + branch, then assign to step output:
+        run: |
+          gh pr view --repo "${PR_TARGET_REPO}" "${PR_BRANCH}" \
+              --json 'number' --jq '"number=\(.number)"' \
+              >> "${GITHUB_OUTPUT}"
+
       - name: Post PyTest Coverage Comment
         id: coverage_comment
         uses: MishaKav/pytest-coverage-comment@v1.1.53
         with:
-          issue-number: ${{ github.event.workflow_run.event.pull_request.number }}
+          issue-number: ${{ steps.pr-context.outputs.number }}
           pytest-coverage-path: pytest-coverage.txt
           junitxml-path: pytest.xml
 
@@ -37,7 +58,7 @@ jobs:
         if: steps.coverage_comment.outputs.coverageHtml == ''
         uses: edumserrano/find-create-or-update-comment@v3
         with:
-          issue-number: ${{ github.event.workflow_run.event.pull_request.number }}
+          issue-number: ${{ steps.pr-context.outputs.number }}
           # see https://github.com/MishaKav/pytest-coverage-comment/blob/81882822c5b22af01f91bd3eacb1cefb6ad73dc2/src/index.js#L97
           # for the generation of the unique id for comment
           # in this particular case, there is no additional watermarkUniqueId
@@ -50,9 +71,27 @@ jobs:
             Check the PyTest Workflow
           edit-mode: replace
 
+  coverage_report_push_main:
+    name: Coverage report push main
+    if: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: pytest-report-mrpro_py312
+
+      - name: Post PyTest Coverage Comment on push main
+        id: coverage_comment
+        uses: MishaKav/pytest-coverage-comment@v1.1.53
+        with:
+          pytest-coverage-path: pytest-coverage.txt
+          junitxml-path: pytest.xml
+
       - name: Create Coverage Badge on Main Branch Push
         uses: schneegans/dynamic-badges-action@v1.7.0
-        if: ${{ github.event.workflow_run.event.event_name == 'push'  && github.event.workflow_run.event.ref == 'refs/heads/main' }}
         with:
           auth: ${{ secrets.GIST_SECRET }}
           gistID: 48e334a10caf60e6708d7c712e56d241

--- a/.github/workflows/report_pytest.yml
+++ b/.github/workflows/report_pytest.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           name: pytest-report-mrpro_py312
           run-id: ${{ github.event.workflow_run.id }}
+          # needs to be explicitly set
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get PR number


### PR DESCRIPTION
This PR fixes not working docs and pytest reporting of #585

The name of test result job was changed and since the `pytest-coverage-comment` uses the job's name as a hidden tag for the comment to update
` <!-- Pytest Coverage Comment: ${{ github.job }} -->`
for all existing PRs with pytest report a 2nd comment would be posted and updated.

I apologize for the first not enough tested PR.

This approach is tested on https://github.com/lunin-inc/amazing-repo with all cases: push on main branch, pull-request from local branch, pull-request from fork.