### PR TITLE
Change MOLLI parameter

### DIFF
--- a/src/mrpro/operators/models/MOLLI.py
+++ b/src/mrpro/operators/models/MOLLI.py
@@ -7,7 +7,7 @@ from mrpro.utils import unsqueeze_right
 
 
 class MOLLI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
-    """Signal model for Modified Look-Locker inversion recovery (MOLLI).
+    r"""Signal model for Modified Look-Locker inversion recovery (MOLLI).
 
     This model describes
     :math:`M_z(t) = a(1 - (1 + c) e^{-t / T_1^*})` with :math:`T_1^* = T_1 / c`.
@@ -55,5 +55,5 @@ class MOLLI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
             signal with shape `(time, *other, coils, z, y, x)`
         """
         ti = unsqueeze_right(self.ti, a.ndim - (self.ti.ndim - 1))  # -1 for time
-        signal = a * (1 - (1+ c) * torch.exp(ti / t1 * c))
+        signal = a * (1 - (1 + c) * torch.exp(-ti / t1 * c))
         return (signal,)

--- a/src/mrpro/operators/models/MOLLI.py
+++ b/src/mrpro/operators/models/MOLLI.py
@@ -10,10 +10,12 @@ class MOLLI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
     """Signal model for Modified Look-Locker inversion recovery (MOLLI).
 
     This model describes
-    :math:`M_z(t) = a(1 - c)e^{(-t / T1^*)}` with :math:`T1^* = T1 / (c - 1)`.
+    :math:`M_z(t) = a(1 - (1 + c) e^{-t / T_1^*})` with :math:`T_1^* = T_1 / c`.
 
     This is a small modification from the original MOLLI signal model [MESS2004]_:
-    :math:`M_z(t) = a - be^{(-t / T1^*)}` with :math:`T1^* = T1 / (b/a - 1)`.
+    :math:`M_z(t) = a - be^{(-t / T_1^*)}` with :math:`T_1^* = T1 / (b/a - 1)`.
+
+    For a meaningful result, :math:`c \in R_{>0}`, :math:`t \in R_{>0}`, and :math:`T_1 \in R_{>0}`
 
     .. [MESS2004] Messroghli DR, Radjenovic A, Kozerke S, Higgins DM, Sivananthan MU, Ridgway JP (2004) Modified
       look-locker inversion recovery (MOLLI) for high-resolution T 1 mapping of the heart. MRM, 52(1).
@@ -53,5 +55,5 @@ class MOLLI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor]):
             signal with shape `(time, *other, coils, z, y, x)`
         """
         ti = unsqueeze_right(self.ti, a.ndim - (self.ti.ndim - 1))  # -1 for time
-        signal = a * (1 - c * torch.exp(ti / t1 * (1 - c)))
+        signal = a * (1 - (1+ c) * torch.exp(ti / t1 * c))
         return (signal,)

--- a/tests/operators/models/test_molli.py
+++ b/tests/operators/models/test_molli.py
@@ -3,15 +3,15 @@
 import pytest
 import torch
 from mrpro.operators.models import MOLLI
-from tests import RandomGenerator, autodiff_test
+from tests import autodiff_test
 from tests.operators.models.conftest import SHAPE_VARIATIONS_SIGNAL_MODELS, create_parameter_tensor_tuples
 
 
 @pytest.mark.parametrize(
     ('ti', 'result'),
     [
-        (0, 'a(1-c)'),  # short ti
-        (20, 'a'),  # long ti
+        (0, 'ac'),  # short ti
+        (1e8, 'a'),  # long ti
     ],
 )
 def test_molli(ti, result):
@@ -20,18 +20,15 @@ def test_molli(ti, result):
     Checking that idata output tensor at ti=0 is close to a. Checking
     that idata output tensor at large ti is close to a(1-c).
     """
-    a, t1 = create_parameter_tensor_tuples()
-    # c>2 is necessary for t1_star to be >= 0 and to ensure t1_star < t1
-    random_generator = RandomGenerator(seed=0)
-    c = random_generator.float32_tensor(size=a.shape, low=2.0, high=4.0)
+    a, t1, c = create_parameter_tensor_tuples(number_of_tensors=3)
 
     # Generate signal model and torch tensor for comparison
     model = MOLLI(ti)
     (image,) = model(a, c, t1)
 
     # Assert closeness to a(1-c) for large ti
-    if result == 'a(1-c)':
-        torch.testing.assert_close(image[0, ...], a * (1 - c))
+    if result == '-ac':
+        torch.testing.assert_close(image[0, ...], -a * c)
     # Assert closeness to a for ti=0
     elif result == 'a':
         torch.testing.assert_close(image[0, ...], a)


### PR DESCRIPTION
Changes the MOLLI parameter c to` b/a-1`, making the constraints for all parameters `>0`.
Before, c had to be >1.
Also make "long ti" longer in the test -- before, a change to the random generator resulted could result in few points not matching the test case.