### PR TITLE
Disable typos autofix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
     rev: v1.29.4
     hooks:
       - id: typos
+        args: [] # empty, to remove write-changes from the default arguments.
 
   - repo: https://github.com/fzimmermann89/check_all
     rev: v1.1


### PR DESCRIPTION
Typos autofix can silently introduce errors if "spelling mistakes" are intentional.

At least I run pre-commit before committ, and would otherwise have to go back through all code to see what typos might have changed.
This now only reports the mistakes and one has to manually fix them (or manually run `typos -w`)