### PR TITLE
Set fixed version of torchkbnufft in notebooks

### DIFF
--- a/.precommit/add_notebook_preamble.py
+++ b/.precommit/add_notebook_preamble.py
@@ -16,8 +16,9 @@ import_python = """# %% tags=["remove-cell"]
 import importlib
 
 if not importlib.util.find_spec('mrpro'):
-    %pip install mrpro[notebook]
+    %pip install mrpro[notebook] 'torchkbnufft==1.4.0'
 """
+
 
 # the temp files of jupytext have the header which looks like:
 # ---

--- a/examples/notebooks/cartesian_reconstruction.ipynb
+++ b/examples/notebooks/cartesian_reconstruction.ipynb
@@ -24,7 +24,7 @@
     "import importlib\n",
     "\n",
     "if not importlib.util.find_spec('mrpro'):\n",
-    "    %pip install mrpro[notebook]"
+    "    %pip install mrpro[notebook] 'torchkbnufft==1.4.0'"
    ]
   },
   {

--- a/examples/notebooks/comparison_trajectory_calculators.ipynb
+++ b/examples/notebooks/comparison_trajectory_calculators.ipynb
@@ -24,7 +24,7 @@
     "import importlib\n",
     "\n",
     "if not importlib.util.find_spec('mrpro'):\n",
-    "    %pip install mrpro[notebook]"
+    "    %pip install mrpro[notebook] 'torchkbnufft==1.4.0'"
    ]
   },
   {

--- a/examples/notebooks/direct_reconstruction.ipynb
+++ b/examples/notebooks/direct_reconstruction.ipynb
@@ -24,7 +24,7 @@
     "import importlib\n",
     "\n",
     "if not importlib.util.find_spec('mrpro'):\n",
-    "    %pip install mrpro[notebook]"
+    "    %pip install mrpro[notebook] 'torchkbnufft==1.4.0'"
    ]
   },
   {

--- a/examples/notebooks/iterative_sense_reconstruction_radial2D.ipynb
+++ b/examples/notebooks/iterative_sense_reconstruction_radial2D.ipynb
@@ -24,7 +24,7 @@
     "import importlib\n",
     "\n",
     "if not importlib.util.find_spec('mrpro'):\n",
-    "    %pip install mrpro[notebook]"
+    "    %pip install mrpro[notebook] 'torchkbnufft==1.4.0'"
    ]
   },
   {

--- a/examples/notebooks/iterative_sense_reconstruction_with_regularization.ipynb
+++ b/examples/notebooks/iterative_sense_reconstruction_with_regularization.ipynb
@@ -24,7 +24,7 @@
     "import importlib\n",
     "\n",
     "if not importlib.util.find_spec('mrpro'):\n",
-    "    %pip install mrpro[notebook]"
+    "    %pip install mrpro[notebook] 'torchkbnufft==1.4.0'"
    ]
   },
   {

--- a/examples/notebooks/qmri_sg_challenge_2024_t1.ipynb
+++ b/examples/notebooks/qmri_sg_challenge_2024_t1.ipynb
@@ -24,7 +24,7 @@
     "import importlib\n",
     "\n",
     "if not importlib.util.find_spec('mrpro'):\n",
-    "    %pip install mrpro[notebook]"
+    "    %pip install mrpro[notebook] 'torchkbnufft==1.4.0'"
    ]
   },
   {

--- a/examples/notebooks/qmri_t1_mapping_with_grad_acq.ipynb
+++ b/examples/notebooks/qmri_t1_mapping_with_grad_acq.ipynb
@@ -24,7 +24,7 @@
     "import importlib\n",
     "\n",
     "if not importlib.util.find_spec('mrpro'):\n",
-    "    %pip install mrpro[notebook]"
+    "    %pip install mrpro[notebook] 'torchkbnufft==1.4.0'"
    ]
   },
   {

--- a/examples/notebooks/tv_minimization_reconstruction_pdhg.ipynb
+++ b/examples/notebooks/tv_minimization_reconstruction_pdhg.ipynb
@@ -24,7 +24,7 @@
     "import importlib\n",
     "\n",
     "if not importlib.util.find_spec('mrpro'):\n",
-    "    %pip install mrpro[notebook]"
+    "    %pip install mrpro[notebook] 'torchkbnufft==1.4.0'"
    ]
   },
   {


### PR DESCRIPTION
`torchkbnufft>1.4.0` requires `numpy>=2.0.0` which updates the pre-installed `numpy` in colab and causes troubles with `h5py`.
You can check this out that presented version of notebooks indeed does not work in colab (unless the environment is restarted) and fails while the h5py tries to parse the dataset from zenodo. 

By the way this PR was made from my own fork and both PyTest and Docs comment reports were posted🥳 