### PR TITLE
Pin sphinx version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ test = [
     "pytest-xdist",
 ]
 docs = [
-    "sphinx",
+    "sphinx>8, <8.2",
     "sphinx_rtd_theme",
     "sphinx-pyproject",
     "myst-nb",


### PR DESCRIPTION
https://github.com/sphinx-doc/sphinx/issues/13362
https://github.com/tox-dev/sphinx-autodoc-typehints/issues/523
Without this version pin, our sphinx build currently fails
```
      File "/github/home/.local/lib/python3.11/site-packages/sphinx/ext/autodoc/__init__.py", line 2980, in add_directive_header
        objrepr = stringify_annotation(
                  ^^^^^^^^^^^^^^^^^^^^^
    TypeError: _stringify_annotation() got an unexpected keyword argument 'short_literals'
```

Maybe due to autodoc type hints not being compatible with sphinx 8.2

See for example the brainweb PR