### PR TITLE
Fix formatting of functions as default arguments

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -298,7 +298,7 @@ def sync_notebooks(source_folder, dest_folder):
 
 object_description_original = sphinx.util.inspect.object_description
 def object_description_function_repr_overwrite(obj, *, _seen: frozenset[int] = frozenset()) -> str:
-    """Overwrite sphinx default function representation to use functioname instead of <functioname>.
+    """Overwrite sphinx default function representation to use functionname instead of <functionname>.
 
     <> would break interspinx and formatting of the function name."""
     if callable(obj):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -298,7 +298,7 @@ def sync_notebooks(source_folder, dest_folder):
 
 object_description_original = sphinx.util.inspect.object_description
 def object_description_function_repr_overwrite(obj, *, _seen: frozenset[int] = frozenset()) -> str:
-    """Overwrite sphinx default function representation to use functioname instad of <functioname>.
+    """Overwrite sphinx default function representation to use functioname instead of <functioname>.
 
     <> would break interspinx and formatting of the function name."""
     if callable(obj):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,16 +82,15 @@ test = [
     "pytest-xdist",
 ]
 docs = [
-    "sphinx>8, <8.2",
-    "sphinx_rtd_theme",
-    "sphinx-pyproject",
-    "myst-nb",
-    "sphinx-mathjax-offline",
-    "sphinx_github_style",
-    "sphinx-autodoc-typehints",
-    "sphinx-copybutton",
-    "sphinx-last-updated-by-git",
-
+    "sphinx>=8.1, <8.2",
+    "sphinx_rtd_theme>=3.0, <3.1",
+    "sphinx-pyproject>=0.3, <0.4",
+    "myst-nb>=1.2, <1.3",
+    "sphinx-mathjax-offline<0.1",
+    "sphinx_github_style>=1.2, <1.3",
+    "sphinx-autodoc-typehints>=3, <3.1",
+    "sphinx-copybutton>=0.5, <0.6",
+    "sphinx-last-updated-by-git>=0.3, <0.4",
 ]
 notebook = [
     "zenodo_get",


### PR DESCRIPTION
Currently this is broken:

https://zimf.de/zipserve/https://github.com/PTB-MR/mrpro/actions/runs/13410186766/artifacts/2615291997/_autosummary/mrpro.data.AcqInfo.html#mrpro.data.AcqInfo.from_ismrmrd_acquisitions

The '<>' in the repr of a function breaks the formatting.

Also, it pins the versions of all sphinx related packages. Reading through the issue tracker, there are many issues caused by updates and changes. I would suggest to only manually update the sphinx versions when required.
Otherwise, subtle breakage as above will go unnoticed for a long time.