### PR TITLE
Fix torchvision in docker images

### DIFF
--- a/docker/install_dependencies.sh
+++ b/docker/install_dependencies.sh
@@ -1,5 +1,5 @@
 # pre-install cpu-version of torch to avoid installation of cuda-version via dependencies
-python -m pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu
+python -m pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cpu
 
 #parse dependencies
 python -m pip install --no-cache-dir toml


### PR DESCRIPTION
The docker images we build on main a currently broken (see failing checks on main).

We manually install a cpu-only version of pytorch, but automatically install torchvision.
Both versions have to match according to https://pytorch.org/get-started/locally/
So we have to install torchvision as well.