### PR TITLE
Add AveragingOp

### DIFF
--- a/src/mrpro/operators/AveragingOp.py
+++ b/src/mrpro/operators/AveragingOp.py
@@ -18,7 +18,7 @@ class AveragingOp(LinearOperator):
     the average of the elements in that group is computed.
 
     For example, this operator can be used to simulate the effect of a sliding window average
-    in a signal model.
+    on a signal model.
     """
 
     def __init__(

--- a/src/mrpro/operators/AveragingOp.py
+++ b/src/mrpro/operators/AveragingOp.py
@@ -24,7 +24,7 @@ class AveragingOp(LinearOperator):
     def __init__(
         self,
         dim: int,
-        idx: Sequence[Sequence[int] | torch.Tensor | slice] | torch.Tensor,
+        idx: Sequence[Sequence[int] | torch.Tensor | slice] | torch.Tensor = (slice(None),),  # noqa: B008
         domain_size: int | None = None,
     ) -> None:
         """Initialize the averaging operator.

--- a/src/mrpro/operators/AveragingOp.py
+++ b/src/mrpro/operators/AveragingOp.py
@@ -1,0 +1,83 @@
+"""Averaging operator."""
+
+from collections.abc import Sequence
+from warnings import warn
+
+import torch
+
+from mrpro.operators.LinearOperator import LinearOperator
+
+
+class AveragingOp(LinearOperator):
+    """Averaging operator.
+
+    This operator averages the input tensor along a specified dimension.
+    The averaging is performed over groups of elements defined by the `idx` parameter.
+    The output tensor will have the same shape as the input tensor, except for the `dim` dimension,
+    which will have a size equal to the number of groups specified in `idx`. For each group,
+    the average of the elements in that group is computed.
+
+    For example, this operator can be used to simulate the effect of a sliding window average
+    in a signal model.
+    """
+
+    def __init__(
+        self, dim: int, idx: Sequence[Sequence[int] | torch.Tensor | slice], domain_size: int | None = None
+    ) -> None:
+        """Initialize the averaging operator.
+
+        Parameters
+        ----------
+        dim
+            The dimension along which to average.
+        idx
+            The indices of the input tensor to average over. Each element of the sequence will result in a
+            separate entry in the `dim` dimension of the output tensor.
+            The entries can be either a sequence of integers or an integer tensor, a slice object, or a boolean tensor.
+        domain_size
+            The size of the input along `dim`. It is only used in the `adjoint` method.
+            If not set, the size will be guessed from the input tensor during the forward pass.
+        """
+        super().__init__()
+        self.domain_size = domain_size
+        self._last_domain_size = domain_size
+        self.idx = idx
+        self.dim = dim
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor]:
+        """Apply the averaging operator to the input tensor."""
+        if self.domain_size and self.domain_size != x.shape[self.dim]:
+            raise ValueError(f'Expected domain size {self.domain_size}, got {x.shape[self.dim]}')
+        self._last_domain_size = x.shape[self.dim]
+
+        placeholder = (slice(None),) * (self.dim % x.ndim)
+        averaged = torch.stack([x[*placeholder, i].mean(self.dim) for i in self.idx], self.dim)
+        return (averaged,)
+
+    def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor]:
+        """Apply the adjoint of the averaging operator to the input tensor."""
+        if self.domain_size is None:
+            if self._last_domain_size is None:
+                raise ValueError('Domain size is not set. Please set it explicitly.')
+            warn(
+                'Domain size is not set. Guessing the last used input size of the forward pass. '
+                'Consider setting the domain size explicitly.',
+                stacklevel=2,
+            )
+            self.domain_size = self._last_domain_size
+
+        adjoint = x.new_zeros(*x.shape[: self.dim], self.domain_size, *x.shape[self.dim + 1 :])
+        placeholder = (slice(None),) * (self.dim % x.ndim)
+        for i, group in enumerate(self.idx):
+            if isinstance(group, slice):
+                n = len(range(*group.indices(self.domain_size)))
+            elif isinstance(group, torch.Tensor) and group.dtype == torch.bool:
+                n = group.sum()
+            else:
+                n = len(group)
+
+            adjoint[*placeholder, group] += (
+                x[*placeholder, i, None].expand(*x.shape[: self.dim], n, *x.shape[self.dim + 1 :]) / n
+            )
+
+        return (adjoint,)

--- a/src/mrpro/operators/AveragingOp.py
+++ b/src/mrpro/operators/AveragingOp.py
@@ -22,7 +22,10 @@ class AveragingOp(LinearOperator):
     """
 
     def __init__(
-        self, dim: int, idx: Sequence[Sequence[int] | torch.Tensor | slice], domain_size: int | None = None
+        self,
+        dim: int,
+        idx: Sequence[Sequence[int] | torch.Tensor | slice] | torch.Tensor,
+        domain_size: int | None = None,
     ) -> None:
         """Initialize the averaging operator.
 
@@ -72,12 +75,12 @@ class AveragingOp(LinearOperator):
             if isinstance(group, slice):
                 n = len(range(*group.indices(self.domain_size)))
             elif isinstance(group, torch.Tensor) and group.dtype == torch.bool:
-                n = group.sum()
+                n = int(group.sum())
             else:
                 n = len(group)
 
             adjoint[*placeholder, group] += (
-                x[*placeholder, i, None].expand(*x.shape[: self.dim], n, *x.shape[self.dim + 1 :]) / n
+                x[*placeholder, i, None].expand(*x.shape[: self.dim], n, *x.shape[self.dim + 1 :]) / n  # type: ignore[index]
             )
 
         return (adjoint,)

--- a/src/mrpro/operators/AveragingOp.py
+++ b/src/mrpro/operators/AveragingOp.py
@@ -54,7 +54,7 @@ class AveragingOp(LinearOperator):
         self._last_domain_size = x.shape[self.dim]
 
         placeholder = (slice(None),) * (self.dim % x.ndim)
-        averaged = torch.stack([x[*placeholder, i].mean(self.dim) for i in self.idx], self.dim)
+        averaged = torch.stack([x[(*placeholder, i)].mean(self.dim) for i in self.idx], self.dim)
         return (averaged,)
 
     def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor]:

--- a/src/mrpro/operators/AveragingOp.py
+++ b/src/mrpro/operators/AveragingOp.py
@@ -79,8 +79,8 @@ class AveragingOp(LinearOperator):
             else:
                 n = len(group)
 
-            adjoint[*placeholder, group] += (
-                x[*placeholder, i, None].expand(*x.shape[: self.dim], n, *x.shape[self.dim + 1 :]) / n  # type: ignore[index]
+            adjoint[(*placeholder, group)] += (
+                x[(*placeholder, i, None)].expand(*x.shape[: self.dim], n, *x.shape[self.dim + 1 :]) / n  # type: ignore[index]
             )
 
         return (adjoint,)

--- a/src/mrpro/operators/AveragingOp.py
+++ b/src/mrpro/operators/AveragingOp.py
@@ -61,7 +61,7 @@ class AveragingOp(LinearOperator):
         """Apply the adjoint of the averaging operator to the input tensor."""
         if self.domain_size is None:
             if self._last_domain_size is None:
-                raise ValueError('Domain size is not set. Please set it explicitly.')
+                raise ValueError('Domain size is not set. Please set it explicitly or run forward first.')
             warn(
                 'Domain size is not set. Guessing the last used input size of the forward pass. '
                 'Consider setting the domain size explicitly.',

--- a/src/mrpro/operators/__init__.py
+++ b/src/mrpro/operators/__init__.py
@@ -4,6 +4,7 @@ from mrpro.operators.Operator import Operator
 from mrpro.operators.LinearOperator import LinearOperator
 from mrpro.operators.Functional import Functional, ProximableFunctional, ElementaryFunctional, ElementaryProximableFunctional, ScaledFunctional, ScaledProximableFunctional
 from mrpro.operators import functionals, models
+from mrpro.operators.AveragingOp import AveragingOp
 from mrpro.operators.CartesianSamplingOp import CartesianSamplingOp
 from mrpro.operators.ConstraintsOp import ConstraintsOp
 from mrpro.operators.DensityCompensationOp import DensityCompensationOp
@@ -30,6 +31,7 @@ from mrpro.operators.ZeroPadOp import ZeroPadOp
 from mrpro.operators.ZeroOp import ZeroOp
 
 __all__ = [
+    "AveragingOp",
     "CartesianSamplingOp",
     "ConstraintsOp",
     "DensityCompensationOp",

--- a/tests/operators/test_averagingop.py
+++ b/tests/operators/test_averagingop.py
@@ -1,0 +1,47 @@
+"""Test the averaging operator."""
+
+import pytest
+import torch
+from mrpro.operators import AveragingOp
+
+from tests import RandomGenerator
+from tests.helper import dotproduct_adjointness_test
+
+
+def test_averageingop_adjointness() -> None:
+    """Test the adjointness of the averaging operator."""
+    rng = RandomGenerator(seed=0)
+    u = rng.complex64_tensor(size=(5, 15, 10))
+    v = rng.complex64_tensor(size=(5, 3, 10))
+    idx = [0, 1, 2], slice(0, 6, 2), torch.tensor([-1, -2, -3])
+    op = AveragingOp(dim=-2, idx=idx, domain_size=15)
+    dotproduct_adjointness_test(op, u, v)
+
+
+def test_averageingop_forward() -> None:
+    """Test the forward method of the averaging operator."""
+    rng = RandomGenerator(seed=1)
+    u = rng.complex64_tensor(size=(5, 10))
+    idx = [0, 1, 2], slice(0, 6, 2), torch.tensor([-1, -2, -3])
+    op = AveragingOp(dim=0, idx=idx, domain_size=5)
+    (actual,) = op(u)
+    torch.testing.assert_close(actual[0], u[(0, 1, 2),].mean(dim=0))
+    torch.testing.assert_close(actual[1], u[(0, 2, 4),].mean(dim=0))
+    torch.testing.assert_close(actual[2], u[(-1, -2, -3),].mean(dim=0))
+
+
+def test_averageingop_no_domain_size() -> None:
+    """Test the adjoint method of the averaging operator without domain size."""
+    rng = RandomGenerator(seed=0)
+    v = rng.float32_tensor(size=(5, 2))
+    idx = rng.int64_tensor(size=(2, 3), low=0, high=9)
+    op = AveragingOp(dim=1, idx=idx)
+
+    with pytest.raises(ValueError, match='Domain'):
+        op.adjoint(v)
+
+    u = rng.float32_tensor(size=(5, 10))
+    op(u)  # this sets the domain size
+    with pytest.warns(match='Domain'):
+        (actual,) = op.adjoint(v)
+    assert actual.shape == u.shape

--- a/tests/operators/test_averagingop.py
+++ b/tests/operators/test_averagingop.py
@@ -22,14 +22,13 @@ def test_averageingop_forward() -> None:
     """Test the forward method of the averaging operator."""
     rng = RandomGenerator(seed=1)
     u = rng.complex64_tensor(size=(5, 10))
-    idx = [0, 1, 2], slice(0, 6, 2), torch.tensor([-1, -2, -3]), (False, True, True, False, True, False)
+    idx = [0, 1, 2], slice(0, 6, 2), torch.tensor([-1, -2, -3]), (False, True, True, False, True)
     op = AveragingOp(dim=0, idx=idx, domain_size=5)
     (actual,) = op(u)
     torch.testing.assert_close(actual[0], u[(0, 1, 2),].mean(dim=0))
     torch.testing.assert_close(actual[1], u[(0, 2, 4),].mean(dim=0))
     torch.testing.assert_close(actual[2], u[(-1, -2, -3),].mean(dim=0))
     torch.testing.assert_close(actual[3], u[(1, 2, 4),].mean(dim=0))
-
 
 
 def test_averageingop_no_domain_size() -> None:

--- a/tests/operators/test_averagingop.py
+++ b/tests/operators/test_averagingop.py
@@ -22,12 +22,14 @@ def test_averageingop_forward() -> None:
     """Test the forward method of the averaging operator."""
     rng = RandomGenerator(seed=1)
     u = rng.complex64_tensor(size=(5, 10))
-    idx = [0, 1, 2], slice(0, 6, 2), torch.tensor([-1, -2, -3])
+    idx = [0, 1, 2], slice(0, 6, 2), torch.tensor([-1, -2, -3]), (False, True, True, False, True, False)
     op = AveragingOp(dim=0, idx=idx, domain_size=5)
     (actual,) = op(u)
     torch.testing.assert_close(actual[0], u[(0, 1, 2),].mean(dim=0))
     torch.testing.assert_close(actual[1], u[(0, 2, 4),].mean(dim=0))
     torch.testing.assert_close(actual[2], u[(-1, -2, -3),].mean(dim=0))
+    torch.testing.assert_close(actual[3], u[(1, 2, 4),].mean(dim=0))
+
 
 
 def test_averageingop_no_domain_size() -> None:


### PR DESCRIPTION
Calculates the avarage over a dimenion or over subets aong a dimension
Useful for qMRI if the images hve been reconstruced using a sliding windows.
Example cmrf (pseudocode):
````
kdata = kdata.split_k1_into_other(split_indices)
mrf_model = SignalAverage(split_indices) @ CardiacFingerprinting()
````