### PR TITLE
Speed up brainweb tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ filterwarnings = [
     "ignore:Anomaly Detection has been enabled:UserWarning",                   # torch.autograd
     "ignore:allow_ops_in_compiled_graph failed to import torch:ImportWarning", # einops and dynamo<2.5
 ]
-addopts = "-n auto"
+addopts = "-n auto --dist loadfile --maxprocesses=8"
 markers = ["cuda : Tests only to be run when cuda device is available"]
 
 # MyPy section

--- a/src/mrpro/phantoms/brainweb.py
+++ b/src/mrpro/phantoms/brainweb.py
@@ -35,6 +35,7 @@ VERSION = 1
 CACHE_DIR = platformdirs.user_cache_dir('mrpro')  #  ~/.cache/mrpro on Linux, %AppData%\Local\mrpro on Windows
 K = TypeVar('K')
 TClassNames = Literal['skl', 'gry', 'wht', 'csf', 'mrw', 'dura', 'fat', 'fat2', 'mus', 'm-s', 'ves']  # noqa: typos
+BRAINWEBSHAPE = (362, 434, 362)
 
 
 @dataclass
@@ -297,7 +298,7 @@ def download_brainweb(
                 downloaded_data[c] = future.result()
                 progressbar.update(1)
 
-        values = norm_([unpack(downloaded_data.pop(c), shape=(362, 434, 362), dtype=np.uint16) for c in ALL_CLASSES])
+        values = norm_([unpack(downloaded_data.pop(c), shape=BRAINWEBSHAPE, dtype=np.uint16) for c in ALL_CLASSES])
 
         with h5py.File(outfilename, 'w') as f:
             f.create_dataset(
@@ -626,9 +627,7 @@ class BrainwebSlices(torch.utils.data.Dataset):
         file_id = np.searchsorted(self._ns_slices, index, 'right') - 1
         slice_id = index - self._ns_slices[file_id] + self._skip_slices[0]
 
-        with h5py.File(
-            self._files[file_id],
-        ) as file:
+        with h5py.File(self._files[file_id]) as file:
             where = [slice(self._skip_slices[0], file['classes'].shape[i] - self._skip_slices[1]) for i in range(3)] + [
                 slice(None)
             ]

--- a/tests/phantoms/test_brainweb.py
+++ b/tests/phantoms/test_brainweb.py
@@ -22,6 +22,14 @@ from mrpro.phantoms.brainweb import (
 
 from tests import RandomGenerator
 
+BRAINWEBTESTSHAPE = (362 // 2, 434 // 2, 362 // 2)  # reduce the size of the brainweb data for faster testing
+
+
+@pytest.fixture(autouse=True)
+def modify_shape(monkeypatch):
+    """Modify the shape of the brainweb data for faster testing."""
+    monkeypatch.setattr('mrpro.phantoms.brainweb.BRAINWEBSHAPE', BRAINWEBTESTSHAPE)
+
 
 @pytest.fixture
 def mock_requests(monkeypatch) -> None:
@@ -37,7 +45,7 @@ def mock_requests(monkeypatch) -> None:
             # Fake data
             subject, class_name = match.groups()
             rng = RandomGenerator(int(subject) * 100 + ALL_CLASSES.index(class_name))
-            fake_data = rng.int16_tensor((362, 434, 362), low=0, high=4096)
+            fake_data = rng.int16_tensor(BRAINWEBTESTSHAPE, low=0, high=4096)
             compressed_data = gzip.compress(fake_data.numpy().astype(np.uint16).tobytes(), compresslevel=0)
             return type('MockResponse', (), {'content': compressed_data, 'raise_for_status': lambda _: None})()
 
@@ -62,7 +70,7 @@ def test_download_brainweb(tmp_path, mock_requests) -> None:
             assert 'subject' in f.attrs
             assert 'version' in f.attrs
             assert f.attrs['version'] == VERSION
-            assert f['classes'].shape == (362, 434, 362, len(ALL_CLASSES) - 1)
+            assert f['classes'].shape == (*BRAINWEBTESTSHAPE, len(ALL_CLASSES) - 1)
 
 
 @pytest.fixture(scope='session')
@@ -74,7 +82,7 @@ def brainweb_test_data(tmp_path_factory, n_subjects=1):
         file_path = test_dir / f's{subject:02d}.h5'
         with h5py.File(file_path, 'w') as f:
             rng = RandomGenerator(int(subject))
-            fake_data = rng.float32_tensor((362, 434, 362, len(ALL_CLASSES) - 1))
+            fake_data = rng.float32_tensor((*BRAINWEBTESTSHAPE, len(ALL_CLASSES) - 1))
             fake_data *= 255 / fake_data.sum(-1, keepdim=True)
             f.create_dataset('classes', data=fake_data.to(torch.uint8))
 
@@ -98,10 +106,10 @@ def test_brainwebvolumes_getitem(brainweb_test_data) -> None:
 
     assert isinstance(sample, dict)
 
-    assert sample['m0'].shape == (362, 434, 362)
-    assert sample['r1'].shape == (362, 434, 362)
-    assert sample['mask'].shape == (362, 434, 362)
-    assert sample['tissueclass'].shape == (362, 434, 362)
+    assert sample['m0'].shape == BRAINWEBTESTSHAPE
+    assert sample['r1'].shape == BRAINWEBTESTSHAPE
+    assert sample['mask'].shape == BRAINWEBTESTSHAPE
+    assert sample['tissueclass'].shape == BRAINWEBTESTSHAPE
 
     assert sample['m0'].dtype == torch.complex64
     assert sample['r1'].dtype == torch.float
@@ -200,7 +208,10 @@ def test_brainwebslices_init(brainweb_test_data) -> None:
 def test_brainwebslices_getitem(brainweb_test_data) -> None:
     """Test dataset __getitem__ method."""
     dataset = BrainwebSlices(
-        folder=brainweb_test_data, what=('m0', 'r1', 't2', 'mask', 'tissueclass', 'dura'), orientation='coronal'
+        folder=brainweb_test_data,
+        what=('m0', 'r1', 't2', 'mask', 'tissueclass', 'dura'),
+        orientation='coronal',
+        skip_slices=((10, 10), (10, 10), (10, 10)),
     )
     sample = dataset[0]
 
@@ -226,7 +237,9 @@ def test_brainwebslices_getitem(brainweb_test_data) -> None:
 @pytest.mark.parametrize('orientation', ['axial', 'coronal', 'sagittal'])
 def test_brainwebslices_orientations(brainweb_test_data, orientation: Literal['axial', 'coronal', 'sagittal']) -> None:
     """Test different slice orientations."""
-    dataset = BrainwebSlices(folder=brainweb_test_data, orientation=orientation)
+    dataset = BrainwebSlices(
+        folder=brainweb_test_data, orientation=orientation, skip_slices=((10, 10), (10, 10), (10, 10))
+    )
     assert len(dataset) > 0
     sample = dataset[0]
     assert isinstance(sample, dict)


### PR DESCRIPTION
reduces the mocked size of the brainweb data by a factor of 8 in the tests and  sets an upper limit for processes to 8
-- more processes seem even on our recon server not to speed up the tests.