### PR TITLE
Fix memory leak in LinearOperator

### DIFF
--- a/src/mrpro/operators/LinearOperator.py
+++ b/src/mrpro/operators/LinearOperator.py
@@ -35,8 +35,9 @@ class _AutogradWrapper(torch.autograd.Function):
         ctx: Any,  # noqa: ANN401
         inputs: tuple[Callable[[torch.Tensor], torch.Tensor], Callable[[torch.Tensor], torch.Tensor], torch.Tensor],
         _output: torch.Tensor,
-    ) -> torch.Tensor:
+    ) -> None:
         ctx.fw, ctx.bw, x = inputs
+        return None
 
     @staticmethod
     def backward(ctx: Any, *grad_output: torch.Tensor) -> tuple[None, None, torch.Tensor]:  # noqa: ANN401

--- a/src/mrpro/operators/LinearOperator.py
+++ b/src/mrpro/operators/LinearOperator.py
@@ -34,10 +34,9 @@ class _AutogradWrapper(torch.autograd.Function):
     def setup_context(
         ctx: Any,  # noqa: ANN401
         inputs: tuple[Callable[[torch.Tensor], torch.Tensor], Callable[[torch.Tensor], torch.Tensor], torch.Tensor],
-        output: torch.Tensor,
+        _output: torch.Tensor,
     ) -> torch.Tensor:
         ctx.fw, ctx.bw, x = inputs
-        return output
 
     @staticmethod
     def backward(ctx: Any, *grad_output: torch.Tensor) -> tuple[None, None, torch.Tensor]:  # noqa: ANN401


### PR DESCRIPTION
Linear Operators that use `adjoint_as_backward` leaked memory in the order of the result size per call.

The `setup_context` of the AutogradWrapper returned the output. This leaks and is not required (https://pytorch.org/docs/stable/notes/extending.html)

Finding the issue took a lot longer than it should have.

 PS: I partially blame copilot:
![image](https://github.com/user-attachments/assets/7a6db70e-2648-4436-a639-b34f615a0624)


I think we can now, after having switched to finufft, also disable the `adjoint_as_backward`  on the FourierOp.
I would still want to fix this functionality, as  it also allows do non-autograd compatible stuff in forward and adjoint.

Fixed #747 

