### PR TITLE
Update adjoint_as_backward setting

### DIFF
--- a/src/mrpro/operators/FourierOp.py
+++ b/src/mrpro/operators/FourierOp.py
@@ -15,7 +15,7 @@ from mrpro.operators.LinearOperator import LinearOperator
 from mrpro.operators.NonUniformFastFourierOp import NonUniformFastFourierOp
 
 
-class FourierOp(LinearOperator, adjoint_as_backward=True):
+class FourierOp(LinearOperator):
     """Fourier Operator class.
 
     This is the recommended operator for all Fourier transformations.

--- a/src/mrpro/operators/NonUniformFastFourierOp.py
+++ b/src/mrpro/operators/NonUniformFastFourierOp.py
@@ -15,7 +15,7 @@ from mrpro.operators.FastFourierOp import FastFourierOp
 from mrpro.operators.LinearOperator import LinearOperator
 
 
-class NonUniformFastFourierOp(LinearOperator, adjoint_as_backward=True):
+class NonUniformFastFourierOp(LinearOperator):
     """Non-Uniform Fast Fourier Operator class."""
 
     def __init__(

--- a/src/mrpro/operators/NonUniformFastFourierOp.py
+++ b/src/mrpro/operators/NonUniformFastFourierOp.py
@@ -208,7 +208,7 @@ class NonUniformFastFourierOp(LinearOperator):
                 raise ValueError('Only CPU and CUDA are supported')
             # We rearrange x into (sep_dims, joint_dims, nufft_directions)
             sep_dims_zyx, permute_zyx, _, permute_210 = self._separate_joint_dimensions(x.ndim)
-            unpermute_210 = torch.tensor(permute_210).argsort().tolist()
+            unpermute_210 = torch.tensor(permute_210).argsort()
 
             x = x.permute(*permute_zyx)
             unflatten_shape = x.shape[: -len(self._direction_zyx)]
@@ -244,7 +244,7 @@ class NonUniformFastFourierOp(LinearOperator):
                 raise ValueError('Only CPU and CUDA are supported')
             # We rearrange x into (sep_dims, joint_dims, nufft_directions)
             _, permute_zyx, sep_dims_210, permute_210 = self._separate_joint_dimensions(x.ndim)
-            unpermute_zyx = torch.tensor(permute_zyx).argsort().tolist()
+            unpermute_zyx = torch.tensor(permute_zyx).argsort()
 
             x = x.permute(*permute_210)
             unflatten_other_shape = x.shape[: -len(self._dimension_210) - 1]  # -1 for coil

--- a/src/mrpro/operators/PatchOp.py
+++ b/src/mrpro/operators/PatchOp.py
@@ -8,7 +8,7 @@ from mrpro.operators.LinearOperator import LinearOperator
 from mrpro.utils.sliding_window import sliding_window
 
 
-class PatchOp(LinearOperator):
+class PatchOp(LinearOperator, adjoint_as_backward=True):
     """Extract N-dimensional patches using a sliding window view.
 
     The adjoint assembles patches to an image.


### PR DESCRIPTION
- Remove it from FourierOp -- we switched from torchkbnufft to finufft, thus no longer have the backward bugs.
- Add it to PatchOp -- Does not really matter for the forward, can save memory usage in the backward of the adjoint in certain cases (if the input is not already saved for the backward of another layer )


Lets see if tests pass.