### PR TITLE
Allow complex inputs to ConstraintOp and add InverseConstraintOp

### DIFF
--- a/src/mrpro/operators/ConstraintsOp.py
+++ b/src/mrpro/operators/ConstraintsOp.py
@@ -91,9 +91,9 @@ class ConstraintsOp(EndomorphOperator):
 
         for lb, ub in zip(self.lower_bounds, self.upper_bounds, strict=True):
             if lb.isnan():
-                raise ValueError('nan is not a valid lower bound.')
+                raise ValueError('nan is invalid as lower bound.')
             if ub.isnan():
-                raise ValueError('nan is not a valid upper bound.')
+                raise ValueError('nan is invalid as upper bound.')
             if lb >= ub:
                 raise ValueError(
                     'bounds should be ( (a1,b1), (a2,b2), ...) with ai < bi if neither ai or bi is None;'

--- a/src/mrpro/operators/ConstraintsOp.py
+++ b/src/mrpro/operators/ConstraintsOp.py
@@ -82,12 +82,8 @@ class ConstraintsOp(EndomorphOperator):
         self.beta_sigmoid = beta_sigmoid
         self.beta_softplus = beta_softplus
 
-        self.lower_bounds = tuple(
-            torch.as_tensor(bound[0]) if bound[0] is not None else -torch.tensor(torch.inf) for bound in bounds
-        )
-        self.upper_bounds = tuple(
-            torch.as_tensor(bound[1]) if bound[1] is not None else torch.tensor(torch.inf) for bound in bounds
-        )
+        self.lower_bounds = tuple(torch.as_tensor(-torch.inf if lb is None else lb) for (lb, ub) in bounds)
+        self.upper_bounds = tuple(torch.as_tensor(torch.inf is ub is None else ub for (lb, ub) in bounds)
 
         for lb, ub in zip(self.lower_bounds, self.upper_bounds, strict=True):
             if lb.isnan():

--- a/src/mrpro/operators/ConstraintsOp.py
+++ b/src/mrpro/operators/ConstraintsOp.py
@@ -83,7 +83,7 @@ class ConstraintsOp(EndomorphOperator):
         self.beta_softplus = beta_softplus
 
         self.lower_bounds = tuple(torch.as_tensor(-torch.inf if lb is None else lb) for (lb, ub) in bounds)
-        self.upper_bounds = tuple(torch.as_tensor(torch.inf is ub is None else ub for (lb, ub) in bounds)
+        self.upper_bounds = tuple(torch.as_tensor(torch.inf is ub is None else ub) for (lb, ub) in bounds)
 
         for lb, ub in zip(self.lower_bounds, self.upper_bounds, strict=True):
             if lb.isnan():

--- a/src/mrpro/operators/ConstraintsOp.py
+++ b/src/mrpro/operators/ConstraintsOp.py
@@ -83,7 +83,7 @@ class ConstraintsOp(EndomorphOperator):
         self.beta_softplus = beta_softplus
 
         self.lower_bounds = tuple(torch.as_tensor(-torch.inf if lb is None else lb) for (lb, ub) in bounds)
-        self.upper_bounds = tuple(torch.as_tensor(torch.inf is ub is None else ub) for (lb, ub) in bounds)
+        self.upper_bounds = tuple(torch.as_tensor(torch.inf if ub is None else ub) for (lb, ub) in bounds)
 
         for lb, ub in zip(self.lower_bounds, self.upper_bounds, strict=True):
             if lb.isnan():

--- a/tests/operators/test_constraints_op.py
+++ b/tests/operators/test_constraints_op.py
@@ -41,6 +41,23 @@ def test_constraints_operator_bounds(bounds: tuple[tuple[float | None, float | N
 
 @pytest.mark.parametrize('beta', [1, 0.5, 2])
 @BOUNDS
+def test_constraints_operator_complex(bounds: tuple[tuple[float | None, float | None], ...], beta: float) -> None:
+    """Test with complex numbers"""
+    # Bounds should be applied to real and imaginary parts separately
+    rng = RandomGenerator(seed=0)
+    x = rng.complex64_tensor((10,))
+    constraints_op = ConstraintsOp(bounds, beta_sigmoid=beta, beta_softplus=beta)
+
+    (actual,) = constraints_op(x)
+    expected = constraints_op(x.real)[0] + 1j * constraints_op(x.imag)[0]
+    torch.testing.assert_close(actual, expected)
+
+    (inverted,) = constraints_op.inverse(actual)
+    torch.testing.assert_close(inverted, x)
+
+
+@pytest.mark.parametrize('beta', [1, 0.5, 2])
+@BOUNDS
 def test_constraints_operator_inverse(bounds: tuple[tuple[float | None, float | None], ...], beta: float) -> None:
     """Tests if operator inverse inverses the operator."""
     rng = RandomGenerator(seed=0)

--- a/tests/operators/test_constraints_op.py
+++ b/tests/operators/test_constraints_op.py
@@ -7,97 +7,58 @@ from mrpro.utils import RandomGenerator
 
 from tests import autodiff_test
 
-
-@pytest.mark.parametrize('beta', [1, 0.5, 2])
-@pytest.mark.parametrize(
+BOUNDS = pytest.mark.parametrize(
     'bounds',
     [
-        ((None, 1.0),),  # case (-infty, 0.)
-        ((1.0, None),),  # case (1, \infty)
+        ((None, 1.0),),  # case (-inf, 1.)
+        ((1.0, None),),  # case (1, inf)
         ((-5.0, 5.0),),  # case (-5, 5)
-        ((-torch.inf, torch.inf),),  # case (-5, 5)
+        ((-torch.inf, torch.inf),),  # case (-inf, inf)
     ],
+    ids=['(-inf, 1.)', '(1, inf)', '(-5, 5)', '(-inf, inf)'],
 )
-def test_constraints_operator_bounds(bounds, beta):
+
+
+@pytest.mark.parametrize('beta', [1, 0.5, 2])
+@BOUNDS
+def test_constraints_operator_bounds(bounds: tuple[tuple[float | None, float | None], ...], beta: float) -> None:
+    """Tests if the operator correctly applies the bounds."""
     rng = RandomGenerator(seed=0)
-
-    # random tensor with arbitrary values
-    # (make sure to hit bounds by scaling it with a "large" number)
-    x = rng.float32_tensor(size=(36,), low=-100.0, high=100.0)
-
-    # define constraints operator using the bounds
+    x = rng.float32_tensor(size=(36,), low=-100.0, high=100.0)  # large values to be sure to hit bounds
     constraints_op = ConstraintsOp(bounds, beta_sigmoid=beta, beta_softplus=beta)
-
-    # transform tensor to be component-wise in the range defined by bounds
     (cx,) = constraints_op(x)
-    ((a, b),) = bounds
 
-    # check if min/max values of transformed tensor
-    # correspond to the chosen bounds
-    if a is not None and b is not None:  # case (a,b) with a<b
-        torch.testing.assert_close(cx.min(), torch.tensor(a)) and torch.testing.assert_close(cx.max(), torch.tensor(b))
-    elif a is not None and b is None:  # case (a, infty)
-        torch.testing.assert_close(cx.min(), torch.tensor(a))
-    elif a is None and b is not None:  # case (-infty, b)
-        torch.testing.assert_close(cx.max(), torch.tensor(b))
+    # check if min/max values of transformed tensor match bounds
+    ((lower_bound, upper_bound),) = bounds
+    if lower_bound is not None and upper_bound is not None:  # case (a,b)
+        torch.testing.assert_close(cx.min(), torch.tensor(lower_bound))
+        torch.testing.assert_close(cx.max(), torch.tensor(upper_bound))
+    elif lower_bound is not None and upper_bound is None:  # case (a, infty)
+        torch.testing.assert_close(cx.min(), torch.tensor(lower_bound))
+    elif lower_bound is None and upper_bound is not None:  # case (-infty, b)
+        torch.testing.assert_close(cx.max(), torch.tensor(upper_bound))
 
 
 @pytest.mark.parametrize('beta', [1, 0.5, 2])
-@pytest.mark.parametrize(
-    'bounds',
-    [
-        ((None, 1.0),),  # case (-infty, 0.)
-        ((1.0, None),),  # case (1, \infty)
-        ((-5.0, 5.0),),  # case (-5, 5)
-        ((None, -1.0),),  # case (-infty, 0.)
-        ((-1.0, None),),  # case (1, \infty)
-    ],
-)
-def test_constraints_operator_inverse(bounds, beta):
-    """Tests if operator inverse inverser the operator."""
-
+@BOUNDS
+def test_constraints_operator_inverse(bounds: tuple[tuple[float | None, float | None], ...], beta: float) -> None:
+    """Tests if operator inverse inverses the operator."""
     rng = RandomGenerator(seed=0)
-
-    # random tensor with arbitrary values
     x = rng.float32_tensor(size=(36,))
-
-    # define constraints operator using the bounds
     constraints_op = ConstraintsOp(bounds, beta_sigmoid=beta, beta_softplus=beta)
-
-    # transform tensor to be component-wise in the range defined by bounds
     (cx,) = constraints_op(x)
-
-    # reverse transformation and check for equality
     (xx,) = constraints_op.inverse(cx)
     torch.testing.assert_close(xx, x)
 
 
 @pytest.mark.parametrize('beta', [1, 0.5, 2])
-@pytest.mark.parametrize(
-    'bounds',
-    [
-        ((None, 1.0),),  # case (-infty, 0.)
-        ((1.0, None),),  # case (1, \infty)
-        ((-5.0, 5.0),),  # case (-5, 5)
-        ((None, -1.0),),  # case (-infty, 0.)
-        ((-1.0, None),),  # case (1, \infty)
-    ],
-)
-def test_constraints_operator_no_nans(bounds, beta):
+@BOUNDS
+def test_constraints_operator_no_nans(bounds: tuple[tuple[float | None, float | None], ...], beta: float) -> None:
     """Tests if the operator always returns valid values, never nans."""
-
     rng = RandomGenerator(seed=0)
-
-    # random tensor with arbitrary values
     x = rng.float32_tensor(size=(36,), low=-100, high=100)
-
-    # define constraints operator using the bounds
     constraints_op = ConstraintsOp(bounds, beta_sigmoid=beta, beta_softplus=beta)
-
-    # transform tensor to be component-wise in the range defined by bounds
     (cx,) = constraints_op(x)
-
-    # reverse transformation and check if no nans are returned
     (xx,) = constraints_op.inverse(cx)
     assert not torch.isnan(xx).any()
 
@@ -109,10 +70,11 @@ def test_constraints_operator_no_nans(bounds, beta):
         ((None, None),),  # fewer bounds than parameters
         ((None, None), (None, None), (None, None), (None, None)),  # more bounds
     ],
+    ids=['matching', 'fewer bounds', 'more bounds'],
 )
-def test_constraints_operator_multiple_inputs(bounds):
+def test_constraints_operator_multiple_inputs(bounds: tuple[tuple[float | None, float | None], ...]) -> None:
+    """Tests if the operator works with multiple inputs."""
     rng = RandomGenerator(seed=0)
-
     # random tensors with arbitrary values
     x1 = rng.float32_tensor(size=(36, 72), low=-1, high=1)
     x2 = rng.float32_tensor(size=(36, 72), low=-1, high=1)
@@ -132,7 +94,7 @@ def test_constraints_operator_multiple_inputs(bounds):
 
 
 @pytest.mark.parametrize(
-    'bounds',
+    'illegal_bounds',
     [
         ((1.0, -1.0), (-1.0, 1.0)),  # first one is invalid
         ((-1.0, 1.0), (1.0, -1.0)),  # second one is invalid
@@ -142,18 +104,19 @@ def test_constraints_operator_multiple_inputs(bounds):
         ((torch.inf, -torch.inf),),  # invalid due to a>b
     ],
 )
-def test_constraints_operator_illegal_bounds(bounds):
+def test_constraints_operator_illegal_bounds(illegal_bounds: tuple[tuple[float | None, float | None], ...]) -> None:
+    """Tests if the operator raises an error for illegal bounds."""
     with pytest.raises(ValueError, match='invalid'):
-        ConstraintsOp(bounds)
+        ConstraintsOp(illegal_bounds)
 
 
 def test_autodiff_constraints_operator():
     """Test autodiff works for constraints operator."""
     # random tensors with arbitrary values
     rng = RandomGenerator(seed=0)
-    x1 = rng.float32_tensor(size=(36, 72), low=-1, high=1)
-    x2 = rng.float32_tensor(size=(36, 72), low=-1, high=1)
-    x3 = rng.float32_tensor(size=(36, 72), low=-1, high=1)
+    x1 = rng.float32_tensor(size=(36, 72), low=-5, high=5)
+    x2 = rng.float32_tensor(size=(36, 72), low=-5, high=5)
+    x3 = rng.float32_tensor(size=(36, 72), low=-5, high=5)
 
     constraints_op = ConstraintsOp(bounds=((None, None), (1.0, None), (None, 1.0)))
     autodiff_test(constraints_op, x1, x2, x3)


### PR DESCRIPTION
ConstraintOp failed with complex inputs.

Now constraints are interpreted as constrains on real and imaginary components,
thus constraining to a rectangle in the complex plane.

cleans up the operator and tests a bit.

Adds an inverse property to get the inverse of an constraint operator as an operator (usefull for chaining operators)
