### PR TITLE
Fix hang on repr of large data

### DIFF
--- a/src/mrpro/utils/summarize.py
+++ b/src/mrpro/utils/summarize.py
@@ -80,10 +80,8 @@ def summarize_values(value: torch.Tensor | Sequence[float], summarization_thresh
     if value.numel() == 0:
         pass
     elif value.is_complex():
-        # workaround for missing unique of complex values
-        unique = torch.view_as_complex(torch.unique(torch.view_as_real(value.ravel()), dim=0))
-        if len(unique) == 1:
-            string.append(f'constant {unique.item():.3g}')
+        if value.isclose(value.ravel()[0]).all():
+            string.append(f'constant {value.ravel()[0].item():.3g}')
             constant = True
         elif value.numel() > summarization_threshold:
             magnitude = value.abs()


### PR DESCRIPTION
Large KData objects have  a unreasonably slow repr on at least some systems/envs (>5s)
This imporves speed by using a faster way to check if all elements in a complex tensor are the same.