### PR TITLE
Fix bug in shape of KData parameters

### DIFF
--- a/src/mrpro/data/KData.py
+++ b/src/mrpro/data/KData.py
@@ -162,6 +162,9 @@ class KData(Dataclass):
             additional_fields=('center_sample', 'number_of_samples', 'discard_pre', 'discard_post'),
             convert_time_stamp=convert_time_stamp,
         )
+        # discard_pre and discard_post is of shape (N_readouts,1,1,1,1) and we only need it as (N_readouts,)
+        discard_pre = discard_pre[:, 0, 0, 0, 0]
+        discard_post = discard_post[:, 0, 0, 0, 0]
 
         if len(torch.unique(acq_info.idx.user5)) > 1:
             warnings.warn(

--- a/src/mrpro/data/KData.py
+++ b/src/mrpro/data/KData.py
@@ -162,9 +162,8 @@ class KData(Dataclass):
             additional_fields=('center_sample', 'number_of_samples', 'discard_pre', 'discard_post'),
             convert_time_stamp=convert_time_stamp,
         )
-        # discard_pre and discard_post is of shape (N_readouts,1,1,1,1) and we only need it as (N_readouts,)
-        discard_pre = discard_pre[:, 0, 0, 0, 0]
-        discard_post = discard_post[:, 0, 0, 0, 0]
+        discard_pre_1d = rearrange(discard_pre, 'n_readouts 1 1 1 1 -> n_readouts')
+        discard_post_1d = rearrange(discard_post, 'n_readouts 1 1 1 1 -> n_readouts')
 
         if len(torch.unique(acq_info.idx.user5)) > 1:
             warnings.warn(
@@ -182,22 +181,25 @@ class KData(Dataclass):
                 stacklevel=1,
             )
 
-        shapes = (torch.as_tensor([acq.data.shape[-1] for acq in acquisitions]) - discard_pre - discard_post).unique()
+        shapes = (
+            torch.as_tensor([acq.data.shape[-1] for acq in acquisitions]) - discard_pre_1d - discard_post_1d
+        ).unique()
         if len(shapes) > 1:
             warnings.warn(
                 f'Acquisitions have different shape. Got {list(shapes)}. '
                 f'Keeping only acquisistions with {shapes[-1]} data samples. Note: discard_pre and discard_post '
-                f'{"have been applied. " if discard_pre.any() or discard_post.any() else "were empty. "}'
+                f'{"have been applied. " if discard_pre_1d.any() or discard_post_1d.any() else "were empty. "}'
                 'Please open an issue of you need to handle this kind of data.',
                 stacklevel=1,
             )
         data = torch.stack(
             [
                 torch.as_tensor(acq.data[..., pre : acq.data.shape[-1] - post], dtype=torch.complex64)
-                for acq, pre, post in zip(acquisitions, discard_pre, discard_post, strict=True)
+                for acq, pre, post in zip(acquisitions, discard_pre_1d, discard_post_1d, strict=True)
                 if acq.data.shape[-1] - pre - post == shapes[-1]
             ]
         )
+        n_k0_tensor = n_k0_tensor - discard_pre - discard_post
         data = rearrange(data, 'acquisitions coils k0 -> acquisitions coils 1 1 k0')
 
         # Raises ValueError if required fields are missing in the header

--- a/src/mrpro/data/traj_calculators/KTrajectorySunflowerGoldenRpe.py
+++ b/src/mrpro/data/traj_calculators/KTrajectorySunflowerGoldenRpe.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 import torch
-from einops import repeat
 
 from mrpro.data.KTrajectory import KTrajectory
 from mrpro.data.traj_calculators.KTrajectoryCalculator import KTrajectoryCalculator
@@ -82,13 +81,12 @@ class KTrajectorySunflowerGoldenRpe(KTrajectoryCalculator):
         -------
             radial phase encoding trajectory for given KHeader
         """
-        angles = repeat((k2_idx * self.angle) % torch.pi, '... k2 k1 -> ... k2 k1 k0', k0=1)
+        angles = (k2_idx * self.angle) % torch.pi
 
         radial = (k1_idx - k1_center).to(torch.float32)
         radial = self._apply_sunflower_shift_between_rpe_lines(radial, angles, k2_idx)
         # Asymmetric k-space point is used to obtain a self-navigator signal, thus should be in k-space center
         radial[(k1_idx == 0).broadcast_to(radial.shape)] = 0
-        radial = repeat(radial, '... k2 k1 -> ... k2 k1 k0', k0=1)
 
         kz = radial * torch.sin(angles)
         ky = radial * torch.cos(angles)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,6 +250,8 @@ def ismrmrd_cart(ellipse_phantom, tmp_path_factory):
         noise_level=1e-4,
         repetitions=3,
         phantom=ellipse_phantom.phantom,
+        discard_pre=10,
+        discard_post=20,
     )
     return ismrmrd_kdata
 

--- a/tests/data/_IsmrmrdRawTestData.py
+++ b/tests/data/_IsmrmrdRawTestData.py
@@ -26,33 +26,6 @@ class IsmrmrdRawTestData:
 
     This is based on
     https://github.com/ismrmrd/ismrmrd-python-tools/blob/master/generate_cartesian_shepp_logan_dataset.py
-
-    Parameters
-    ----------
-    filename
-        full path and filename
-    matrix_size
-        size of image matrix
-    n_coils
-        number of coils
-    oversampling
-        oversampling along readout (k0) direction
-    repetitions
-        number of repetitions,
-    flag_invalid_reps
-        flag to indicate that number of phase encoding steps are different for repetitions
-    acceleration
-        undersampling along phase encoding (k1)
-    noise_level
-        scaling factor for noise level
-    trajectory_type
-        cartesian
-    sampling_order
-        order how phase encoding points (k1) are obtained
-    phantom
-        phantom with different ellipses
-    n_separate_calibration_lines
-        number of additional calibration lines, linear Cartesian sampled
     """
 
     def __init__(
@@ -70,7 +43,42 @@ class IsmrmrdRawTestData:
         phantom: EllipsePhantom | None = None,
         add_bodycoil_acquisitions: bool = False,
         n_separate_calibration_lines: int = 0,
+        discard_pre: int = 0,
+        discard_post: int = 0,
     ):
+        """Initialize IsmrmrdRawTestData.
+
+        Parameters
+        ----------
+        filename
+            full path and filename
+        matrix_size
+            size of image matrix
+        n_coils
+            number of coils
+        oversampling
+            oversampling along readout (k0) direction
+        repetitions
+            number of repetitions,
+        flag_invalid_reps
+            flag to indicate that number of phase encoding steps are different for repetitions
+        acceleration
+            undersampling along phase encoding (k1)
+        noise_level
+            scaling factor for noise level
+        trajectory_type
+            cartesian
+        sampling_order
+            order how phase encoding points (k1) are obtained
+        phantom
+            phantom with different ellipses
+        n_separate_calibration_lines
+            number of additional calibration lines, linear Cartesian sampled
+        discard_pre
+            data points to discard at the beginning of the first five readouts
+        discard_post
+            data points to discard at the end of the first five readouts
+        """
         if not phantom:
             phantom = EllipsePhantom()
 
@@ -89,10 +97,6 @@ class IsmrmrdRawTestData:
         self.n_noise_samples = 4
 
         rng = RandomGenerator(0)
-
-        # Elements to discard at the beginning and end of the readout for some lines
-        discard_pre = 20
-        discard_post = 10
 
         # The number of points in image space (x,y) and kspace (fe,pe)
         n_x = self.matrix_size

--- a/tests/data/test_traj_calculators.py
+++ b/tests/data/test_traj_calculators.py
@@ -98,8 +98,8 @@ def test_KTrajectorySunflowerGoldenRpe() -> None:
     n_k0 = 100
     n_k1 = 20
     n_k2 = 10
-    k2_idx = torch.arange(n_k2)[:, None]
-    k1_idx = torch.arange(n_k1)
+    k2_idx = torch.arange(n_k2)[:, None, None]
+    k1_idx = torch.arange(n_k1)[:, None]
 
     trajectory_calculator = KTrajectorySunflowerGoldenRpe()
     trajectory = trajectory_calculator(


### PR DESCRIPTION
The change of all tensors to 5D meant that the use of discard_pre/discard_post led to wrong dimensions here:
https://github.com/PTB-MR/mrpro/blob/2f9d495eed367780c2f1f9f56c8210e408af85f6/src/mrpro/data/KData.py#L182

and in KTrajectorySunflowerGoldenRpe a k0-dimension was added which is not needed.
