### PR TITLE
Suggestion for save to ismrmrd

### DIFF
--- a/src/mrpro/data/Dataclass.py
+++ b/src/mrpro/data/Dataclass.py
@@ -847,6 +847,15 @@ class Dataclass:
                 return False
         return True
 
+    def __len__(self) -> int:
+        """Return the number of fields in the dataclass along the first dimension."""
+        return self.shape[0]
+
+    def __iter__(self) -> Iterator[Any]:
+        """Iterate over the first dimension of the dataclass."""
+        for i in range(len(self)):
+            yield self[i]
+
 
 class FakeDataclassBackend(einops._backends.AbstractBackend):
     """Einops backend for Dataclass: Will only raise an error if used."""

--- a/src/mrpro/utils/__init__.py
+++ b/src/mrpro/utils/__init__.py
@@ -11,7 +11,7 @@ from mrpro.utils.pad_or_crop import pad_or_crop
 from mrpro.utils.split_idx import split_idx
 from mrpro.utils.sliding_window import sliding_window
 from mrpro.utils.summarize import summarize_object, summarize_values
-from mrpro.utils.reshape import broadcast_right, unsqueeze_left, unsqueeze_right, reduce_view, reshape_broadcasted, ravel_multi_index, unsqueeze_tensors_left, unsqueeze_tensors_right, unsqueeze_at, unsqueeze_tensors_at, broadcasted_rearrange, broadcasted_concatenate
+from mrpro.utils.reshape import broadcast_right, broadcasted_rearrange, unsqueeze_left, unsqueeze_right, reduce_view, reshape_broadcasted, ravel_multi_index, unsqueeze_tensors_left, unsqueeze_tensors_right, unsqueeze_at, unsqueeze_tensors_at, broadcasted_concatenate
 from mrpro.utils.TensorAttributeMixin import TensorAttributeMixin
 from mrpro.utils.interpolate import interpolate, apply_lowres
 from mrpro.utils.RandomGenerator import RandomGenerator

--- a/src/mrpro/utils/reshape.py
+++ b/src/mrpro/utils/reshape.py
@@ -394,10 +394,10 @@ def broadcasted_rearrange(
 
     """
     tensor = tensor.broadcast_to(broadcasted_shape) if broadcasted_shape is not None else tensor
-    # the broadcast-preservation is done by patching the reshape method of the tensor
-    original_reshape, tensor.reshape = tensor.reshape, lambda shape: reshape_broadcasted(tensor, *shape)  # type: ignore[method-assign, assignment]
+    # the broadcast-preservation is done by patching the reshape method of the einops backend
+    einops._backends.TorchBackend.reshape = lambda _, tensor, shape: reshape_broadcasted(tensor, *shape)  # type: ignore[method-assign]
     new_tensor = einops.repeat(tensor, pattern, **axes_lengths)  # allows both repeat and rearrange
-    tensor.reshape = original_reshape  # type: ignore[method-assign]
+    del einops._backends.TorchBackend.reshape  # resets to inherited method
     if reduce_views:
         new_tensor = reduce_view(new_tensor)
     return new_tensor

--- a/tests/data/test_dataclass.py
+++ b/tests/data/test_dataclass.py
@@ -431,3 +431,10 @@ def test_dataclass_rearrange_einops() -> None:
     a = A()
     with pytest.raises(NotImplementedError, match='rearrange method'):
         einops.rearrange(a, 'dim1 dim2 -> dim2 dim1')
+
+
+def test_dataclass_shape() -> None:
+    """Test shape property of the dataclass."""
+    a = A()
+    assert a.shape == (10, 20)
+    assert len(a) == 10


### PR DESCRIPTION
Hi @ckolbPTB,

a suggestion for the save to ismrmrd functionality - this was easier to write as a PR to #421 than a review comment.

Most relevant changes:
 - the write_single_acqinfo function is no longer attached to AcqInfo, as it is a special case that only works with a single acquistion (otherwise i would _underscore name it)
 - the ismrmrd acquisition is recreated in each loop pass. Saving to ismrmrd file doesnt seem to be to performance critical and this makes the code a bit clearer, the overhat of recreating that object seems to be small.
 - use a context manager for dataset to close the hdf5 file on an exception
 - use self.rearrange instead of the nested loop

I also fixed a bug in the rearrange (if permuting axes and reshaping, axes that can be reduced to singleton after the reshape were not) and added a missing len(),iter() and shape test to dataclasses.


An open question is the center sample/ acq_is_reversed https://github.com/PTB-MR/mrpro/blob/1d4fe2af1bce2682732c91fcc7b613de9fb76f29/src/mrpro/data/KData.py#L393-L398
Are you sure that this logic is correct? Why does we have to modify it? Doesnt the argmin get the center sample?
Or should it count from the "other side" and +1 is only correct for symmetric readout?