### PR TITLE
Update to zenodo_get 2.0 api

### DIFF
--- a/examples/notebooks/cartesian_reconstruction.ipynb
+++ b/examples/notebooks/cartesian_reconstruction.ipynb
@@ -69,11 +69,9 @@
     "\n",
     "import zenodo_get\n",
     "\n",
-    "dataset = '14173489'\n",
-    "\n",
     "tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up\n",
     "data_folder = Path(tmp.name)\n",
-    "zenodo_get.zenodo_get([dataset, '-r', 5, '-o', data_folder])  # r: retries"
+    "zenodo_get.download(record='14173489', retry_attempts=5, output_dir=data_folder)"
    ]
   },
   {

--- a/examples/notebooks/comparison_trajectory_calculators.ipynb
+++ b/examples/notebooks/comparison_trajectory_calculators.ipynb
@@ -64,11 +64,9 @@
     "import torch\n",
     "import zenodo_get\n",
     "\n",
-    "dataset = '14617082'\n",
-    "\n",
     "tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up\n",
     "data_folder = Path(tmp.name)\n",
-    "zenodo_get.zenodo_get([dataset, '-r', 5, '-o', data_folder])  # r: retries"
+    "zenodo_get.download(record='14617082', retry_attempts=5, output_dir=data_folder)"
    ]
   },
   {

--- a/examples/notebooks/direct_reconstruction.ipynb
+++ b/examples/notebooks/direct_reconstruction.ipynb
@@ -81,11 +81,9 @@
     "\n",
     "import zenodo_get\n",
     "\n",
-    "dataset = '14617082'\n",
-    "\n",
     "tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up\n",
     "data_folder = Path(tmp.name)\n",
-    "zenodo_get.zenodo_get([dataset, '-r', 5, '-o', data_folder])  # r: retries"
+    "zenodo_get.download(record='14617082', retry_attempts=5, output_dir=data_folder)"
    ]
   },
   {

--- a/examples/notebooks/iterative_sense_reconstruction_radial2D.ipynb
+++ b/examples/notebooks/iterative_sense_reconstruction_radial2D.ipynb
@@ -107,11 +107,9 @@
     "\n",
     "import zenodo_get\n",
     "\n",
-    "dataset = '14617082'\n",
-    "\n",
     "tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up\n",
     "data_folder = Path(tmp.name)\n",
-    "zenodo_get.zenodo_get([dataset, '-r', 5, '-o', data_folder])  # r: retries"
+    "zenodo_get.download(record='14617082', retry_attempts=5, output_dir=data_folder)"
    ]
   },
   {

--- a/examples/notebooks/iterative_sense_reconstruction_with_regularization.ipynb
+++ b/examples/notebooks/iterative_sense_reconstruction_with_regularization.ipynb
@@ -57,11 +57,9 @@
     "\n",
     "import zenodo_get\n",
     "\n",
-    "dataset = '14617082'\n",
-    "\n",
     "tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up\n",
     "data_folder = Path(tmp.name)\n",
-    "zenodo_get.zenodo_get([dataset, '-r', 5, '-o', data_folder])  # r: retries"
+    "zenodo_get.download(record='14617082', retry_attempts=5, output_dir=data_folder)"
    ]
   },
   {

--- a/examples/notebooks/pgd_wavelet_reconstruction.ipynb
+++ b/examples/notebooks/pgd_wavelet_reconstruction.ipynb
@@ -138,11 +138,9 @@
     "\n",
     "import zenodo_get\n",
     "\n",
-    "dataset = '14617082'\n",
-    "\n",
     "tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up\n",
     "data_folder = Path(tmp.name)\n",
-    "zenodo_get.zenodo_get([dataset, '-r', 5, '-o', data_folder])  # r: retries"
+    "zenodo_get.download(record='14617082', retry_attempts=5, output_dir=data_folder)"
    ]
   },
   {

--- a/examples/notebooks/qmri_cardiac_fingerprinting.ipynb
+++ b/examples/notebooks/qmri_cardiac_fingerprinting.ipynb
@@ -120,11 +120,9 @@
     "\n",
     "import zenodo_get\n",
     "\n",
-    "dataset = '15182376'\n",
-    "\n",
     "tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up\n",
     "data_folder = Path(tmp.name)\n",
-    "zenodo_get.zenodo_get([dataset, '-r', 5, '-o', data_folder])  # r: retries"
+    "zenodo_get.download(record='15182376', retry_attempts=5, output_dir=data_folder)"
    ]
   },
   {

--- a/examples/notebooks/qmri_sg_challenge_2024_t1.ipynb
+++ b/examples/notebooks/qmri_sg_challenge_2024_t1.ipynb
@@ -64,11 +64,9 @@
     "\n",
     "import zenodo_get\n",
     "\n",
-    "dataset = '10868350'\n",
-    "\n",
     "tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up\n",
     "data_folder = Path(tmp.name)\n",
-    "zenodo_get.zenodo_get([dataset, '-r', 5, '-o', data_folder])  # r: retries\n",
+    "zenodo_get.download(record='10868350', retry_attempts=5, output_dir=data_folder)\n",
     "with zipfile.ZipFile(data_folder / Path('T1 IR.zip'), 'r') as zip_ref:\n",
     "    zip_ref.extractall(data_folder)"
    ]

--- a/examples/notebooks/qmri_t1_mapping_with_grad_acq.ipynb
+++ b/examples/notebooks/qmri_t1_mapping_with_grad_acq.ipynb
@@ -148,11 +148,9 @@
     "\n",
     "import zenodo_get\n",
     "\n",
-    "dataset = '13207352'\n",
-    "\n",
     "tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up\n",
     "data_folder = Path(tmp.name)\n",
-    "zenodo_get.zenodo_get([dataset, '-r', 5, '-o', data_folder])  # r: retries"
+    "zenodo_get.download(record='13207352', retry_attempts=5, output_dir=data_folder)"
    ]
   },
   {

--- a/examples/notebooks/tv_minimization_reconstruction_pdhg.ipynb
+++ b/examples/notebooks/tv_minimization_reconstruction_pdhg.ipynb
@@ -115,11 +115,9 @@
     "\n",
     "import zenodo_get\n",
     "\n",
-    "dataset = '14617082'\n",
-    "\n",
     "tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up\n",
     "data_folder = Path(tmp.name)\n",
-    "zenodo_get.zenodo_get([dataset, '-r', 5, '-o', data_folder])  # r: retries"
+    "zenodo_get.download(record='14617082', retry_attempts=5, output_dir=data_folder)"
    ]
   },
   {

--- a/examples/scripts/cartesian_reconstruction.py
+++ b/examples/scripts/cartesian_reconstruction.py
@@ -17,11 +17,9 @@ from pathlib import Path
 
 import zenodo_get
 
-dataset = '14173489'
-
 tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up
 data_folder = Path(tmp.name)
-zenodo_get.zenodo_get([dataset, '-r', 5, '-o', data_folder])  # r: retries
+zenodo_get.download(record='14173489', retry_attempts=5, output_dir=data_folder)
 
 # %% [markdown]
 # We have three different scans obtained from the same object with the same FOV and resolution, saved as ISMRMRD

--- a/examples/scripts/comparison_trajectory_calculators.py
+++ b/examples/scripts/comparison_trajectory_calculators.py
@@ -16,11 +16,9 @@ import mrpro
 import torch
 import zenodo_get
 
-dataset = '14617082'
-
 tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up
 data_folder = Path(tmp.name)
-zenodo_get.zenodo_get([dataset, '-r', 5, '-o', data_folder])  # r: retries
+zenodo_get.download(record='14617082', retry_attempts=5, output_dir=data_folder)
 
 # %% [markdown]
 # ### Using KTrajectoryIsmrmrd - Trajectory saved in ISMRMRD file

--- a/examples/scripts/direct_reconstruction.py
+++ b/examples/scripts/direct_reconstruction.py
@@ -24,11 +24,9 @@ from pathlib import Path
 
 import zenodo_get
 
-dataset = '14617082'
-
 tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up
 data_folder = Path(tmp.name)
-zenodo_get.zenodo_get([dataset, '-r', 5, '-o', data_folder])  # r: retries
+zenodo_get.download(record='14617082', retry_attempts=5, output_dir=data_folder)
 
 # %%
 import mrpro

--- a/examples/scripts/iterative_sense_reconstruction_radial2D.py
+++ b/examples/scripts/iterative_sense_reconstruction_radial2D.py
@@ -50,11 +50,9 @@ from pathlib import Path
 
 import zenodo_get
 
-dataset = '14617082'
-
 tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up
 data_folder = Path(tmp.name)
-zenodo_get.zenodo_get([dataset, '-r', 5, '-o', data_folder])  # r: retries
+zenodo_get.download(record='14617082', retry_attempts=5, output_dir=data_folder)
 
 # %%
 import mrpro

--- a/examples/scripts/iterative_sense_reconstruction_with_regularization.py
+++ b/examples/scripts/iterative_sense_reconstruction_with_regularization.py
@@ -10,11 +10,9 @@ from pathlib import Path
 
 import zenodo_get
 
-dataset = '14617082'
-
 tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up
 data_folder = Path(tmp.name)
-zenodo_get.zenodo_get([dataset, '-r', 5, '-o', data_folder])  # r: retries
+zenodo_get.download(record='14617082', retry_attempts=5, output_dir=data_folder)
 
 # %% [markdown]
 # ### Image reconstruction

--- a/examples/scripts/pgd_wavelet_reconstruction.py
+++ b/examples/scripts/pgd_wavelet_reconstruction.py
@@ -86,11 +86,9 @@ from pathlib import Path
 
 import zenodo_get
 
-dataset = '14617082'
-
 tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up
 data_folder = Path(tmp.name)
-zenodo_get.zenodo_get([dataset, '-r', 5, '-o', data_folder])  # r: retries
+zenodo_get.download(record='14617082', retry_attempts=5, output_dir=data_folder)
 
 # %%
 # Load in the data from the ISMRMRD file

--- a/examples/scripts/qmri_cardiac_fingerprinting.py
+++ b/examples/scripts/qmri_cardiac_fingerprinting.py
@@ -43,11 +43,9 @@ from pathlib import Path
 
 import zenodo_get
 
-dataset = '15182376'
-
 tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up
 data_folder = Path(tmp.name)
-zenodo_get.zenodo_get([dataset, '-r', 5, '-o', data_folder])  # r: retries
+zenodo_get.download(record='15182376', retry_attempts=5, output_dir=data_folder)
 
 # %% [markdown]
 # ## Reconstruct qualitative images

--- a/examples/scripts/qmri_sg_challenge_2024_t1.py
+++ b/examples/scripts/qmri_sg_challenge_2024_t1.py
@@ -19,11 +19,9 @@ from pathlib import Path
 
 import zenodo_get
 
-dataset = '10868350'
-
 tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up
 data_folder = Path(tmp.name)
-zenodo_get.zenodo_get([dataset, '-r', 5, '-o', data_folder])  # r: retries
+zenodo_get.download(record='10868350', retry_attempts=5, output_dir=data_folder)
 with zipfile.ZipFile(data_folder / Path('T1 IR.zip'), 'r') as zip_ref:
     zip_ref.extractall(data_folder)
 

--- a/examples/scripts/qmri_t1_mapping_with_grad_acq.py
+++ b/examples/scripts/qmri_t1_mapping_with_grad_acq.py
@@ -61,11 +61,9 @@ from pathlib import Path
 
 import zenodo_get
 
-dataset = '13207352'
-
 tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up
 data_folder = Path(tmp.name)
-zenodo_get.zenodo_get([dataset, '-r', 5, '-o', data_folder])  # r: retries
+zenodo_get.download(record='13207352', retry_attempts=5, output_dir=data_folder)
 # %% [markdown]
 # We will use the following libraries:
 # %%

--- a/examples/scripts/tv_minimization_reconstruction_pdhg.py
+++ b/examples/scripts/tv_minimization_reconstruction_pdhg.py
@@ -58,11 +58,9 @@ from pathlib import Path
 
 import zenodo_get
 
-dataset = '14617082'
-
 tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up
 data_folder = Path(tmp.name)
-zenodo_get.zenodo_get([dataset, '-r', 5, '-o', data_folder])  # r: retries
+zenodo_get.download(record='14617082', retry_attempts=5, output_dir=data_folder)
 
 # %%
 import mrpro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ docs = [
     "sphinx-last-updated-by-git>=0.3, <0.4",
 ]
 notebooks = [
-    "zenodo_get",
+    "zenodo_get>=2.0",
     "ipykernel",
     "ipywidgets",
     "jupytext",


### PR DESCRIPTION
Latest version (2.0) of zenodo_get has large changes in api compared to previous version 1.6 : `zenodo_get` replaced by `download`:

https://github.com/dvolgyes/zenodo_get/commit/1cf0e44c8c41e130f73dc778eb43f821236e180b