### PR TITLE
Change WASABI model: make c scaling parameter

### DIFF
--- a/src/mrpro/operators/models/WASABI.py
+++ b/src/mrpro/operators/models/WASABI.py
@@ -22,6 +22,9 @@ class WASABI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
     ) -> None:
         """Initialize WASABI signal model for mapping of B0 and B1 [SCHU2016]_.
 
+        This model uses a slight modification from the original published model.
+        The parameter `a` corresponds to `d/c` in the original model.
+
         Parameters
         ----------
         offsets
@@ -54,30 +57,32 @@ class WASABI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
         b0_shift: torch.Tensor,
         relative_b1: torch.Tensor,
         c: torch.Tensor,
-        d: torch.Tensor,
+        a: torch.Tensor,
     ) -> tuple[torch.Tensor,]:
-        """Apply WASABI signal model.
+        """Apply the WASABI (Water Shift and B1) signal model.
 
         Parameters
         ----------
         b0_shift
-            B0 shift [Hz]
-            with shape `(*other, coils, z, y, x)`
+            B0 field in homogeneity or off-resonance shift in Hz.
+            Shape `...`, for example `*other, coils, z, y, x` or `samples`.
         relative_b1
-            relative B1 amplitude
-            with shape `(*other, coils, z, y, x)`
+            Relative B1 amplitude scaling factor (actual B1 / nominal B1).
+            Shape `...`, for example `*other, coils, z, y, x` or `samples`.
         c
-            additional fit parameter for the signal model
-            with shape `(*other, coils, z, y, x)`
-        d
-            additional fit parameter for the signal model
-            with shape `(*other, coils, z, y, x)`
+            Signal amplitude parameter (related to M0).
+            Shape `...`, for example `*other, coils, z, y, x` or `samples`.
+        a
+            Signal modulation scaling parameter, corresponds to `d/c` in the original model.
+            Shape `...`, for example `*other, coils, z, y, x` or `samples`.
 
         Returns
         -------
-            signal with shape `(offsets, *other, coils, z, y, x)`
+            Signal calculated for each frequency offset.
+            Shape `offsets ...`. For example `offsets, *other, coils, z, y, x`, or `offsets, samples`
+            where `offsets` is the number of frequency offsets.
         """
-        ndim = max(b0_shift.ndim, relative_b1.ndim, c.ndim, d.ndim)
+        ndim = max(b0_shift.ndim, relative_b1.ndim, c.ndim, a.ndim)
         offsets = unsqueeze_right(self.offsets, ndim - self.offsets.ndim + 1)  # leftmost is offsets
         rf_duration = unsqueeze_right(self.rf_duration, ndim - self.rf_duration.ndim)
         b1_nominal = unsqueeze_right(self.b1_nominal, ndim - self.b1_nominal.ndim)
@@ -85,9 +90,9 @@ class WASABI(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
         offsets_shifted = offsets - b0_shift
         b1 = b1_nominal * relative_b1
 
-        signal = (
-            c
-            - d
+        signal = c * (
+            1
+            - a
             * (torch.pi * b1 * self.gamma * rf_duration) ** 2
             * torch.sinc(rf_duration * torch.sqrt((b1 * self.gamma) ** 2 + offsets_shifted**2)) ** 2
         )

--- a/tests/operators/models/test_wasabi.py
+++ b/tests/operators/models/test_wasabi.py
@@ -18,19 +18,19 @@ def test_WASABI_shift(parameter_shape: Sequence[int] = (2, 5, 10, 10, 10)):
     offsets = torch.linspace(-300, 300, 13)
     relative_b1 = rng.float32_tensor(parameter_shape, low=0.1, high=2)
     c = rng.complex64_tensor(parameter_shape)
-    d = rng.complex64_tensor(parameter_shape)
+    a = rng.complex64_tensor(parameter_shape)
     no_b0_shift = torch.zeros(parameter_shape)
 
     # with no B0 shift and symmetric offsets the signal should be symmetric around the center
     model = WASABI(offsets=offsets)
-    (signal,) = model(no_b0_shift, relative_b1, c, d)
+    (signal,) = model(no_b0_shift, relative_b1, c, a)
     torch.testing.assert_close(signal, torch.flip(signal, dims=(0,)))
     assert signal.isfinite().all()
 
     # with asymmetric offsets the signal should be symmetric around a different center
     offsets_shifted = offsets + 100
     model = WASABI(offsets=offsets_shifted)
-    (signal_offsetsshifted,) = model(no_b0_shift, relative_b1, c, d)
+    (signal_offsetsshifted,) = model(no_b0_shift, relative_b1, c, a)
     lower_index = int((offsets_shifted == -200).nonzero())
     upper_index = int((offsets_shifted == 200).nonzero())
     torch.testing.assert_close(signal_offsetsshifted[lower_index], signal_offsetsshifted[upper_index])
@@ -40,7 +40,7 @@ def test_WASABI_shift(parameter_shape: Sequence[int] = (2, 5, 10, 10, 10)):
     b0_shift = rng.float32_tensor(parameter_shape, low=-100, high=100)
     offsets_b0_shifted = unsqueeze_right(offsets, b0_shift.ndim) + b0_shift
     model = WASABI(offsets=offsets_b0_shifted)
-    (signal_matching_shift,) = model(b0_shift, relative_b1, c, d)
+    (signal_matching_shift,) = model(b0_shift, relative_b1, c, a)
     torch.testing.assert_close(signal, signal_matching_shift)
 
 
@@ -50,15 +50,15 @@ def test_WASABI_scaling(parameter_shape: Sequence[int] = (2, 5, 10, 10, 10)) -> 
     offsets = rng.float32_tensor(13, low=-100, high=100)
     relative_b1 = rng.float32_tensor(parameter_shape, low=0.1, high=2)
     c = rng.complex64_tensor(parameter_shape)
-    d = rng.complex64_tensor(parameter_shape)
+    a = rng.complex64_tensor(parameter_shape)
     b0_shift = rng.float32_tensor(parameter_shape, low=-100, high=100)
     model = WASABI(offsets=offsets)
-    (signal,) = model(b0_shift, relative_b1, c, d)
+    (signal,) = model(b0_shift, relative_b1, c, a)
     assert signal.isfinite().all()
 
-    # WASABI should be linearly scaling with c and d
+    # WASABI should be linearly scaling with c
     scale = rng.complex64_tensor(parameter_shape)
-    (signal_scaled,) = model(b0_shift, relative_b1, c * scale, d * scale)
+    (signal_scaled,) = model(b0_shift, relative_b1, c * scale, a)
     torch.testing.assert_close(scale * signal, signal_scaled)
 
 
@@ -68,10 +68,10 @@ def test_WASABI_extreme_offset(parameter_shape: Sequence[int] = (2, 5, 10, 10, 1
     b0_shift = rng.float32_tensor(parameter_shape, low=-100, high=100)
     relative_b1 = rng.float32_tensor(parameter_shape, low=0.1, high=2)
     c = rng.complex64_tensor(parameter_shape)
-    d = rng.complex64_tensor(parameter_shape)
+    a = rng.complex64_tensor(parameter_shape)
     offset = [500000]
     model = WASABI(offsets=offset)
-    (signal,) = model(b0_shift, relative_b1, c, d)
+    (signal,) = model(b0_shift, relative_b1, c, a)
     # For an extreme offset, the signal should be unattenuated
     torch.testing.assert_close(signal[0], c)
 
@@ -84,9 +84,9 @@ def test_WASABI_shape(parameter_shape: Sequence[int], contrast_dim_shape: Sequen
     b0_shift = rng.float32_tensor(parameter_shape, low=-100, high=100)
     relative_b1 = rng.float32_tensor(parameter_shape, low=0.1, high=2)
     c = rng.complex64_tensor(parameter_shape)
-    d = rng.complex64_tensor(parameter_shape)
+    a = rng.complex64_tensor(parameter_shape)
     model = WASABI(offsets)
-    (signal,) = model(b0_shift, relative_b1, c, d)
+    (signal,) = model(b0_shift, relative_b1, c, a)
     assert signal.shape == signal_shape
     assert signal.isfinite().all()
 
@@ -98,9 +98,9 @@ def test_autodiff_WASABI(parameter_shape: Sequence[int] = (2, 5, 3), contrast_di
     b0_shift = rng.float32_tensor(parameter_shape, low=-100, high=100)
     relative_b1 = rng.float32_tensor(parameter_shape, low=0.1, high=2)
     c = rng.complex64_tensor(parameter_shape)
-    d = rng.complex64_tensor(parameter_shape)
+    a = rng.complex64_tensor(parameter_shape)
     model = WASABI(offsets=offsets)
-    autodiff_test(model, b0_shift, relative_b1, c, d)
+    autodiff_test(model, b0_shift, relative_b1, c, a)
 
 
 @pytest.mark.cuda
@@ -111,24 +111,24 @@ def test_wasabi_cuda(parameter_shape: Sequence[int] = (2, 5, 3), contrast_dim_sh
     b0_shift = rng.float32_tensor(parameter_shape, low=-100, high=100)
     relative_b1 = rng.float32_tensor(parameter_shape, low=0.1, high=2)
     c = rng.complex64_tensor(parameter_shape)
-    d = rng.complex64_tensor(parameter_shape)
+    a = rng.complex64_tensor(parameter_shape)
 
     # Create on CPU, transfer to GPU and run on GPU
     model = WASABI(offset)
     model.cuda()
-    (signal,) = model(b0_shift.cuda(), relative_b1.cuda(), c.cuda(), d.cuda())
+    (signal,) = model(b0_shift.cuda(), relative_b1.cuda(), c.cuda(), a.cuda())
     assert signal.is_cuda
     assert signal.isfinite().all()
 
     # Create on GPU and run on GPU
     model = WASABI(offset.cuda())
-    (signal,) = model(b0_shift.cuda(), relative_b1.cuda(), c.cuda(), d.cuda())
+    (signal,) = model(b0_shift.cuda(), relative_b1.cuda(), c.cuda(), a.cuda())
     assert signal.is_cuda
     assert signal.isfinite().all()
 
     # Create on GPU, transfer to CPU and run on CPU
     model = WASABI(offset.cuda())
     model.cpu()
-    (signal,) = model(b0_shift, relative_b1, c, d)
+    (signal,) = model(b0_shift, relative_b1, c, a)
     assert signal.is_cpu
     assert signal.isfinite().all()


### PR DESCRIPTION
Change the model from
`c-d*something` to` c*(1-a*something)` with` a=d/c`

This makes c a pure scaling parameter (easier for dictionary matching) 