### PR TITLE
Fix random undersampling trajectory generation

### DIFF
--- a/src/mrpro/data/traj_calculators/KTrajectoryCartesian.py
+++ b/src/mrpro/data/traj_calculators/KTrajectoryCartesian.py
@@ -112,20 +112,20 @@ class KTrajectoryCartesian(KTrajectoryCalculator):
         n_keep = min(int(n_k1 / acceleration), n_k1)
         if n_center > n_keep:
             raise ValueError(f'Number of center lines ({n_center}) exceeds number of lines to keep ({n_keep}).')
-
         rng = RandomGenerator(seed)
-        k1_center = n_k1 // 2
-        center_start = k1_center - n_center // 2
-        center_end = center_start + n_center
         k1_idx = rng.gaussian_variable_density_samples(
-            (*n_other, n_keep), low=0, high=n_k1, fwhm=fwhm_ratio * n_k1, always_sample=range(center_start, center_end)
+            (*n_other, n_keep),
+            low=-n_k1 // 2,
+            high=n_k1 // 2,
+            fwhm=fwhm_ratio * n_k1,
+            always_sample=range(-n_center // 2, n_center // 2),
         )
 
         return cls()(
             n_k0=n_k0,
             k0_center=n_k0 // 2,
             k1_idx=k1_idx[..., None, None, :, None],
-            k1_center=k1_center,
+            k1_center=0,
             k2_idx=torch.tensor(0),
             k2_center=0,
         )

--- a/src/mrpro/data/traj_calculators/KTrajectoryCartesian.py
+++ b/src/mrpro/data/traj_calculators/KTrajectoryCartesian.py
@@ -65,9 +65,9 @@ class KTrajectoryCartesian(KTrajectoryCalculator):
         encoding_matrix: SpatialDimension[int] | int,
         acceleration: float = 2.0,
         n_center: int = 10,
-        fwhm_ratio: float = 0.3,
+        fwhm_ratio: float = 1.0,
         n_other: Sequence[int] = (1,),
-        seed: int = 0,
+        seed: int | None = None,
     ) -> KTrajectory:
         """
         Generate k-space Gaussian weighted variable density sampling.

--- a/tests/data/test_traj_calculators.py
+++ b/tests/data/test_traj_calculators.py
@@ -198,14 +198,9 @@ def test_KTrajectoryPulseq(pulseq_example_rad_seq) -> None:
     torch.testing.assert_close(trajectory.ky.to(torch.float32), ky_test.to(torch.float32), atol=1e-2, rtol=1e-3)
 
 
-@pytest.mark.parametrize(
-    'acceleration',
-    [
-        2,
-    ],
-)
-def test_KTrajectoryCartesian_random(acceleration: int, n_k=64) -> None:
+def test_KTrajectoryCartesian_random(acceleration: int = 2, n_k: int = 64) -> None:
     """Test the generation of a 2D gaussian variable density pattern"""
+
     traj = KTrajectoryCartesian.gaussian_variable_density(n_k, acceleration=acceleration, n_other=(2, 3), n_center=8)
 
     assert traj.kx.shape == (1, 1, 1, 1, 1, n_k)


### PR DESCRIPTION
There was an issue in how the sampling probability was used. Basically, the mid-freqency lines where sampled most often (instead of the low frequency lines)

@koflera can you also check if this fixes the issue?
@rkcatarina try this