### PR TITLE
Fix operators' docstring typos 

### DIFF
--- a/src/mrpro/operators/GridSamplingOp.py
+++ b/src/mrpro/operators/GridSamplingOp.py
@@ -193,13 +193,13 @@ class GridSamplingOp(LinearOperator):
         Parameters
         ----------
         grid_z
-            Z-component of sampling grid. Shape `*batchdim, z,y,x`. Values should be in ``[-1, 1.]``. Use `None` for a
+            Z-component of sampling grid. Shape `(*batchdim, z,y,x)`. Values should be in ``[-1, 1.]``. Use `None` for a
             2D interpolation along `y` and `x`.
         grid_y
-            Y-component of sampling grid. Shape `*batchdim, z,y,x` or `*batchdim, y,x` if `grid_z` is `None`.
+            Y-component of sampling grid. Shape `(*batchdim, z,y,x)` or `*batchdim, y,x` if `grid_z` is `None`.
             Values should be in ``[-1, 1.]``.
         grid_x
-            X-component of sampling grid. Shape `*batchdim, z,y,x` or `*batchdim, y,x` if `grid_z` is `None`.
+            X-component of sampling grid. Shape `(*batchdim, z,y,x)` or `*batchdim, y,x` if `grid_z` is `None`.
             Values should be in ``[-1, 1.]``.
         input_shape
             Used in the adjoint. The z, y, x shape of the domain of the operator.

--- a/src/mrpro/operators/Jacobian.py
+++ b/src/mrpro/operators/Jacobian.py
@@ -11,8 +11,8 @@ from mrpro.operators.Operator import Operator
 class Jacobian(LinearOperator):
     """Jacobian of an Operator.
 
-    This operator implements the Jacobian of a (non-linear) operator at a given point `x0` as a LinearOperator,
-    i.e. a linearization of the operator at the point `x0`.
+    This operator implements the Jacobian of a (non-linear) operator at a given point :math:`x_0` as a LinearOperator,
+    i.e. a linearization of the operator at the point :math:`x_0`.
     """
 
     def __init__(self, operator: Operator[torch.Tensor, tuple[torch.Tensor]], *x0: torch.Tensor):
@@ -65,7 +65,7 @@ class Jacobian(LinearOperator):
 
     @property
     def value_at_x0(self) -> tuple[torch.Tensor, ...]:
-        """Evaluation of the operator at the point x0."""
+        """Evaluation of the operator at the point :math:`x_0`."""
         if self._f_x0 is None:
             self._f_x0 = self._operator(*self._x0)
         assert self._f_x0 is not None  # noqa: S101 (hint for mypy)
@@ -74,7 +74,7 @@ class Jacobian(LinearOperator):
     def taylor(self, *x: torch.Tensor) -> tuple[torch.Tensor, ...]:
         """Taylor approximation of the operator.
 
-        Approximate the operator at x by a first order Taylor expansion around x0,
+        Approximate the operator at x by a first order Taylor expansion around :math:`x_0`,
         :math:`f(x_0) + J_f(x_0)(x - x_0)`.
 
         This is not faster than the forward method of the operator itself, as the calculation of the
@@ -98,7 +98,7 @@ class Jacobian(LinearOperator):
     def gauss_newton(self, *x: torch.Tensor) -> tuple[torch.Tensor, ...]:
         """Calculate the Gauss-Newton approximation of the Hessian of the operator.
 
-        Returns J^T J x, where J is the Jacobian of the operator at x0.
+        Returns :math:`J^T J x`, where :math:`J` is the Jacobian of the operator at :math:`x_0`.
         Uses backward and forward automatic differentiation of the operator.
 
         Parameters

--- a/src/mrpro/operators/LinearOperator.py
+++ b/src/mrpro/operators/LinearOperator.py
@@ -52,7 +52,7 @@ class LinearOperator(Operator[torch.Tensor, tuple[torch.Tensor]]):
     """General Linear Operator.
 
     LinearOperators have exactly one input tensors and one output tensor,
-    and fulfill :math:`f(a*x + b*y) = a*f(x) + b*f(y)`
+    and fulfill :math:`f(ax + by) = af(x) + bf(y)`
     with :math:`a`, :math:`b` scalars and :math:`x`, :math:`y` tensors.
 
     LinearOperators can be composed, added, multiplied, applied to tensors.

--- a/src/mrpro/operators/LinearOperatorMatrix.py
+++ b/src/mrpro/operators/LinearOperatorMatrix.py
@@ -184,7 +184,7 @@ class LinearOperatorMatrix(Operator[Unpack[tuple[torch.Tensor, ...]], tuple[torc
     def __mul__(self, other: torch.Tensor | Sequence[torch.Tensor | complex] | complex) -> Self:
         """LinearOperatorMatrix*Tensor multiplication.
 
-        Example: ([A,B]*c)(x) = [A*c, B*c](x) = A(c*x) + B(c*x)
+        Example: :math:`([A,B]c)(x) = [Ac, Bc](x) = A(cx) + B(cx)`
         """
         if isinstance(other, torch.Tensor | complex | float | int):
             other_: Sequence[torch.Tensor | complex] = (other,) * self.shape[1]
@@ -200,7 +200,7 @@ class LinearOperatorMatrix(Operator[Unpack[tuple[torch.Tensor, ...]], tuple[torc
     def __rmul__(self, other: torch.Tensor | Sequence[torch.Tensor] | complex) -> Self:
         """Tensor*LinearOperatorMatrix multiplication.
 
-        Example: (c*[A,B])(x) = [c*A, c*B](x) = c*A(x) + c*B(x)
+        Example: (c[A,B])(x) = [cA, cB](x) = cA(x) + cB(x)
         """
         if isinstance(other, torch.Tensor | complex | float | int):
             other_: Sequence[torch.Tensor | complex] = (other,) * self.shape[0]
@@ -287,9 +287,9 @@ class LinearOperatorMatrix(Operator[Unpack[tuple[torch.Tensor, ...]], tuple[torc
         absolute_tolerance: float = 1e-5,
         callback: Callable[[torch.Tensor], None] | None = None,
     ) -> torch.Tensor:
-        """Upper bound of operator norm of the Matrix.
+        r"""Upper bound of operator norm of the Matrix.
 
-        Uses the bounds :math:`||[A, B]^T|||<=sqrt(||A||^2 + ||B||^2)` and :math:`||[A, B]|||<=max(||A||,||B||)`
+        Uses the bounds :math:`||[A, B]^T||\leq\sqrt{(||A||^2 + ||B||^2)}` and :math:`||[A, B]||\leq\max(||A||,||B||)`
         to estimate the operator norm of the matrix.
         First,  operator_norm is called on each element of the matrix.
         Next, the norm is estimated for each column using the first bound.

--- a/src/mrpro/operators/NonUniformFastFourierOp.py
+++ b/src/mrpro/operators/NonUniformFastFourierOp.py
@@ -28,16 +28,14 @@ class NonUniformFastFourierOp(LinearOperator, adjoint_as_backward=True):
     ) -> None:
         """Initialize Non-Uniform Fast Fourier Operator.
 
-        ```{note}
-        Consider using `~mrpro.operators.FourierOp` instead of this operator. It automatically detects if a non-uniform
-        or regular fast Fourier transformation is required and can also be constructed automatically from
-        a `mrpro.data.KData` object.
-        ````
+        .. note::
+            Consider using `~mrpro.operators.FourierOp` instead of this operator. It automatically detects if a
+            non-uniform or regular fast Fourier transformation is required and can also be constructed automatically
+            from a `mrpro.data.KData` object.
 
-        ```{note}
-        The NUFFT is scaled such that it matches 'orthonormal' FFT scaling for cartesian trajectories.
-        This is different from other packages, which apply scaling based on the size of the oversampled grid.
-        ````
+        .. note::
+            The NUFFT is scaled such that it matches 'orthonormal' FFT scaling for cartesian trajectories.
+            This is different from other packages, which apply scaling based on the size of the oversampled grid.
 
         Parameters
         ----------
@@ -197,12 +195,12 @@ class NonUniformFastFourierOp(LinearOperator, adjoint_as_backward=True):
         Parameters
         ----------
         x
-            Coil image data, typically with shape `(... coils z y x)`.
+            Coil image data, typically with shape `(..., coils, z, y, x)`.
 
         Returns
         -------
             Coil k-space data at non-uniform locations,
-            with shape `(... coils k2 k1 k0)`.
+            with shape `(..., coils, k2, k1, k0)`.
         """
         return super().__call__(x)
 
@@ -246,12 +244,12 @@ class NonUniformFastFourierOp(LinearOperator, adjoint_as_backward=True):
         ----------
         x
             Coil k-space data at non-uniform locations,
-            with shape `(... coils k2 k1 k0)`.
+            with shape `(..., coils, k2, k1, k0)`.
 
         Returns
         -------
             Coil image data on a Cartesian grid,
-            with shape `(... coils z y x)`.
+            with shape `(..., coils, z, y, x)`.
         """
         if len(self._direction_zyx):
             if x.device.type == 'cpu' and self.oversampling not in (0.0, 1.25, 2.0):

--- a/src/mrpro/operators/RearrangeOp.py
+++ b/src/mrpro/operators/RearrangeOp.py
@@ -22,12 +22,12 @@ class RearrangeOp(LinearOperator):
         pattern
             Pattern describing the forward of the operator.
             Also see `einops.rearrange` for more information.
-            Example: "... h w -> ... (w h)"
+            Example: `(... h w) -> (... (w h))`
         additional_info
             Additional information passed to the rearrange function,
             describing the size of certain dimensions.
             Might be required for the adjoint rule.
-            Example: {'h': 2, 'w': 2}
+            Example: `{'h': 2, 'w': 2}`
         """
         super().__init__()
         if (match := re.match('(.+)->(.+)', pattern)) is None:

--- a/src/mrpro/operators/SensitivityOp.py
+++ b/src/mrpro/operators/SensitivityOp.py
@@ -37,11 +37,11 @@ class SensitivityOp(LinearOperator):
         Parameters
         ----------
         img
-            Input image data, typically with shape `... 1 z y x`.
+            Input image data, typically with shape `(... 1 z y x)`.
 
         Returns
         -------
-            Multi-coil image data with shape `... coils z y x`.
+            Multi-coil image data with shape `(... coils z y x)`.
         """
         return super().__call__(img)
 
@@ -64,10 +64,10 @@ class SensitivityOp(LinearOperator):
         Parameters
         ----------
         img
-            Multi-coil image data, typically with shape `... coils z y x`.
+            Multi-coil image data, typically with shape `(... coils z y x)`.
 
         Returns
         -------
-            Combined image data, with shape `... 1 z y x`.
+            Combined image data, with shape `(... 1 z y x)`.
         """
         return ((self.csm_tensor.conj() * img).sum(-4, keepdim=True),)

--- a/src/mrpro/operators/SliceProjectionOp.py
+++ b/src/mrpro/operators/SliceProjectionOp.py
@@ -115,10 +115,11 @@ class SliceProjectionOp(LinearOperator):
         Different settings for different volume batches are NOT supported, consider creating multiple
         operators if required.
 
-        .. note::
-            All parameters must be on cpu when creating the operator. Preparation of the operator on
-            the GPU would be slower than transferring the parameters to the CPU, creation, then transferring
-            the operator back to the GPU.
+        Note
+        ----
+        All parameters must be on cpu when creating the operator. Preparation of the operator on
+        the GPU would be slower than transferring the parameters to the CPU, creation, then transferring
+        the operator back to the GPU.
 
 
         Parameters
@@ -171,7 +172,7 @@ class SliceProjectionOp(LinearOperator):
         if not np.vectorize(_at_least_width_1)(slice_profile_array).all():
             raise ValueError(
                 'The slice profile must have a width of at least 1 voxel,'
-                ' i.e. the profile should be greater then 1e-6 in (-0.5,0.5)'
+                ' i.e. the profile should be greater then 1e-6 in (-0.5, 0.5)'
             )
 
         slice_shift_tensor = cast(torch.Tensor, torch.atleast_1d(torch.as_tensor(slice_shift)))
@@ -227,15 +228,15 @@ class SliceProjectionOp(LinearOperator):
         Parameters
         ----------
         x
-            Input 3D Volume tensor. Expected shape `..., Z, Y, X`,
+            Input 3D Volume tensor. Expected shape `(..., Z, Y, X)`,
             where Z, Y, X match the `input_shape` provided during initialization.
-            `...` represents optional batch dimensions.
+            `(...)` represents optional batch dimensions.
 
         Returns
         -------
             The 2D slice. The shape of the slice will be
-            `..., 1, max_dim, max_dim` where `max_dim` is the maximum of
-            the input Z, Y, X dimensions, and `...` matches input batch dimensions.
+            `(..., 1, max_dim, max_dim)` where `max_dim` is the maximum of
+            the input Z, Y, X dimensions, and `(...)` matches input batch dimensions.
         """
         return super().__call__(x)
 
@@ -274,13 +275,13 @@ class SliceProjectionOp(LinearOperator):
         Parameters
         ----------
         x
-            Input 2D Slice tensor. Expected shape is `..., 1, max_dim, max_dim`,
+            Input 2D Slice tensor. Expected shape is `(..., 1, max_dim, max_dim)`,
             where `max_dim` corresponds to the output slice dimensions from the
-            forward pass. `...` represents optional batch dimensions.
+            forward pass. `(...)` represents optional batch dimensions.
 
         Returns
         -------
-            The 3D Volume. The shape will be `..., Z, Y, X`,
+            The 3D Volume. The shape will be `(..., Z, Y, X)`,
             matching the original `input_shape` of the forward operation.
         """
         match (self.matrix, self.matrix_adjoint):
@@ -376,8 +377,8 @@ class SliceProjectionOp(LinearOperator):
         slice_function
             Function that describes the slice profile. See `mrpro.utils.slice_profiles` for examples.
         rotation_center
-            Center of rotation, if None the center of the volume is used,
-            i.e. for 4 pixels 0 1 2 3 it is between 1 and 2
+            Center of rotation, if `None` the center of the volume is used,
+            i.e. for 4 pixels `[0 1 2 3]` it is between 1 and 2
 
         Returns
         -------

--- a/src/mrpro/operators/WaveletOp.py
+++ b/src/mrpro/operators/WaveletOp.py
@@ -51,7 +51,7 @@ class WaveletOp(LinearOperator):
 
         For complex images the wavelet coefficients are calculated for real and imaginary part separately.
 
-        For a 2D image, the coefficients are labeled [aa, (ad_n, da_n, dd_n), ..., (ad_1, da_1, dd_1)] where a refers
+        For a 2D image, the coefficients are labeled `[aa, (ad_n, da_n, dd_n), ..., (ad_1, da_1, dd_1)]` where a refers
         to the approximation coefficients and d to the detail coefficients. The index indicates the level.
 
         Parameters

--- a/src/mrpro/operators/ZeroOp.py
+++ b/src/mrpro/operators/ZeroOp.py
@@ -22,8 +22,8 @@ class ZeroOp(LinearOperator):
         Parameters
         ----------
         keep_shape
-            If True, the shape of the input is kept.
-            If False, the output is, regardless of the input shape, an integer scalar 0,
+            If `True`, the shape of the input is kept.
+            If `False`, the output is, regardless of the input shape, an integer scalar 0,
             which can broadcast to the input shape and dtype.
         """
         self.keep_shape = keep_shape
@@ -44,7 +44,7 @@ class ZeroOp(LinearOperator):
         Returns
         -------
             A tensor of zeros. This will be `torch.zeros_like(x)`
-            if `keep_shape` is True, or `torch.tensor(0)` if `keep_shape` is False.
+            if `keep_shape` is `True`, or `torch.tensor(0)` if `keep_shape` is `False`.
 
         .. note::
             Prefer calling the instance of the ZeroOp operator as ``operator(x)`` over
@@ -78,7 +78,7 @@ class ZeroOp(LinearOperator):
         Returns
         -------
             A tensor of zeros. This will be `torch.zeros_like(x)`
-            if `keep_shape` is True, or `torch.tensor(0)` if `keep_shape` is False.
+            if `keep_shape` is `True`, or `torch.tensor(0)` if `keep_shape` is `False`.
 
         """
         if self.keep_shape:

--- a/src/mrpro/operators/functionals/L1Norm.py
+++ b/src/mrpro/operators/functionals/L1Norm.py
@@ -9,7 +9,7 @@ class L1Norm(ElementaryProximableFunctional):
     r"""Functional class for the L1 Norm.
 
     This implements the functional given by
-    :math:`f: C^N -> [0, \infty), x ->  \| W (x-b)\|_1`,
+    :math:`f: C^N \rightarrow [0, \infty), x \rightarrow  \| W (x-b)\|_1`,
     where W is a either a scalar or tensor that corresponds to a (block-) diagonal operator
     that is applied to the input.
 
@@ -24,7 +24,7 @@ class L1Norm(ElementaryProximableFunctional):
     ) -> tuple[torch.Tensor]:
         """Compute the L1 norm of the input tensor.
 
-        Calculates `|| W * (x - b) ||_1`, where `W` is `weight` and `b` is `target`.
+        Calculates :math:`|| W * (x - b) ||_1`, where :math:`W` is `weight` and :math:`b` is `target`.
         The norm is computed along dimensions specified by `dim`.
         If `divide_by_n` is true, the result is averaged over these dimensions;
         otherwise, it's summed.

--- a/src/mrpro/operators/functionals/L1NormViewAsReal.py
+++ b/src/mrpro/operators/functionals/L1NormViewAsReal.py
@@ -6,10 +6,10 @@ from mrpro.operators.Functional import ElementaryProximableFunctional
 
 
 class L1NormViewAsReal(ElementaryProximableFunctional):
-    r"""Functional class for the L1 Norm, where C is identified with R^2.
+    r"""Functional class for the L1 Norm, where C is identified with :math:`R^2`.
 
     This implements the functional given by
-    :math:`f: C^N -> [0, \infty), x ->  \|W_r * Re(x-b) )\|_1 + \|( W_i * Im(x-b) )\|_1`,
+    :math:`f: C^N \rightarrow [0, \infty), x \rightarrow \|W_r * \mathrm{Re}(x-b))\|_1 +\|( W_i *\mathrm{Im}(x-b))\|_1`,
     where :math:`W_r` and :math:`W_i` are a either scalars or tensors and `*` denotes element-wise multiplication.
 
     If the parameter `weight` is real-valued, :math:`W_r` and :math:`W_i` are both set to `weight`.
@@ -26,11 +26,11 @@ class L1NormViewAsReal(ElementaryProximableFunctional):
     ) -> tuple[torch.Tensor]:
         r"""Compute the L1 norm, viewing complex numbers as R^2.
 
-        Calculates :math:`\|W_r * Re(x-b)\|_1 + \|W_i * Im(x-b)\|_1`.
-        If `weight` is real, :math:`W_r = W_i = weight`.
-        If `weight` is complex, :math:`W_r = Re(weight)` and :math:`W_i = Im(weight)`.
+        Calculates :math:`\|W_r * \mathrm{Re}(x-b)\|_1 + \|W_i * \mathrm{Im}(x-b)\|_1`.
+        If `weight` is real, :math:`W_r = W_i = \mathrm{weight}`.
+        If `weight` is complex, :math:`W_r = \mathrm{Re}(\mathrm{weight})` and :math:`W_i=\mathrm{Im}(\mathrm{weight})`.
         `b` is `target`. The norm is computed along `dim`.
-        If `divide_by_n` is true, the result is averaged; otherwise, summed.
+        If `divide_by_n` is `True`, the result is averaged; otherwise, summed.
 
         Parameters
         ----------

--- a/src/mrpro/operators/functionals/L2NormSquared.py
+++ b/src/mrpro/operators/functionals/L2NormSquared.py
@@ -9,13 +9,13 @@ class L2NormSquared(ElementaryProximableFunctional):
     r"""Functional class for the squared L2 Norm.
 
     This implements the functional given by
-    :math:`f: C^N -> [0, \infty), x -> \| W (x-b)\|_2^2`,
+    :math:`f: C^N \rightarrow [0, \infty), x \rightarrow \| W (x-b)\|_2^2`,
     where :math:`W` is either a scalar or tensor that corresponds to a (block-) diagonal operator
     that is applied to the input. This is, for example, useful for non-Cartesian MRI
     reconstruction when using a density-compensation function for k-space pre-conditioning,
     for masking of image data, or for spatially varying regularization weights.
 
-    In most cases, consider setting `divide_by_n` to `true` to be independent of input size.
+    In most cases, consider setting `divide_by_n` to `True` to be independent of input size.
     Alternatively, the functional :class:`mrpro.operators.functionals.MSE` can be used.
     The norm is computed along the dimensions given at initialization, all other dimensions are
     considered batch dimensions.
@@ -27,9 +27,9 @@ class L2NormSquared(ElementaryProximableFunctional):
     ) -> tuple[torch.Tensor]:
         r"""Compute the squared L2 norm of the input tensor.
 
-        Calculates :math:`\| W * (x - b) \|_2^2`, where `W` is `weight` and `b` is `target`.
+        Calculates :math:`\| W * (x - b) \|_2^2`, where :math:`W` is `weight` and :math`b` is `target`.
         The squared norm is computed along dimensions specified by `dim`.
-        If `divide_by_n` is true, the result is averaged over these
+        If `divide_by_n` is `True`, the result is averaged over these
         dimensions; otherwise, it's summed.
 
         Parameters
@@ -39,7 +39,7 @@ class L2NormSquared(ElementaryProximableFunctional):
 
         Returns
         -------
-            The squared L2 norm. If `keepdim` is true, the dimensions `dim` are retained
+            The squared L2 norm. If `keepdim` is `True`, the dimensions `dim` are retained
             with size 1; otherwise, they are reduced.
         """
         return super().__call__(x)
@@ -50,8 +50,9 @@ class L2NormSquared(ElementaryProximableFunctional):
     ) -> tuple[torch.Tensor]:
         """Apply forward of L2NormSquared.
 
-        .. note::
-            Prefer calling the instance of the L2NormSquared as ``operator(x)`` over directly calling this method.
+        Note
+        ----
+        Prefer calling the instance of the L2NormSquared as ``operator(x)`` over directly calling this method.
         """
         value = (self.weight * (x - self.target)).abs().square()
 

--- a/src/mrpro/operators/functionals/MSE.py
+++ b/src/mrpro/operators/functionals/MSE.py
@@ -21,9 +21,9 @@ class MSE(L2NormSquared):
         r"""Initialize MSE Functional.
 
         The MSE functional is given by
-        :math:`f: C^N -> [0, \infty), x -> 1/N \| W (x-b)\|_2^2`,
+        :math:`f: C^N \rightarrow [0, \infty), x \rightarrow 1/N \| W (x-b)\|_2^2`,
         where :math:`W` is either a scalar or tensor that corresponds to a (block-) diagonal operator
-        that is applied to the input. The division by `N` can be disabled by setting `divide_by_n` to `false`.
+        that is applied to the input. The division by `N` can be disabled by setting `divide_by_n` to `False`.
         For more details also see :class:`mrpro.operators.functionals.L2NormSquared`.
 
         Parameters
@@ -36,11 +36,10 @@ class MSE(L2NormSquared):
             dimension(s) over which functional is reduced.
             All other dimensions of  `weight ( x - target)` will be treated as batch dimensions.
         divide_by_n
-            if true, the result is scaled by the number of elements of the dimensions index by `dim` in
-            the tensor `weight ( x - target)`. If true, the functional is thus calculated as the mean,
-            else the sum.
+            If `True`, the result is scaled by the number of elements of the dimensions in the
+            tensor `weight ( x - target)` indexed by `dim`. The functional is thus calculated as the mean, else the sum.
         keepdim
-            if true, the dimension(s) of the input indexed by dim are maintained and collapsed to singeltons,
+            If `True`, the dimension(s) of the input indexed by dim are maintained and collapsed to singeltons,
             else they are removed from the result.
 
         """
@@ -52,9 +51,9 @@ class MSE(L2NormSquared):
     ) -> tuple[torch.Tensor]:
         r"""Compute the Mean Squared Error (MSE).
 
-        Calculates :math:`1/N \| W * (x - b) \|_2^2`, where `W` is `weight`,
-        `b` is `target`, and `N` is the number of elements over which the
-        mean is computed (if `divide_by_n` is true at initialization of L2NormSquared).
+        Calculates :math:`1/N \| W * (x - b) \|_2^2`, where :math:`W` is `weight`,
+        :math:`b` is `target`, and `N` is the number of elements over which the
+        mean is computed (if `divide_by_n` is `True` at initialization of L2NormSquared).
         The squared norm is computed along dimensions specified by `dim`.
 
         Parameters
@@ -64,7 +63,7 @@ class MSE(L2NormSquared):
 
         Returns
         -------
-            The MSE. If `keepdim` is true, the dimensions `dim` are retained
+            The MSE. If `keepdim` is `True`, the dimensions `dim` are retained
             with size 1; otherwise, they are reduced.
         """
         return super().__call__(x)
@@ -75,8 +74,9 @@ class MSE(L2NormSquared):
     ) -> tuple[torch.Tensor]:
         """Apply forward of MSE.
 
-        .. note::
-            Prefer calling the instance of the MSE as ``operator(x)`` over directly calling this method.
+        Note
+        ----
+        Prefer calling the instance of the MSE as ``operator(x)`` over directly calling this method.
         """
         # MSE uses the forward implementation of L2NormSquared
         return super().forward(x)

--- a/src/mrpro/operators/functionals/SSIM.py
+++ b/src/mrpro/operators/functionals/SSIM.py
@@ -29,14 +29,14 @@ def ssim3d(
     target
         Ground truth tensor, shape `(... z, y, x)` or broadcastable with prediction.
     prediction
-        Predicted tensor, same shape as target
+        Predicted tensor, same shape as target.
     data_range
-        Value range if the data. If None, the max-to-min per volume of the target will be used.
+        Value range if the data. If `None`, the max-to-min per volume of the target will be used.
     weight
         Weight (or mask) tensor, same shape as target.
-        Only windows with all weight values > 0 (or True) are considered.
+        Only windows with all weight values > 0 (or `True`) are considered.
         Windows will be weighted by the average value of the weight in the window.
-        If None, all windows are considered without weighting.
+        If `None`, all windows are considered without weighting.
     k1
         Constant for SSIM computation. Commonly 0.01.
     k2
@@ -242,8 +242,9 @@ class SSIM(Functional):
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor]:
         """Apply forward of SSIM.
 
-        .. note::
-            Prefer calling the instance of the SSIM as ``operator(x)`` over directly calling this method.
+        Note
+        ----
+        Prefer calling the instance of the SSIM as ``operator(x)`` over directly calling this method.
         """
         ssim = ssim3d(
             self.target.real,

--- a/src/mrpro/operators/functionals/ZeroFunctional.py
+++ b/src/mrpro/operators/functionals/ZeroFunctional.py
@@ -76,7 +76,7 @@ class ZeroFunctional(ElementaryProximableFunctional):
     def prox_convex_conj(self, x: torch.Tensor, sigma: float | torch.Tensor = 1.0) -> tuple[torch.Tensor,]:
         r"""Apply the proximal operator of the convex conjugate of the functional to a tensor.
 
-        The convex conjugate of the zero functional is the indicator function over :math:`C^N \setminus {0}`,
+        The convex conjugate of the zero functional is the indicator function over :math:`C^N \setminus \{0\}`,
         which evaluates to infinity for all values of `x` except zero.
         If ``sigma > 0``, the proximal operator of the scaled convex conjugate is constant zero,
         otherwise it is the identity.

--- a/src/mrpro/operators/models/EPG.py
+++ b/src/mrpro/operators/models/EPG.py
@@ -116,14 +116,14 @@ def rf(state: torch.Tensor, matrix: torch.Tensor) -> torch.Tensor:
     Parameters
     ----------
     state
-        EPG configuration states. Shape `..., 3 (f_plus, f_minus, z), n`
+        EPG configuration states. Shape `(..., 3 (f_plus, f_minus, z), n)`
     matrix
         Rotation matrix describing the mixing of the EPG configuration states due to an RF pulse.
-        Shape `..., 3, 3`
+        Shape `(..., 3, 3)`
 
     Returns
     -------
-        EPG configuration states after RF pulse. Shape `..., 3 (f_plus, f_minus, z), n`
+        EPG configuration states after RF pulse. Shape `(..., 3 (f_plus, f_minus, z), n)`
     """
     return matrix.to(state) @ state
 
@@ -135,12 +135,12 @@ def gradient_dephasing(state: torch.Tensor) -> torch.Tensor:
     Parameters
     ----------
     state
-        EPG configuration states. Shape `..., 3 (f_plus, f_minus, z), n`
+        EPG configuration states. Shape `(..., 3 (f_plus, f_minus, z), n)`
         with n being the number of configuration states > 1
 
     Returns
     -------
-        EPG configuration states after gradient. Shape `..., 3 (f_plus, f_minus, z), n`
+        EPG configuration states after gradient. Shape `(..., 3 (f_plus, f_minus, z), n)`
     """
     zero = state.new_zeros(state.shape[:-2] + (1,))
     f_plus = torch.cat((state[..., 1, 1:2].conj(), state[..., 0, :-1]), dim=-1)
@@ -179,7 +179,7 @@ def relax(states: torch.Tensor, relaxation_matrix: torch.Tensor, t1_recovery: bo
     Parameters
     ----------
     states
-        EPG configuration states. Shape `..., 3 (f_plus, f_minus, z), n`
+        EPG configuration states. Shape `(..., 3 (f_plus, f_minus, z), n)`
     relaxation_matrix
         matrix describing EPG relaxation
     t1_recovery
@@ -188,7 +188,7 @@ def relax(states: torch.Tensor, relaxation_matrix: torch.Tensor, t1_recovery: bo
     Returns
     -------
         EPG configuration states after relaxation and recovery.
-        Shape `..., 3 (f_plus, f_minus, z), n`
+        Shape `(..., 3 (f_plus, f_minus, z), n)`
     """
     relaxation_matrix = relaxation_matrix.to(states)
     states = relaxation_matrix[..., None] * states
@@ -221,7 +221,7 @@ def initial_state(
 
     Returns
     -------
-        Initial EPG state tensor. Shape `*shape, 3 (f_plus, f_minus, z), n`
+        Initial EPG state tensor. Shape `(*shape, 3 (f_plus, f_minus, z), n)`
     """
     if n_states < 2:
         raise ValueError('Number of states should be at least 2.')

--- a/src/mrpro/operators/models/cMRF.py
+++ b/src/mrpro/operators/models/cMRF.py
@@ -23,10 +23,10 @@ class CardiacFingerprinting(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor
         |----------------|----------------|----------------|----------------|----------------
          [INV 30ms][ACQ]           [ACQ]   [T2-prep][ACQ]   [T2-prep][ACQ]  [T2-prep][ACQ]
 
-    .. note::
-
-       This model is on purpose not flexible in all design choices. Instead, consider writing a custom
-       `~mrpro.operators.SignalModel` based on this implementation if you need to simulate a different sequence.
+    Note
+    ----
+    This model is on purpose not flexible in all design choices. Instead, consider writing a custom
+    `~mrpro.operators.SignalModel` based on this implementation if you need to simulate a different sequence.
 
     References
     ----------
@@ -101,13 +101,13 @@ class CardiacFingerprinting(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor
         ----------
         m0
             Steady state magnetization (complex).
-            Shape `...`, for example `*other, coils, z, y, x` or `samples`.
+            Shape `(...)`, for example `(*other, coils, z, y, x)` or `samples`.
         t1
             Longitudinal (T1) relaxation time in seconds.
-            Shape `...`, for example `*other, coils, z, y, x` or `samples`.
+            Shape `(...)`, for example `(*other, coils, z, y, x)` or `samples`.
         t2
             Transversal (T2) relaxation time in seconds.
-            Shape `...`, for example `*other, coils, z, y, x` or `samples`.
+            Shape `(...)`, for example `(*other, coils, z, y, x)` or `samples`.
 
         Returns
         -------
@@ -120,9 +120,10 @@ class CardiacFingerprinting(SignalModel[torch.Tensor, torch.Tensor, torch.Tensor
     def forward(self, m0: torch.Tensor, t1: torch.Tensor, t2: torch.Tensor) -> tuple[torch.Tensor]:
         """Apply forward of CardiacFingerprinting.
 
-        .. note::
-            Prefer calling the instance of the CardiacFingerprinting as ``operator(x)`` over
-            directly calling this method.
+        Note
+        ----
+        Prefer calling the instance of the CardiacFingerprinting as ``operator(x)`` over
+        directly calling this method.
         """
         parameters = Parameters(m0, t1, t2)
         _, signals = self.sequence(parameters, states=20)


### PR DESCRIPTION
Typos corrections for the `mrpro.operators` including the better TeX notations.