### PR TITLE
Fix nans in Inati CSM estimation

### DIFF
--- a/src/mrpro/algorithms/csm/inati.py
+++ b/src/mrpro/algorithms/csm/inati.py
@@ -32,10 +32,13 @@ def inati(
     """
     # After 10 power iterations we will have a very good estimate of the singular vector
     n_power_iterations = 10
+    eps = 1e-8  # for numerical stability
 
     if isinstance(smoothing_width, int):
         smoothing_width = SpatialDimension(
-            z=smoothing_width if coil_img.shape[-3] > 1 else 1, y=smoothing_width, x=smoothing_width
+            z=smoothing_width if coil_img.shape[-3] > 1 else 1,
+            y=smoothing_width,
+            x=smoothing_width,
         )
 
     if any(ks % 2 != 1 for ks in [smoothing_width.z, smoothing_width.y, smoothing_width.x]):
@@ -44,22 +47,33 @@ def inati(
     ks_halved = [ks // 2 for ks in smoothing_width.zyx]
     padded_coil_img = torch.nn.functional.pad(
         coil_img,
-        (ks_halved[-1], ks_halved[-1], ks_halved[-2], ks_halved[-2], ks_halved[-3], ks_halved[-3]),
+        (
+            ks_halved[-1],
+            ks_halved[-1],
+            ks_halved[-2],
+            ks_halved[-2],
+            ks_halved[-3],
+            ks_halved[-3],
+        ),
         mode='replicate',
     )
     # Get the voxels in an ROI defined by the smoothing_width around each voxel leading to shape
     # (z y x coils window=prod(smoothing_width))
     coil_img_roi = sliding_window(padded_coil_img, smoothing_width.zyx, dim=(-3, -2, -1)).flatten(-3)
-    coil_img_cov = einsum(coil_img_roi.conj(), coil_img_roi, '... coils1 window,... coils2 window->... coils1 coils2')
+    coil_img_cov = einsum(
+        coil_img_roi.conj(),
+        coil_img_roi,
+        '... coils1 window,... coils2 window->... coils1 coils2',
+    )
 
     singular_vector = torch.sum(coil_img_roi, dim=-1)  # z y x coils
-    singular_vector /= singular_vector.norm(dim=-1, keepdim=True)
+    singular_vector /= singular_vector.norm(dim=-1, keepdim=True) + eps
     for _ in range(n_power_iterations):
         singular_vector = einsum(coil_img_cov, singular_vector, '... coils1 coils2,... coils2->... coils1')
-        singular_vector /= singular_vector.norm(dim=-1, keepdim=True)
+        singular_vector /= singular_vector.norm(dim=-1, keepdim=True) + eps
 
     singular_value = einsum(coil_img_roi, singular_vector, '... coils window,... coils->... window')
     phase = singular_value.sum(-1)
-    phase /= phase.abs()
+    phase /= phase.abs() + eps
     csm = einsum(singular_vector.conj(), phase, '... coils,...->coils ...')  # coils z y x
     return csm

--- a/src/mrpro/algorithms/csm/inati.py
+++ b/src/mrpro/algorithms/csm/inati.py
@@ -36,9 +36,7 @@ def inati(
 
     if isinstance(smoothing_width, int):
         smoothing_width = SpatialDimension(
-            z=smoothing_width if coil_img.shape[-3] > 1 else 1,
-            y=smoothing_width,
-            x=smoothing_width,
+            z=smoothing_width if coil_img.shape[-3] > 1 else 1, y=smoothing_width, x=smoothing_width
         )
 
     if any(ks % 2 != 1 for ks in [smoothing_width.z, smoothing_width.y, smoothing_width.x]):
@@ -47,14 +45,7 @@ def inati(
     ks_halved = [ks // 2 for ks in smoothing_width.zyx]
     padded_coil_img = torch.nn.functional.pad(
         coil_img,
-        (
-            ks_halved[-1],
-            ks_halved[-1],
-            ks_halved[-2],
-            ks_halved[-2],
-            ks_halved[-3],
-            ks_halved[-3],
-        ),
+        (ks_halved[-1], ks_halved[-1], ks_halved[-2], ks_halved[-2], ks_halved[-3], ks_halved[-3]),
         mode='replicate',
     )
     # Get the voxels in an ROI defined by the smoothing_width around each voxel leading to shape


### PR DESCRIPTION
Really low signal intensity in patches resulted in nans in the estimated CSMs.

Add a small eps to the singular vector calculation.