### PR TITLE
Fix small issues

### DIFF
--- a/src/mrpro/data/CsmData.py
+++ b/src/mrpro/data/CsmData.py
@@ -48,7 +48,7 @@ def get_downsampled_size(
     )
 
 
-class CsmData(QData):
+class CsmData(QData, init=False):
     """Coil sensitivity map class."""
 
     @classmethod

--- a/src/mrpro/data/Dataclass.py
+++ b/src/mrpro/data/Dataclass.py
@@ -823,6 +823,16 @@ class Dataclass:
         new._reduce_repeats_(recurse=True)
         return new
 
+    def stack(self, *others: Self) -> Self:
+        """Stack other along new first dimension.
+
+        Parameters
+        ----------
+        others
+            other instance to stack.
+        """
+        return self[None].concatenate(*[o[None] for o in others], dim=0)
+
     def __eq__(self, other: object) -> bool:
         """Check deep equality of two dataclasses.
 

--- a/src/mrpro/data/Dataclass.py
+++ b/src/mrpro/data/Dataclass.py
@@ -100,6 +100,7 @@ class Dataclass:
         cls,
         no_new_attributes: bool = True,
         auto_reduce_repeats: bool = True,
+        init: bool = True,
         *args,
         **kwargs,
     ) -> None:
@@ -113,7 +114,7 @@ class Dataclass:
             If `True`, try to reduce dimensions only containing repeats to singleton.
             This will be done after init and post_init.
         """
-        dataclasses.dataclass(cls, repr=False, eq=False)  # type: ignore[call-overload]
+        dataclasses.dataclass(cls, repr=False, eq=False, init=init)  # type: ignore[call-overload]
         super().__init_subclass__(**kwargs)
         child_post_init = vars(cls).get('__post_init__')
 

--- a/src/mrpro/data/Dataclass.py
+++ b/src/mrpro/data/Dataclass.py
@@ -41,7 +41,7 @@ class HasConcatenate(Protocol):
         """Concatenate other instances to self."""
 
 
-class InconsistentDeviceError(ValueError):
+class InconsistentDeviceError(RuntimeError):
     """Raised if the devices of different fields differ.
 
     There is no single device that all fields are on, thus

--- a/src/mrpro/operators/models/SaturationRecovery.py
+++ b/src/mrpro/operators/models/SaturationRecovery.py
@@ -11,7 +11,7 @@ from mrpro.utils.reshape import unsqueeze_right
 class SaturationRecovery(SignalModel[torch.Tensor, torch.Tensor]):
     """Signal model for saturation recovery."""
 
-    def __init__(self, saturation_time: float | torch.Tensor | Sequence[int]) -> None:
+    def __init__(self, saturation_time: float | torch.Tensor | Sequence[float]) -> None:
         """Initialize saturation recovery signal model for T1 mapping.
 
         Parameters

--- a/src/mrpro/phantoms/__init__.py
+++ b/src/mrpro/phantoms/__init__.py
@@ -6,6 +6,7 @@ from mrpro.phantoms import brainweb
 from mrpro.phantoms.m4raw import M4RawDataset
 from mrpro.phantoms import mdcnn
 from mrpro.phantoms.fastmri import FastMRIKDataDataset, FastMRIImageDataset
+from mrpro.phantoms import coils
 
 __all__ = [
     "EllipseParameters",
@@ -14,5 +15,6 @@ __all__ = [
     "FastMRIKDataDataset",
     "M4RawDataset",
     "brainweb",
+    "coils",
     "mdcnn"
 ]

--- a/src/mrpro/phantoms/brainweb.py
+++ b/src/mrpro/phantoms/brainweb.py
@@ -4,6 +4,7 @@ import concurrent.futures
 import gzip
 import io
 import re
+import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from os import PathLike
@@ -155,7 +156,7 @@ def augment(
         scale *= 1 + max_random_scaling_factor * rand[3]
         translate = rand[4:6]  # subpixel translation for edge aliasing
         if trim:
-            data = data[trim_indices(data.sum(-1) > 0.1 * data.amax())]
+            data = data[[slice(None), *trim_indices(data.sum(0) > 0.1 * data.amax())]]
 
         data = torchvision.transforms.functional.affine(
             data,
@@ -243,7 +244,7 @@ VALUES_3T_RANDOMIZED: Mapping[TClassNames, BrainwebTissue] = MappingProxyType(
 )
 """Tissue values for 3T with wide randomization ranges."""
 
-DEFAULT_VALUES = {'r1': 0.0, 'm0': 0.0, 'r2': 0.0, 'mask': 0, 'tissueclass': -1}
+DEFAULT_VALUES = {'r1': 0.0, 'm0': 0.0, 'r2': 0.0, 'mask': 0, 'tissueclass': -1, 't1': 10.0, 't2': 0.0}
 """Default values for masked out regions."""
 
 
@@ -274,11 +275,23 @@ def download_brainweb(
     if n_files > 20:
         raise ValueError('Cannot download more than 20 files.')
 
-    def load_file(url: str, timeout: float = 60) -> bytes:
-        """Load url content."""
-        response = requests.get(url, timeout=timeout)
-        response.raise_for_status()
-        return response.content
+    def load_file(
+        url: str,
+        timeout: float = 60,
+        max_retries: int = 3,
+        retry_delay: float = 30,
+    ) -> bytes:
+        """Load url content with retries for network errors."""
+        for attempt in range(max_retries):
+            try:
+                response = requests.get(url, timeout=timeout)
+                response.raise_for_status()
+                return response.content
+            except requests.exceptions.RequestException:
+                if attempt == max_retries - 1:
+                    break
+                time.sleep(retry_delay)
+        raise ConnectionError(f'Failed to download {url} after {max_retries} attempts.')
 
     def unpack(data: bytes, dtype: np.typing.DTypeLike, shape: Sequence[int]) -> np.ndarray:
         """Unpack gzipped data."""
@@ -541,7 +554,11 @@ class BrainwebSlices(torch.utils.data.Dataset):
         folder: str | Path = CACHE_DIR_BRAINWEB,
         what: Sequence[Literal['r1', 'r2', 'm0', 't1', 't2', 'mask', 'tissueclass'] | TClassNames] = ('m0', 'r1', 'r2'),
         parameters: Mapping[TClassNames, BrainwebTissue] = VALUES_3T_RANDOMIZED,
-        orientation: Literal['axial', 'coronal', 'sagittal'] = 'axial',
+        orientation: Literal['axial', 'coronal', 'sagittal'] | Sequence[Literal['axial', 'coronal', 'sagittal']] = (
+            'axial',
+            'coronal',
+            'sagittal',
+        ),
         skip_slices: tuple[tuple[int, int], tuple[int, int], tuple[int, int]] = ((80, 80), (100, 100), (100, 100)),
         step: int = 1,
         slice_preparation: Callable[[torch.Tensor, torch.Generator | None], torch.Tensor] = DEFAULT_AUGMENT_256,
@@ -598,23 +615,36 @@ class BrainwebSlices(torch.utils.data.Dataset):
         self.what = what
         self.mask_values = mask_values
 
+        if isinstance(orientation, str):
+            orientation = [orientation]
+        elif len(orientation) != len(set(orientation)):
+            raise ValueError('Orientations must be unique.')
         try:
-            self._axis = {'axial': 0, 'coronal': 1, 'sagittal': 2}[orientation]
+            self.axes = [{'axial': 0, 'coronal': 1, 'sagittal': 2}[o] for o in orientation]
         except KeyError:
             raise ValueError(f'Invalid axis: {orientation}.') from None
-        self._skip_slices = skip_slices[self._axis]
 
-        files = []
-        ns_slices = [0]
-        for fn in Path(folder).glob('s??.h5'):
-            with h5py.File(fn) as f:
-                n_slices = f['classes'].shape[self._axis] - self._skip_slices[0] - self._skip_slices[1]
-                ns_slices.append(n_slices)
-                files.append(fn)
-        if not files:
+        self.skip_slices = skip_slices
+
+        files_and_axes = []
+        ns_slices = []
+        h5_files = sorted(Path(folder).glob('s??.h5'))
+        if not h5_files:
             raise FileNotFoundError(f'No files found in {folder}.')
-        self._files = tuple(files)
-        self._ns_slices = np.cumsum(ns_slices)
+
+        for axis in self.axes:
+            skip_start, skip_end = self.skip_slices[axis]
+            for fn in h5_files:
+                with h5py.File(fn) as f:
+                    n_slices = f['classes'].shape[axis] - skip_start - skip_end
+                if n_slices > 0:
+                    files_and_axes.append((fn, axis))
+                    ns_slices.append(n_slices)
+        if not files_and_axes:
+            raise FileNotFoundError(f'After skipping {self.skip_slices} slices, no images are left.')
+
+        self._files_and_axes = tuple(files_and_axes)
+        self._ns_slices = np.cumsum([0, *ns_slices])
 
         self.slice_preparation = slice_preparation
 
@@ -633,21 +663,19 @@ class BrainwebSlices(torch.utils.data.Dataset):
         self, index: int
     ) -> dict[Literal['r1', 'r2', 'm0', 't1', 't2', 'mask', 'tissueclass'] | TClassNames, torch.Tensor]:
         """Get a single slice."""
-        if index * self.step >= self._ns_slices[-1]:
+        if index < 0:
+            index = len(self) + index
+        if not 0 <= index < len(self):
             raise IndexError
-        elif index < 0:
-            index = self._ns_slices[-1] + index * self.step
-        else:
-            index = index * self.step
+        index = index * self.step
 
-        file_id = np.searchsorted(self._ns_slices, index, 'right') - 1
-        slice_id = index - self._ns_slices[file_id] + self._skip_slices[0]
+        chunk_id = np.searchsorted(self._ns_slices, index, 'right') - 1
+        file_path, axis = self._files_and_axes[chunk_id]
+        slice_id = index - self._ns_slices[chunk_id] + self.skip_slices[axis][0]
 
-        with h5py.File(self._files[file_id]) as file:
-            where = [slice(self._skip_slices[0], file['classes'].shape[i] - self._skip_slices[1]) for i in range(3)] + [
-                slice(None)
-            ]
-            where[self._axis] = slice_id
+        with h5py.File(file_path) as file:
+            where = [slice(None)] * 3
+            where[axis] = slice_id
             data = torch.as_tensor(np.array(file['classes'][tuple(where)], dtype=np.uint8))
             classnames = tuple(file.attrs['classnames'])
 
@@ -679,9 +707,10 @@ class BrainwebSlices(torch.utils.data.Dataset):
             elif el in classnames:
                 result[el] = data[..., classnames.index(el)]
             elif el == 'mask':
-                result[el] = ~(
+                result[el] = (
                     torch.nn.functional.conv2d((~mask)[None, None].float(), torch.ones(1, 1, 3, 3), padding=1)[0, 0] < 1
                 )
+
             else:
                 raise NotImplementedError(f'what=({el},) is not implemented.')
 

--- a/src/mrpro/phantoms/fastmri.py
+++ b/src/mrpro/phantoms/fastmri.py
@@ -89,7 +89,7 @@ class FastMRIKDataDataset(torch.utils.data.Dataset):
                 n_k0=n_k0,
                 k0_center=n_k0 // 2,
                 k1_idx=info.idx.k1,
-                k1_center=n_k1 // 2,
+                k1_center=first + n_k1 // 2,
                 k2_idx=torch.tensor(0),
                 k2_center=0,
             )
@@ -212,4 +212,4 @@ class FastMRIImageDataset(torch.utils.data.Dataset):
                 img = (img * csm.conj()).sum(dim=0, keepdim=True)
             if self.augment is not None:
                 img = self.augment(img, idx)
-            return rearrange(img, 'coils y x -> 1 coils 1 y x')  # , rearrange(csm, 'coils y x -> 1 coils 1 y x')
+            return rearrange(img, 'coils y x -> 1 coils 1 y x')

--- a/tests/data/test_dataclass.py
+++ b/tests/data/test_dataclass.py
@@ -380,16 +380,32 @@ def test_dataclass_split_invalid() -> None:
         a.split(dim=0, size=-2)
 
 
+def test_dataclass_stack() -> None:
+    """Test stacking of dataclasses."""
+    a = A()
+    b = A()
+    c = A()
+
+    stacked1 = a.stack(b, c)
+    assert stacked1.shape == (1, 10, 20)  # repeats get reduced.
+
+    a.floattensor = torch.ones(10, 20) * 1
+    b.floattensor = torch.ones(10, 20) * 2
+    c.floattensor = torch.ones(10, 20) * 3
+    stacked2 = a.stack(b, c)
+    assert stacked2.shape == (3, 10, 20)  # different values, no reduction.
+
+
 def test_dataclass_concatenate() -> None:
     """Test concatenation of dataclasses."""
     a = A()
     b = A()
     c = A()
-    concatenated = a.concatenate(b, c, dim=0)
-    assert concatenated.shape == (30, 20)
-    assert concatenated.floattensor.shape == (1, 20)  # broadcasted
-    assert concatenated.floattensor2.shape == (30, 1)  # not broadcasted in concatenation dimension
-    assert concatenated.split(dim=0, size=10) == (a, b, c)
+    stacked = a.stack(b, c)
+    assert stacked.shape == (3, 10, 20)
+    assert stacked.floattensor.shape == (1, 10, 20)  # broadcasted
+    assert stacked.floattensor2.shape == (3, 10, 1)  # not broadcasted in concatenation dimension
+    assert stacked.split(dim=0, size=1) == (a, b, c)
 
 
 def test_dataclass_equal() -> None:


### PR DESCRIPTION
- SSIM masking was wrong for 2D data
- Dataclass mixed device error was a ValueError instead of a RuntimeError. The repr expected a RuntimeError.
- FastMRI KData dataset undoes zero-padding. The k1-index logic was wrong.
- Saturation recovery had wrong type hints
- coils where not imported in phantoms
- csmdata had wrong inheritance/typing on init.
- adds "stack" +test to dataclass for stacking along zeroth dim.