### PR TITLE
Remove forced vscode language server setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
     "autoDocstring.docstringFormat": "numpy-notypes",
-    "python.languageServer": "Pylance",
     "python.testing.unittestArgs": [
         "-v",
         "-s",


### PR DESCRIPTION
The setting overwrites the user and machine vscode language server settings.
This makes it for example incompatible with cursor.

If one needs to set this for their python setup (depending on the installed extension), it should be done in the machine vscode settings.