### PR TITLE
Add detach to dataclass

### DIFF
--- a/src/mrpro/data/Dataclass.py
+++ b/src/mrpro/data/Dataclass.py
@@ -524,6 +524,19 @@ class Dataclass:
 
     # endregion Move to device/dtype
 
+    def detach(self) -> Self:
+        """Detach the data from the autograd graph.
+
+        Returns
+        -------
+            A new dataclass with the data detached from the autograd graph.
+            The data is shared between the original and the new object.
+            Use ``detach().clone()`` to create an independent copy.
+        """
+        new = shallowcopy(self)
+        new.apply_(lambda data: data.detach() if isinstance(data, torch.Tensor) else data, recurse=True)
+        return new
+
     # region Properties
     @property
     def device(self) -> torch.device | None:

--- a/tests/data/test_dataclass.py
+++ b/tests/data/test_dataclass.py
@@ -455,3 +455,19 @@ def test_dataclass_shape() -> None:
     a = A()
     assert a.shape == (10, 20)
     assert len(a) == 10
+
+
+def test_dataclass_detach() -> None:
+    """Test detach method of the dataclass."""
+    b = B()
+    original = b.child.floattensor.clone()
+    parameter1 = torch.tensor(2.0, requires_grad=True)
+    parameter2 = torch.tensor(3.0, requires_grad=True)
+    b.child.floattensor = b.child.floattensor * parameter1
+    detached = b.detach()
+    detached.child.floattensor = detached.child.floattensor * parameter2
+    detached.child.floattensor.sum().backward()
+
+    torch.testing.assert_close(b.child.floattensor, original * parameter1 * parameter2, msg='data is not shared.')
+    assert parameter1.grad is None, 'detached after multiplication -> no gradient should be computed'
+    assert parameter2.grad is not None, 'used after the detach -> gradient should be computed'


### PR DESCRIPTION
Somehow this leaked into #819 , but better to have it as a separate PR:

A recursive detach for a dataclass, matching torch.Tensor.detach in behavior.