### PR TITLE
Add missing dependencies

### DIFF
--- a/docker/minimal_requirements.txt
+++ b/docker/minimal_requirements.txt
@@ -11,4 +11,6 @@ scipy==1.12
 ptwt==0.1.8
 tqdm==4.60.0
 typing-extensions==4.12
+platformdirs==4.0
+requests==2.25
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dependencies = [
     "torchvision>=0.18.1",
     "tqdm>=4.60.0",
     "typing-extensions>=4.12",
+    "platformdirs>=4.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dependencies = [
     "tqdm>=4.60.0",
     "typing-extensions>=4.12",
     "platformdirs>=4.0",
+    "requests>=2.25",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
I thought it was a built-in package. Instead, 
in most cases, this was already a dependency of our dependencies -- but not in all cases. 
