### PR TITLE
Add KData to EllipsePhantom 

### DIFF
--- a/src/mrpro/data/traj_calculators/KTrajectoryCartesian.py
+++ b/src/mrpro/data/traj_calculators/KTrajectoryCartesian.py
@@ -67,6 +67,10 @@ class KTrajectoryCartesian(KTrajectoryCalculator):
         ----------
         encoding_matrix
             Encoded K-space size.
+
+        Returns
+        -------
+            Cartesian trajectory.
         """
         return cls()(
             n_k0=encoding_matrix.x,

--- a/src/mrpro/data/traj_calculators/KTrajectoryCartesian.py
+++ b/src/mrpro/data/traj_calculators/KTrajectoryCartesian.py
@@ -60,6 +60,24 @@ class KTrajectoryCartesian(KTrajectoryCalculator):
         return KTrajectory(kz, ky, kx)
 
     @classmethod
+    def fullysampled(cls, encoding_matrix: SpatialDimension[int]) -> KTrajectory:
+        """Generate fully sampled Cartesian trajectory.
+
+        Parameters
+        ----------
+        encoding_matrix
+            Encoded K-space size.
+        """
+        return cls()(
+            n_k0=encoding_matrix.x,
+            k0_center=encoding_matrix.x // 2,
+            k1_idx=torch.arange(encoding_matrix.y)[:, None],
+            k1_center=encoding_matrix.y // 2,
+            k2_idx=torch.arange(encoding_matrix.z)[:, None, None],
+            k2_center=encoding_matrix.z // 2,
+        )
+
+    @classmethod
     def gaussian_variable_density(
         cls,
         encoding_matrix: SpatialDimension[int] | int,

--- a/src/mrpro/phantoms/EllipsePhantom.py
+++ b/src/mrpro/phantoms/EllipsePhantom.py
@@ -47,6 +47,10 @@ class EllipsePhantom:
         kx
             k-space locations in kx (frequency encoding direction).
 
+        Returns
+        -------
+            K-space data.
+
         References
         ----------
         .. [KOA2007] Koay C, Sarlls J, Oezarslan E (2007) Three-dimensional analytical magnetic resonance imaging
@@ -86,6 +90,10 @@ class EllipsePhantom:
         image_dimensions
             Number of voxels in the image.
             This is a 2D simulation, so the output will be of shape `(1 1 1 image_dimensions.y image_dimensions.x)`.
+
+        Returns
+        -------
+            Image representation of phantom
         """
         # Calculate image representation of phantom
         ny, nx = image_dimensions.y, image_dimensions.x
@@ -114,6 +122,10 @@ class EllipsePhantom:
             Trajectory.
         encoding_matrix
             Encoding matrix.
+
+        Returns
+        -------
+            K-space data with header and trajectory.
         """
         if (trajectory.kz != 0).any():
             raise ValueError('Only 2D k-space data is supported')

--- a/src/mrpro/phantoms/EllipsePhantom.py
+++ b/src/mrpro/phantoms/EllipsePhantom.py
@@ -2,10 +2,12 @@
 
 from collections.abc import Sequence
 
-import numpy as np
 import torch
 from einops import repeat
 
+from mrpro.data.KData import KData
+from mrpro.data.KHeader import KHeader
+from mrpro.data.KTrajectory import KTrajectory
 from mrpro.data.SpatialDimension import SpatialDimension
 from mrpro.phantoms.phantom_elements import EllipseParameters
 
@@ -51,17 +53,21 @@ class EllipsePhantom:
            phantom in the Fourier domain. MRM 58(2) https://doi.org/10.1002/mrm.21292
         ..
         """
-        # kx and ky have to be of same shape
-        if kx.shape != ky.shape:
-            raise ValueError(f'shape mismatch between kx {kx.shape} and ky {ky.shape}')
+        # kx and ky should be broadcastable
+        try:
+            shape = torch.broadcast_shapes(kx.shape, ky.shape)
+        except RuntimeError:
+            raise ValueError(f'shape mismatch between kx {kx.shape} and ky {ky.shape}') from None
+        if kx.device != ky.device:
+            raise ValueError(f'device mismatch between kx {kx.device} and ky {ky.device}')
 
-        kdata = torch.zeros_like(kx, dtype=torch.complex64)
+        kdata = torch.zeros(shape, dtype=torch.complex64, device=kx.device)
         for ellipse in self.ellipses:
             arg = torch.sqrt((ellipse.radius_x * 2) ** 2 * kx**2 + (ellipse.radius_y * 2) ** 2 * ky**2)
             arg[arg < 1e-6] = 1e-6  # avoid zeros
 
             cdata = 2 * 2 * ellipse.radius_x * ellipse.radius_y * 0.5 * torch.special.bessel_j1(torch.pi * arg) / arg
-            kdata += (
+            kdata = kdata + (
                 torch.exp(-1j * 2 * torch.pi * (ellipse.center_x * kx + ellipse.center_y * ky))
                 * cdata
                 * ellipse.intensity
@@ -69,7 +75,7 @@ class EllipsePhantom:
 
         # Scale k-space data by factor sqrt(number of points) to ensure correct scaling after FFT with
         # normalization "ortho". See e.g. https://docs.scipy.org/doc/scipy/tutorial/fft.html
-        kdata *= np.sqrt(torch.numel(kdata))
+        kdata = kdata * kdata.numel() ** 0.5
         return kdata
 
     def image_space(self, image_dimensions: SpatialDimension[int]) -> torch.Tensor:
@@ -98,3 +104,26 @@ class EllipsePhantom:
             idata += ellipse.intensity * in_ellipse
 
         return repeat(idata, 'y x->other coils z y x', other=1, coils=1, z=1)
+
+    def kdata(self, trajectory: KTrajectory, encoding_matrix: SpatialDimension[int]) -> KData:
+        """Create k-space data for the phantom.
+
+        Parameters
+        ----------
+        trajectory
+            Trajectory.
+        encoding_matrix
+            Encoding matrix.
+        """
+        if (trajectory.kz != 0).any():
+            raise ValueError('Only 2D k-space data is supported')
+
+        data = self.kspace(trajectory.ky, trajectory.kx)
+        header = KHeader(
+            recon_fov=SpatialDimension(z=0.01, y=1, x=1),
+            encoding_fov=SpatialDimension(z=0.01, y=1, x=1),
+            encoding_matrix=encoding_matrix,
+            recon_matrix=encoding_matrix,
+        )
+        kdata = KData(data=data, header=header, traj=trajectory)
+        return kdata

--- a/tests/data/test_traj_calculators.py
+++ b/tests/data/test_traj_calculators.py
@@ -217,6 +217,18 @@ def test_KTrajectoryCartesian_random(acceleration: int = 2, n_k: int = 64) -> No
         assert center_idx in lines1
 
 
+def test_KTrajectoryCartesian_fullysampled() -> None:
+    """Test the generation of a fully sampled Cartesian trajectory"""
+    traj = KTrajectoryCartesian.fullysampled(SpatialDimension(10, 64, 64))
+    assert traj.kx.shape == (1, 1, 1, 1, 1, 64)
+    assert traj.ky.shape == (1, 1, 1, 1, 64, 1)
+    assert traj.kz.shape == (1, 1, 1, 10, 1, 1)
+    assert len(traj.kx.unique()) == 64
+    assert len(traj.ky.unique()) == 64
+    assert len(traj.kz.unique()) == 10
+    assert traj.kx.diff().unique() == 1
+
+
 @pytest.mark.parametrize('acceleration', [1, 16])
 def test_KTrajectoryCartesian_random_edgecases(acceleration: int, n_k=128) -> None:
     """Test the generation of a 2D gaussian variable density pattern"""
@@ -229,7 +241,7 @@ def test_KTrajectoryCartesian_random_edgecases(acceleration: int, n_k=128) -> No
         assert center_idx in traj.ky.ravel()
 
 
-def test_KTrajectorySpiral():
+def test_KTrajectorySpiral() -> None:
     """Test the generation of a 2D spiral trajectory"""
     trajectory_calculator = KTrajectorySpiral2D()
     trajectory = trajectory_calculator(

--- a/tests/data/test_traj_calculators.py
+++ b/tests/data/test_traj_calculators.py
@@ -220,9 +220,9 @@ def test_KTrajectoryCartesian_random(acceleration: int = 2, n_k: int = 64) -> No
 def test_KTrajectoryCartesian_fullysampled() -> None:
     """Test the generation of a fully sampled Cartesian trajectory"""
     traj = KTrajectoryCartesian.fullysampled(SpatialDimension(10, 64, 64))
-    assert traj.kx.shape == (1, 1, 1, 1, 1, 64)
-    assert traj.ky.shape == (1, 1, 1, 1, 64, 1)
-    assert traj.kz.shape == (1, 1, 1, 10, 1, 1)
+    assert traj.kx.shape == (1, 1, 1, 1, 64)
+    assert traj.ky.shape == (1, 1, 1, 64, 1)
+    assert traj.kz.shape == (1, 1, 10, 1, 1)
     assert len(traj.kx.unique()) == 64
     assert len(traj.ky.unique()) == 64
     assert len(traj.kz.unique()) == 10

--- a/tests/phantoms/test_ellipse_phantom.py
+++ b/tests/phantoms/test_ellipse_phantom.py
@@ -47,7 +47,7 @@ def test_kspace_image_match(ellipse_phantom: EllipsePhantomTestData) -> None:
     assert relative_image_difference(reconstructed_img, img[0, 0, 0]) <= 0.05
 
 
-def test_kspace_fullysampled(ellipse_phantom: EllipsePhantomTestData) -> None:
+def test_kdata_fullysampled(ellipse_phantom: EllipsePhantomTestData) -> None:
     """Check if kspace has correct shape."""
     matrix = SpatialDimension(z=1, y=ellipse_phantom.n_y, x=ellipse_phantom.n_x)
     traj = KTrajectoryCartesian.fullysampled(matrix)

--- a/tests/phantoms/test_ellipse_phantom.py
+++ b/tests/phantoms/test_ellipse_phantom.py
@@ -3,25 +3,27 @@
 import pytest
 import torch
 from mrpro.data import SpatialDimension
-from mrpro.operators import FastFourierOp
+from mrpro.data.traj_calculators import KTrajectoryCartesian
+from mrpro.operators import FastFourierOp, FourierOp
 
 from tests import relative_image_difference
+from tests.phantoms import EllipsePhantomTestData
 
 
-def test_image_space(ellipse_phantom):
+def test_image_space(ellipse_phantom: EllipsePhantomTestData) -> None:
     """Check if image space has correct shape."""
     img_dimension = SpatialDimension(z=1, y=ellipse_phantom.n_y, x=ellipse_phantom.n_x)
     img = ellipse_phantom.phantom.image_space(img_dimension)
     assert img.shape[-2:] == (ellipse_phantom.n_y, ellipse_phantom.n_x)
 
 
-def test_kspace_correct_shape(ellipse_phantom):
+def test_kspace_correct_shape(ellipse_phantom: EllipsePhantomTestData) -> None:
     """Check if kspace has correct shape."""
     kdata = ellipse_phantom.phantom.kspace(ellipse_phantom.ky, ellipse_phantom.kx)
     assert kdata.shape == (ellipse_phantom.n_y, ellipse_phantom.n_x)
 
 
-def test_kspace_raises_error(ellipse_phantom):
+def test_kspace_raises_error(ellipse_phantom: EllipsePhantomTestData) -> None:
     """Check if kspace raises error if kx and ky have different shapes."""
     [kx_, _] = torch.meshgrid(
         torch.linspace(-ellipse_phantom.n_x // 2, ellipse_phantom.n_x // 2, ellipse_phantom.n_x + 1),
@@ -32,7 +34,7 @@ def test_kspace_raises_error(ellipse_phantom):
         ellipse_phantom.phantom.kspace(ellipse_phantom.ky, kx_)
 
 
-def test_kspace_image_match(ellipse_phantom):
+def test_kspace_image_match(ellipse_phantom: EllipsePhantomTestData) -> None:
     """Check if fft of kspace matches image."""
     img_dimension = SpatialDimension(z=1, y=ellipse_phantom.n_y, x=ellipse_phantom.n_x)
     img = ellipse_phantom.phantom.image_space(img_dimension)
@@ -42,4 +44,15 @@ def test_kspace_image_match(ellipse_phantom):
     # Due to discretization artifacts the reconstructed image will be different to the reference image. Using standard
     # testing functions such as numpy.testing.assert_almost_equal fails because there are few voxels with high
     # differences along the edges of the elliptic objects.
-    assert relative_image_difference(reconstructed_img, img[0, 0, 0, :, :]) <= 0.05
+    assert relative_image_difference(reconstructed_img, img[0, 0, 0]) <= 0.05
+
+
+def test_kspace_fullysampled(ellipse_phantom: EllipsePhantomTestData) -> None:
+    """Check if kspace has correct shape."""
+    matrix = SpatialDimension(z=1, y=ellipse_phantom.n_y, x=ellipse_phantom.n_x)
+    traj = KTrajectoryCartesian.fullysampled(matrix)
+    kdata = ellipse_phantom.phantom.kdata(traj, matrix)
+    fourier_op = FourierOp.from_kdata(kdata)
+    (reconstructed_img,) = fourier_op.adjoint(kdata.data)
+    img = ellipse_phantom.phantom.image_space(matrix)
+    assert relative_image_difference(reconstructed_img[0, 0, 0], img[0, 0, 0]) <= 0.05

--- a/tests/phantoms/test_ellipse_phantom.py
+++ b/tests/phantoms/test_ellipse_phantom.py
@@ -48,7 +48,7 @@ def test_kspace_image_match(ellipse_phantom: EllipsePhantomTestData) -> None:
 
 
 def test_kdata_fullysampled(ellipse_phantom: EllipsePhantomTestData) -> None:
-    """Check if kspace has correct shape."""
+    """Check if kdata object is created and can be reconstructed."""
     matrix = SpatialDimension(z=1, y=ellipse_phantom.n_y, x=ellipse_phantom.n_x)
     traj = KTrajectoryCartesian.fullysampled(matrix)
     kdata = ellipse_phantom.phantom.kdata(traj, matrix)


### PR DESCRIPTION
Add creation of KData in Ellipse phantom
Add `fullysampled` class method in `KTrajectoryCartesian` to generate fully sampled Cartesian trajectories.


This is now an easy way to genrate a KData object to test something without requieing any data on my too-small-hdd...
