### PR TITLE
Limit ptwt version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
     "pytorch-finufft>=0.1.0",
     "cufinufft==2.3.1; platform_system=='Linux'",
     "scipy>=1.12",
-    "ptwt>=0.1.8",
+    "ptwt>=0.1.8, <1.0",
     "torchvision>=0.18.1",
     "tqdm>=4.60.0",
     "typing-extensions>=4.12",


### PR DESCRIPTION
The 1.0 version (relased on Friday) of ptwt seems to be incompatible with our code.
We will need to fix this at some point, for now, I would limit our compatibility to <1.0 to unbreak tests.