### PR TITLE
Unpin cufinufft version

### DIFF
--- a/docker/minimal_requirements.txt
+++ b/docker/minimal_requirements.txt
@@ -5,7 +5,7 @@ ismrmrd==1.14.1
 einops==0.7.0
 pydicom==3.0.1
 pypulseq==1.4.2
-pytorch-finufft==0.1.0
+pytorch-finufft==2.4.1
 cufinufft==2.3.1
 scipy==1.12
 ptwt==0.1.8

--- a/docker/minimal_requirements.txt
+++ b/docker/minimal_requirements.txt
@@ -5,7 +5,7 @@ ismrmrd==1.14.1
 einops==0.7.0
 pydicom==3.0.1
 pypulseq==1.4.2
-pytorch-finufft==2.4.1
+pytorch-finufft==0.1.0
 cufinufft==2.3.1
 scipy==1.12
 ptwt==0.1.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "pydicom>=3.0.1",
     "pypulseq>=1.4.2",
     "pytorch-finufft>=0.1.0",
-    "cufinufft==2.3.1; platform_system=='Linux'",
+    "cufinufft>=2.4.1; platform_system=='Linux'",
     "scipy>=1.12",
     "ptwt>=0.1.8, <1.0",
     "torchvision>=0.18.1",


### PR DESCRIPTION
With a new release cufinufft

https://github.com/flatironinstitute/finufft/releases/tag/v2.4.1

we don't need to pin the cufinufft version 2.3.1 for CI (see #849)
