### PR TITLE
Add SymmetrizedGradientOp and TGV image reconstruction demonstration

### DIFF
--- a/examples/notebooks/tgv_minimization_reconstruction_pdhg.ipynb
+++ b/examples/notebooks/tgv_minimization_reconstruction_pdhg.ipynb
@@ -1,0 +1,499 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {
+    "lines_to_next_cell": 0
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PTB-MR/mrpro/blob/main/examples/notebooks/tgv_minimization_reconstruction_pdhg.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import importlib\n",
+    "\n",
+    "if not importlib.util.find_spec('mrpro'):\n",
+    "    %pip install mrpro[notebooks]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "# Total-generalized-variation (TGV)-minimization reconstruction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "### Image reconstruction\n",
+    "Here, we use the Primal Dual Hybrid Gradient (PDHG) algorithm to reconstruct an image from 2D radial k-space data.\n",
+    "\n",
+    "Let $y$ denote the k-space data of the image $x_{\\mathrm{true}}$ sampled with an acquisition model $A$\n",
+    "(Fourier transform, coil sensitivity maps, ...), i.e the forward problem is given as\n",
+    "\n",
+    "$ y = Ax_{\\mathrm{true}} + n, $\n",
+    "\n",
+    "where $n$ describes complex Gaussian noise. When using TGV-minimization as regularization method, an approximation of\n",
+    "$x_{\\mathrm{true}}$ is obtained by minimizing the following functional $\\mathcal{F}$\n",
+    "\n",
+    "$$\n",
+    "\\mathcal{F}(x, v) = \\frac{1}{2}||Ax - y||_2^2\n",
+    "+ \\lambda_1 \\| \\nabla x - v \\|_1\n",
+    "+ \\lambda_0 \\| \\mathcal{E} v \\|_1, \\quad \\quad \\quad (1)\n",
+    "$$\n",
+    "\n",
+    "where $\\nabla$ is the discretized gradient operator and $\\mathcal{E}$ is the discretized\n",
+    "symmetrized gradient operator.\n",
+    "\n",
+    "The minimization of the functional $\\mathcal{F}$ is a non-trivial task due to the presence of the operator\n",
+    "$\\nabla$ in the non-differentiable $\\ell_1$-norm. A suitable algorithm to solve the problem is the\n",
+    "PDHG-algorithm [[Chambolle \\& Pock, JMIV 2011](https://doi.org/10.1007%2Fs10851-010-0251-1)].\\\n",
+    "PDHG is a method for solving problems of the form\n",
+    "\n",
+    "$$\n",
+    "\\min_{x, v} f(K(x, v)) + g(x, v)  \\quad \\quad \\quad (2)\n",
+    "$$\n",
+    "\n",
+    "where $f$ and $g$ denote proper, convex, lower-semicontinous functionals and $K$ denotes a linear operator.\\\n",
+    "PDHG essentially consists of three steps, which read as\n",
+    "\n",
+    "$z_{k+1} = \\mathrm{prox}_{\\sigma f^{\\ast}}(z_k + \\sigma K \\bar{x}_k)$\n",
+    "\n",
+    "$x_{k+1} = \\mathrm{prox}_{\\tau g}(x_k - \\tau K^H z_{k+1})$\n",
+    "\n",
+    "$\\bar{x}_{k+1} = x_{k+1} + \\theta(x_{k+1} - x_k)$,\n",
+    "\n",
+    "where $\\mathrm{prox}$ denotes the proximal operator and $f^{\\ast}$ denotes the convex conjugate of the\n",
+    "functional $f$, $\\theta\\in [0,1]$ and step sizes $\\sigma, \\tau$ such that $\\sigma \\tau < 1/L^2$, where\n",
+    "$L=\\|K\\|_2$ is the operator norm of the operator $K$.\n",
+    "\n",
+    "The first step is to recast problem (1) into the general form of (2) and then to apply the steps above\n",
+    "in an iterative fashion. In the following, we use this approach to reconstruct a 2D radial image using\n",
+    "`~mrpro.algorithms.optimizers.pdhg`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "### Load data\n",
+    "Our example data contains three scans acquired with a 2D golden angle radial trajectory and\n",
+    "varying number of spokes:\n",
+    "\n",
+    "- ``radial2D_24spokes_golden_angle_with_traj.h5``\n",
+    "- ``radial2D_96spokes_golden_angle_with_traj.h5``\n",
+    "- ``radial2D_402spokes_golden_angle_with_traj.h5``\n",
+    "\n",
+    "We will use the 402 spokes as a reference and try to reconstruct the image from the 24 spokes data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {
+    "mystnb": {
+     "code_prompt_show": "Show download details"
+    },
+    "tags": [
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Download raw data from Zenodo\n",
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import zenodo_get\n",
+    "\n",
+    "tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up\n",
+    "data_folder = Path(tmp.name)\n",
+    "zenodo_get.download(record='14617082', retry_attempts=5, output_dir=data_folder)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mrpro\n",
+    "\n",
+    "# We have embedded the trajectory information in the ISMRMRD files.\n",
+    "kdata_402spokes = mrpro.data.KData.from_file(\n",
+    "    data_folder / 'radial2D_402spokes_golden_angle_with_traj.h5', mrpro.data.traj_calculators.KTrajectoryIsmrmrd()\n",
+    ")\n",
+    "kdata_24spokes = mrpro.data.KData.from_file(\n",
+    "    data_folder / 'radial2D_24spokes_golden_angle_with_traj.h5', mrpro.data.traj_calculators.KTrajectoryIsmrmrd()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "### Comparison reconstructions\n",
+    "Before running the TGV-minimization reconstruction, we first run a direct (adjoint) reconstruction\n",
+    "using `~mrpro.algorithms.reconstruction.DirectReconstruction` (see <project:direct_reconstruction.ipynb>)\n",
+    "of both the 24 spokes and 402 spokes data to have a reference for comparison."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "direct_reconstruction_402 = mrpro.algorithms.reconstruction.DirectReconstruction(kdata_402spokes)\n",
+    "direct_reconstruction_24 = mrpro.algorithms.reconstruction.DirectReconstruction(kdata_24spokes)\n",
+    "img_direct_402 = direct_reconstruction_402(kdata_402spokes)\n",
+    "img_direct_24 = direct_reconstruction_24(kdata_24spokes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "We also run an iterative SENSE reconstruction (see <project:iterative_sense_reconstruction_radial2D.ipynb>) with early\n",
+    "stopping of the 24 spokes data. We use it as a comparison and as an initial guess for the TGV-minimization\n",
+    "reconstruction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sense_reconstruction = mrpro.algorithms.reconstruction.IterativeSENSEReconstruction(\n",
+    "    kdata_24spokes,\n",
+    "    n_iterations=8,\n",
+    "    csm=direct_reconstruction_24.csm,\n",
+    "    dcf=direct_reconstruction_24.dcf,\n",
+    ")\n",
+    "img_sense_24 = sense_reconstruction(kdata_24spokes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "### Set up the operator $A$\n",
+    "Now, to set up the problem, we need to define the acquisition operator $A$, consisting of a\n",
+    "`~mrpro.operators.FourierOp` and a `~mrpro.operators.SensitivityOp`, which applies the coil sensitivity maps\n",
+    "(CSM) to the image. We reuse the CSMs estimated in the direct reconstruction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fourier_operator = mrpro.operators.FourierOp.from_kdata(kdata_24spokes)\n",
+    "\n",
+    "assert direct_reconstruction_24.csm is not None\n",
+    "csm_operator = direct_reconstruction_24.csm.as_operator()\n",
+    "\n",
+    "# The acquisition operator is the composition of the Fourier operator and the CSM operator\n",
+    "acquisition_operator = fourier_operator @ csm_operator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "### Recast the problem to be able to apply PDHG\n",
+    "To apply the PDHG algorithm, we need to recast the problem into the form of (2). We need to identify\n",
+    "the functionals $f$ and $g$ and the operator $K$. We chose an identification for which both\n",
+    "$\\mathrm{prox}_{\\sigma f^{\\ast}}$ and $\\mathrm{prox}_{\\tau g}$ are easy to compute:\n",
+    "\n",
+    "#### $f(z) = f(p,q,r) = f_1(p) + f_2(q) + f_3(r) = \\frac{1}{2}\\|p - y\\|_2^2 + \\lambda_1 \\|q\\|_1 + \\lambda_0 \\|r\\|_1.$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "regularization_lambda_1 = 0.2\n",
+    "regularization_lambda_0 = 0.4\n",
+    "f_1 = 0.5 * mrpro.operators.functionals.L2NormSquared(target=kdata_24spokes.data, divide_by_n=True)\n",
+    "f_2 = regularization_lambda_1 * mrpro.operators.functionals.L1NormViewAsReal(divide_by_n=True)\n",
+    "f_3 = regularization_lambda_0 * mrpro.operators.functionals.L1NormViewAsReal(divide_by_n=True)\n",
+    "f = mrpro.operators.ProximableFunctionalSeparableSum(f_1, f_2, f_3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15",
+   "metadata": {},
+   "source": [
+    "#### $K = [[A, 0], [\\nabla, -I], [0, \\mathcal{E}]]^{\\top}$\n",
+    "\n",
+    "$$\n",
+    "K(x,v) \\;=\\;\n",
+    "\\begin{bmatrix}\n",
+    "A & 0\\\\\n",
+    "\\nabla & -I\\\\\n",
+    "0 & \\mathcal{E}\n",
+    "\\end{bmatrix}\n",
+    "\\begin{bmatrix}\n",
+    "x\\\\ v\n",
+    "\\end{bmatrix}\n",
+    "\\;=\\;\n",
+    "\\begin{bmatrix}\n",
+    "Ax\\\\\n",
+    "\\nabla x - v\\\\\n",
+    "\\mathcal{E}v\n",
+    "\\end{bmatrix}\n",
+    "$$\n",
+    "\n",
+    "  where $\\nabla$ is the finite difference operator that computes the directional derivatives along the last two\n",
+    "  dimensions (y,x), implemented as `~mrpro.operators.FiniteDifferenceOp`, and\n",
+    "  $\\mathcal{E}$ is the corresponding symmetrized gradient operator implemented as\n",
+    "  `~mrpro.operators.SymmetrizedGradientOp`\n",
+    "\n",
+    "$$\n",
+    "\\mathcal{E}v \\;=\\; \\tfrac12\\,(\\nabla v + (\\nabla v)^{\\top})\n",
+    "$$\n",
+    "\n",
+    " `~mrpro.operators.LinearOperatorMatrix` can be used to stack the operators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Directions along which to compute the finite differences\n",
+    "dim = (-2, -1)\n",
+    "\n",
+    "# Define the operator matrix K\n",
+    "# 1. First row [A, 0] (corresponding to the L2-norm data term): Ax + 0\n",
+    "data_term_row = (acquisition_operator, mrpro.operators.ZeroOp())\n",
+    "\n",
+    "# 2. Second row [\\nabla, -I] (corresponding to the first L1-norm regularization term): \\nabla x - v\n",
+    "# Reduce the number of dimensions of the image by one before applying the finite difference operator\n",
+    "# to make the output of the finite difference operator match the auxiliary tensor v.\n",
+    "squeeze_op = mrpro.operators.RearrangeOp('1 ... -> ...')\n",
+    "forward_nabla = mrpro.operators.FiniteDifferenceOp(dim=dim, mode='forward')\n",
+    "grad_term_row = (forward_nabla @ squeeze_op, -1 * mrpro.operators.IdentityOp())\n",
+    "\n",
+    "# 3. Third row [0, \\mathcal{E}] (corresponding to the second L1-norm regularization term): 0 + \\mathcal{E} v\n",
+    "symmetric_gradient_op = mrpro.operators.SymmetrizedGradientOp(dim=dim, mode='backward')\n",
+    "sym_grad_term_row = (mrpro.operators.ZeroOp(), symmetric_gradient_op)\n",
+    "\n",
+    "K = mrpro.operators.LinearOperatorMatrix((data_term_row, grad_term_row, sym_grad_term_row))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
+   "metadata": {},
+   "source": [
+    "#### $g(x, v) = 0,$\n",
+    "\n",
+    "implemented as `~mrpro.operators.functionals.ZeroFunctional`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "g = ProximableFunctionalSeparableSum = mrpro.operators.ProximableFunctionalSeparableSum(\n",
+    "    *(mrpro.operators.functionals.ZeroFunctional(),) * 2\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19",
+   "metadata": {},
+   "source": [
+    "### Run PDHG for a certain number of iterations\n",
+    "Now we can run the PDHG algorithm to solve the minimization problem. We use\n",
+    "the iterative SENSE image as an initial value to speed up the convergence.\n",
+    "```{note}\n",
+    "We can use the `callback` parameter of `~mrpro.algorithms.optimizers` to get some information\n",
+    "about the progress. In the collapsed cell, we implement a simple callback function that print the status\n",
+    "message\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20",
+   "metadata": {
+    "mystnb": {
+     "code_prompt_show": "Show callback details"
+    },
+    "tags": [
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# This is a \"callback\" function that will be called after each iteration of the PDHG algorithm.\n",
+    "# We use it here to print progress information.\n",
+    "\n",
+    "from mrpro.algorithms.optimizers.pdhg import PDHGStatus\n",
+    "\n",
+    "\n",
+    "def callback(optimizer_status: PDHGStatus) -> None:\n",
+    "    \"\"\"Print the value of the objective functional every 16th iteration.\"\"\"\n",
+    "    iteration = optimizer_status['iteration_number']\n",
+    "    solution = optimizer_status['solution']\n",
+    "    if iteration % 16 == 0:\n",
+    "        print(f'Iteration {iteration: >3}: Objective = {optimizer_status[\"objective\"](*solution).item():.3e}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Auxiliary tensor v which is in the gradient domain.\n",
+    "auxiliary_v_tensor = img_sense_24.data.new_zeros((len(dim), *img_sense_24.shape))\n",
+    "# Increase the number of dimensions of initial image by one.\n",
+    "# Must make the number of dimensions of the elements in initial values list match one another,\n",
+    "# because (currently) pdhg function concatenates the individual norms of each operator\n",
+    "# in a matrix's row and the norm has the same shape as the input.\n",
+    "# If the number of dimensions don't match, we get a runtime error like this:\n",
+    "#   RuntimeError: stack expects each tensor to be equal size, but got ... at entry 0 and ... at entry 1\n",
+    "initial_image = img_sense_24.data.unsqueeze(0)\n",
+    "\n",
+    "(img_pdhg_24, _) = mrpro.algorithms.optimizers.pdhg(\n",
+    "    f=f,\n",
+    "    g=g,\n",
+    "    operator=K,\n",
+    "    initial_values=(initial_image, auxiliary_v_tensor),\n",
+    "    max_iterations=257,\n",
+    "    callback=callback,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22",
+   "metadata": {},
+   "source": [
+    "### Compare the results\n",
+    "We now compare the results of the direct reconstruction, the iterative SENSE reconstruction, and the TGV-minimization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23",
+   "metadata": {
+    "mystnb": {
+     "code_prompt_show": "Show plotting details"
+    },
+    "tags": [
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import torch\n",
+    "\n",
+    "\n",
+    "def show_images(*images: torch.Tensor, titles: list[str] | None = None) -> None:\n",
+    "    \"\"\"Plot images.\"\"\"\n",
+    "    n_images = len(images)\n",
+    "    _, axes = plt.subplots(1, n_images, squeeze=False, figsize=(n_images * 3, 3))\n",
+    "    for i in range(n_images):\n",
+    "        axes[0][i].imshow(images[i], cmap='gray')\n",
+    "        axes[0][i].axis('off')\n",
+    "        if titles:\n",
+    "            axes[0][i].set_title(titles[i])\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# see the collapsed cell above for the implementation of show_images\n",
+    "show_images(\n",
+    "    img_direct_402.rss().squeeze(),\n",
+    "    img_direct_24.rss().squeeze(),\n",
+    "    img_sense_24.rss().squeeze(),\n",
+    "    img_pdhg_24.abs().squeeze(),\n",
+    "    titles=['402 spokes', '24 spokes (direct)', '24 spokes (SENSE)', '24 spokes (PDHG)'],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25",
+   "metadata": {},
+   "source": [
+    "Hurrah! We have successfully reconstructed an image from 24 spokes using TGV-minimization.\n",
+    "\n",
+    "### Next steps\n",
+    "Play around with the regularization weight and the number of iterations to see how they affect the final image.\n",
+    "You can also try to use the 96 spokes data to see how the reconstruction quality improves with more spokes."
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "T4",
+   "provenance": []
+  },
+  "jupytext": {
+   "cell_metadata_filter": "mystnb,tags,-all"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/scripts/tgv_minimization_reconstruction_pdhg.py
+++ b/examples/scripts/tgv_minimization_reconstruction_pdhg.py
@@ -1,0 +1,286 @@
+# %% [markdown]
+# # Total-generalized-variation (TGV)-minimization reconstruction
+
+# %% [markdown]
+# ### Image reconstruction
+# Here, we use the Primal Dual Hybrid Gradient (PDHG) algorithm to reconstruct an image from 2D radial k-space data.
+#
+# Let $y$ denote the k-space data of the image $x_{\mathrm{true}}$ sampled with an acquisition model $A$
+# (Fourier transform, coil sensitivity maps, ...), i.e the forward problem is given as
+#
+# $ y = Ax_{\mathrm{true}} + n, $
+#
+# where $n$ describes complex Gaussian noise. When using TGV-minimization as regularization method, an approximation of
+# $x_{\mathrm{true}}$ is obtained by minimizing the following functional $\mathcal{F}$
+#
+# $$
+# \mathcal{F}(x, v) = \frac{1}{2}||Ax - y||_2^2
+# + \lambda_1 \| \nabla x - v \|_1
+# + \lambda_0 \| \mathcal{E} v \|_1, \quad \quad \quad (1)
+# $$
+#
+# where $\nabla$ is the discretized gradient operator and $\mathcal{E}$ is the discretized
+# symmetrized gradient operator.
+#
+# The minimization of the functional $\mathcal{F}$ is a non-trivial task due to the presence of the operator
+# $\nabla$ in the non-differentiable $\ell_1$-norm. A suitable algorithm to solve the problem is the
+# PDHG-algorithm [[Chambolle \& Pock, JMIV 2011](https://doi.org/10.1007%2Fs10851-010-0251-1)].\
+# PDHG is a method for solving problems of the form
+#
+# $$
+# \min_{x, v} f(K(x, v)) + g(x, v)  \quad \quad \quad (2)
+# $$
+#
+# where $f$ and $g$ denote proper, convex, lower-semicontinous functionals and $K$ denotes a linear operator.\
+# PDHG essentially consists of three steps, which read as
+#
+# $z_{k+1} = \mathrm{prox}_{\sigma f^{\ast}}(z_k + \sigma K \bar{x}_k)$
+#
+# $x_{k+1} = \mathrm{prox}_{\tau g}(x_k - \tau K^H z_{k+1})$
+#
+# $\bar{x}_{k+1} = x_{k+1} + \theta(x_{k+1} - x_k)$,
+#
+# where $\mathrm{prox}$ denotes the proximal operator and $f^{\ast}$ denotes the convex conjugate of the
+# functional $f$, $\theta\in [0,1]$ and step sizes $\sigma, \tau$ such that $\sigma \tau < 1/L^2$, where
+# $L=\|K\|_2$ is the operator norm of the operator $K$.
+#
+# The first step is to recast problem (1) into the general form of (2) and then to apply the steps above
+# in an iterative fashion. In the following, we use this approach to reconstruct a 2D radial image using
+# `~mrpro.algorithms.optimizers.pdhg`.
+
+# %% [markdown]
+# ### Load data
+# Our example data contains three scans acquired with a 2D golden angle radial trajectory and
+# varying number of spokes:
+#
+# - ``radial2D_24spokes_golden_angle_with_traj.h5``
+# - ``radial2D_96spokes_golden_angle_with_traj.h5``
+# - ``radial2D_402spokes_golden_angle_with_traj.h5``
+#
+# We will use the 402 spokes as a reference and try to reconstruct the image from the 24 spokes data.
+
+# %% tags=["hide-cell"] mystnb={"code_prompt_show": "Show download details"}
+# Download raw data from Zenodo
+import tempfile
+from pathlib import Path
+
+import zenodo_get
+
+tmp = tempfile.TemporaryDirectory()  # RAII, automatically cleaned up
+data_folder = Path(tmp.name)
+zenodo_get.download(record='14617082', retry_attempts=5, output_dir=data_folder)
+
+# %%
+import mrpro
+
+# We have embedded the trajectory information in the ISMRMRD files.
+kdata_402spokes = mrpro.data.KData.from_file(
+    data_folder / 'radial2D_402spokes_golden_angle_with_traj.h5', mrpro.data.traj_calculators.KTrajectoryIsmrmrd()
+)
+kdata_24spokes = mrpro.data.KData.from_file(
+    data_folder / 'radial2D_24spokes_golden_angle_with_traj.h5', mrpro.data.traj_calculators.KTrajectoryIsmrmrd()
+)
+
+# %% [markdown]
+# ### Comparison reconstructions
+# Before running the TGV-minimization reconstruction, we first run a direct (adjoint) reconstruction
+# using `~mrpro.algorithms.reconstruction.DirectReconstruction` (see <project:direct_reconstruction.ipynb>)
+# of both the 24 spokes and 402 spokes data to have a reference for comparison.
+
+# %%
+direct_reconstruction_402 = mrpro.algorithms.reconstruction.DirectReconstruction(kdata_402spokes)
+direct_reconstruction_24 = mrpro.algorithms.reconstruction.DirectReconstruction(kdata_24spokes)
+img_direct_402 = direct_reconstruction_402(kdata_402spokes)
+img_direct_24 = direct_reconstruction_24(kdata_24spokes)
+
+# %% [markdown]
+# We also run an iterative SENSE reconstruction (see <project:iterative_sense_reconstruction_radial2D.ipynb>) with early
+# stopping of the 24 spokes data. We use it as a comparison and as an initial guess for the TGV-minimization
+# reconstruction.
+
+# %%
+sense_reconstruction = mrpro.algorithms.reconstruction.IterativeSENSEReconstruction(
+    kdata_24spokes,
+    n_iterations=8,
+    csm=direct_reconstruction_24.csm,
+    dcf=direct_reconstruction_24.dcf,
+)
+img_sense_24 = sense_reconstruction(kdata_24spokes)
+
+# %% [markdown]
+# ### Set up the operator $A$
+# Now, to set up the problem, we need to define the acquisition operator $A$, consisting of a
+# `~mrpro.operators.FourierOp` and a `~mrpro.operators.SensitivityOp`, which applies the coil sensitivity maps
+# (CSM) to the image. We reuse the CSMs estimated in the direct reconstruction.
+
+# %%
+fourier_operator = mrpro.operators.FourierOp.from_kdata(kdata_24spokes)
+
+assert direct_reconstruction_24.csm is not None
+csm_operator = direct_reconstruction_24.csm.as_operator()
+
+# The acquisition operator is the composition of the Fourier operator and the CSM operator
+acquisition_operator = fourier_operator @ csm_operator
+
+# %% [markdown]
+# ### Recast the problem to be able to apply PDHG
+# To apply the PDHG algorithm, we need to recast the problem into the form of (2). We need to identify
+# the functionals $f$ and $g$ and the operator $K$. We chose an identification for which both
+# $\mathrm{prox}_{\sigma f^{\ast}}$ and $\mathrm{prox}_{\tau g}$ are easy to compute:
+#
+# #### $f(z) = f(p,q,r) = f_1(p) + f_2(q) + f_3(r) = \frac{1}{2}\|p - y\|_2^2 + \lambda_1 \|q\|_1 + \lambda_0 \|r\|_1.$
+
+# %%
+regularization_lambda_1 = 0.2
+regularization_lambda_0 = 0.4
+f_1 = 0.5 * mrpro.operators.functionals.L2NormSquared(target=kdata_24spokes.data, divide_by_n=True)
+f_2 = regularization_lambda_1 * mrpro.operators.functionals.L1NormViewAsReal(divide_by_n=True)
+f_3 = regularization_lambda_0 * mrpro.operators.functionals.L1NormViewAsReal(divide_by_n=True)
+f = mrpro.operators.ProximableFunctionalSeparableSum(f_1, f_2, f_3)
+
+# %% [markdown]
+# #### $K = [[A, 0], [\nabla, -I], [0, \mathcal{E}]]^{\top}$
+#
+# $$
+# K(x,v) \;=\;
+# \begin{bmatrix}
+# A & 0\\
+# \nabla & -I\\
+# 0 & \mathcal{E}
+# \end{bmatrix}
+# \begin{bmatrix}
+# x\\ v
+# \end{bmatrix}
+# \;=\;
+# \begin{bmatrix}
+# Ax\\
+# \nabla x - v\\
+# \mathcal{E}v
+# \end{bmatrix}
+# $$
+#
+#   where $\nabla$ is the finite difference operator that computes the directional derivatives along the last two
+#   dimensions (y,x), implemented as `~mrpro.operators.FiniteDifferenceOp`, and
+#   $\mathcal{E}$ is the corresponding symmetrized gradient operator implemented as
+#   `~mrpro.operators.SymmetrizedGradientOp`
+#
+# $$
+# \mathcal{E}v \;=\; \tfrac12\,(\nabla v + (\nabla v)^{\top})
+# $$
+#
+#  `~mrpro.operators.LinearOperatorMatrix` can be used to stack the operators.
+
+# %%
+# Directions along which to compute the finite differences
+dim = (-2, -1)
+
+# Define the operator matrix K
+# 1. First row [A, 0] (corresponding to the L2-norm data term): Ax + 0
+data_term_row = (acquisition_operator, mrpro.operators.ZeroOp())
+
+# 2. Second row [\nabla, -I] (corresponding to the first L1-norm regularization term): \nabla x - v
+# Reduce the number of dimensions of the image by one before applying the finite difference operator
+# to make the output of the finite difference operator match the auxiliary tensor v.
+squeeze_op = mrpro.operators.RearrangeOp('1 ... -> ...')
+forward_nabla = mrpro.operators.FiniteDifferenceOp(dim=dim, mode='forward')
+grad_term_row = (forward_nabla @ squeeze_op, -1 * mrpro.operators.IdentityOp())
+
+# 3. Third row [0, \mathcal{E}] (corresponding to the second L1-norm regularization term): 0 + \mathcal{E} v
+symmetric_gradient_op = mrpro.operators.SymmetrizedGradientOp(dim=dim, mode='backward')
+sym_grad_term_row = (mrpro.operators.ZeroOp(), symmetric_gradient_op)
+
+K = mrpro.operators.LinearOperatorMatrix((data_term_row, grad_term_row, sym_grad_term_row))
+
+# %% [markdown]
+# #### $g(x, v) = 0,$
+#
+# implemented as `~mrpro.operators.functionals.ZeroFunctional`
+
+# %%
+g = ProximableFunctionalSeparableSum = mrpro.operators.ProximableFunctionalSeparableSum(
+    *(mrpro.operators.functionals.ZeroFunctional(),) * 2
+)
+
+
+# %% [markdown]
+# ### Run PDHG for a certain number of iterations
+# Now we can run the PDHG algorithm to solve the minimization problem. We use
+# the iterative SENSE image as an initial value to speed up the convergence.
+# ```{note}
+# We can use the `callback` parameter of `~mrpro.algorithms.optimizers` to get some information
+# about the progress. In the collapsed cell, we implement a simple callback function that print the status
+# message
+# ```
+
+# %% tags=["hide-cell"] mystnb={"code_prompt_show": "Show callback details"}
+# This is a "callback" function that will be called after each iteration of the PDHG algorithm.
+# We use it here to print progress information.
+
+from mrpro.algorithms.optimizers.pdhg import PDHGStatus
+
+
+def callback(optimizer_status: PDHGStatus) -> None:
+    """Print the value of the objective functional every 16th iteration."""
+    iteration = optimizer_status['iteration_number']
+    solution = optimizer_status['solution']
+    if iteration % 16 == 0:
+        print(f'Iteration {iteration: >3}: Objective = {optimizer_status["objective"](*solution).item():.3e}')
+
+
+# %%
+# Auxiliary tensor v which is in the gradient domain.
+auxiliary_v_tensor = img_sense_24.data.new_zeros((len(dim), *img_sense_24.shape))
+# Increase the number of dimensions of initial image by one.
+# Must make the number of dimensions of the elements in initial values list match one another,
+# because (currently) pdhg function concatenates the individual norms of each operator
+# in a matrix's row and the norm has the same shape as the input.
+# If the number of dimensions don't match, we get a runtime error like this:
+#   RuntimeError: stack expects each tensor to be equal size, but got ... at entry 0 and ... at entry 1
+initial_image = img_sense_24.data.unsqueeze(0)
+
+(img_pdhg_24, _) = mrpro.algorithms.optimizers.pdhg(
+    f=f,
+    g=g,
+    operator=K,
+    initial_values=(initial_image, auxiliary_v_tensor),
+    max_iterations=257,
+    callback=callback,
+)
+
+# %% [markdown]
+# ### Compare the results
+# We now compare the results of the direct reconstruction, the iterative SENSE reconstruction, and the TGV-minimization
+
+# %% tags=["hide-cell"] mystnb={"code_prompt_show": "Show plotting details"}
+import matplotlib.pyplot as plt
+import torch
+
+
+def show_images(*images: torch.Tensor, titles: list[str] | None = None) -> None:
+    """Plot images."""
+    n_images = len(images)
+    _, axes = plt.subplots(1, n_images, squeeze=False, figsize=(n_images * 3, 3))
+    for i in range(n_images):
+        axes[0][i].imshow(images[i], cmap='gray')
+        axes[0][i].axis('off')
+        if titles:
+            axes[0][i].set_title(titles[i])
+    plt.show()
+
+
+# %%
+# see the collapsed cell above for the implementation of show_images
+show_images(
+    img_direct_402.rss().squeeze(),
+    img_direct_24.rss().squeeze(),
+    img_sense_24.rss().squeeze(),
+    img_pdhg_24.abs().squeeze(),
+    titles=['402 spokes', '24 spokes (direct)', '24 spokes (SENSE)', '24 spokes (PDHG)'],
+)
+
+# %% [markdown]
+# Hurrah! We have successfully reconstructed an image from 24 spokes using TGV-minimization.
+#
+# ### Next steps
+# Play around with the regularization weight and the number of iterations to see how they affect the final image.
+# You can also try to use the 96 spokes data to see how the reconstruction quality improves with more spokes.

--- a/src/mrpro/operators/SymmetrizedGradientOp.py
+++ b/src/mrpro/operators/SymmetrizedGradientOp.py
@@ -1,0 +1,99 @@
+"""Symmetrized gradient operator."""
+
+from collections.abc import Sequence
+from typing import Literal
+
+import torch
+
+from mrpro.operators.FiniteDifferenceOp import FiniteDifferenceOp
+from mrpro.operators.LinearOperator import LinearOperator
+from mrpro.operators.RearrangeOp import RearrangeOp
+
+
+class SymmetrizedGradientOp(LinearOperator):
+    r"""Symmetrized gradient operator.
+
+    The symmetrized gradient :math:`\mathcal{E}: \mathcal{R}^d \to \mathcal{R}^{d+1}`
+    is defined as:
+
+    .. math::
+
+        \mathcal{E}v = \frac{1}{2}(\nabla v + (\nabla v)^{\top})
+
+    where :math:`(\nabla v)^{\top}` denotes the transpose of the Jacobian matrix :math:`\nabla v`.
+
+    This is used, for example, in Total Generalized Variation (TGV) regularization with the 2D case
+    shown in [TGV]_.
+
+    References
+    ----------
+    .. [TGV] Bredies, K. Recovering piecewise smooth multichannel images by minimization of convex
+       functionals with total generalized variation penalty. In: Bruhn, A., Pock, T., Tai, X.C. (eds)
+       Efficient Algorithms for Global Optimization Methods in Computer Vision. Lecture Notes in Computer Science,
+       vol. 8293, Springer, Berlin, Heidelberg, 2014, pp. 44-77. https://doi.org/10.1007/978-3-642-54774-4_3
+    """
+
+    def __init__(
+        self,
+        dim: Sequence[int],
+        mode: Literal['central', 'forward', 'backward'] = 'central',
+        pad_mode: Literal['zeros', 'circular'] = 'zeros',
+    ) -> None:
+        """Symmetrized gradient operator.
+
+        Parameters
+        ----------
+        dim
+            Dimension along which finite differences are calculated.
+            k elements for k gradients.
+        mode
+            Type of finite difference operator
+        pad_mode
+            Padding to ensure output has the same size as the input
+        """
+        super().__init__()
+        finite_difference_op = FiniteDifferenceOp(dim, mode=mode, pad_mode=pad_mode)
+        transpose_op = RearrangeOp('sym_grad_dim  grad_dim  ...   ->   grad_dim  sym_grad_dim  ...')
+        self.symmetric_gradient_op = 0.5 * (1 + transpose_op) @ finite_difference_op
+
+    def __call__(self, v: torch.Tensor) -> tuple[torch.Tensor,]:
+        """Apply forward of symmetrized gradient operator.
+
+        Since v is assumed to be the finite difference of a tensor d-dimensional tensor x (i.e., v = ∇x),
+        the first dimension of v must match the number of dimensions specified in `dim` during initialization.
+
+        Parameters
+        ----------
+        v
+            d-dimensional input tensor
+
+        Returns
+        -------
+        w
+            A single-element tuple containing a (d+1)-dimensional tensor of the symmetrized gradient of v.
+        """
+        return super().__call__(v)
+
+    def forward(self, v: torch.Tensor) -> tuple[torch.Tensor,]:
+        """Apply forward of SymmetrizedGradientOp.
+
+        .. note::
+            Prefer calling the instance of the SymmetrizedGradientOp operator as ``operator(x)`` over
+            directly calling this method. See this PyTorch `discussion <https://discuss.pytorch.org/t/is-model-forward-x-the-same-as-model-call-x/33460/3>`_.
+        """
+        return self.symmetric_gradient_op(v)
+
+    def adjoint(self, w: torch.Tensor) -> tuple[torch.Tensor,]:
+        """Apply adjoint of symmetrized gradient operator.
+
+        Parameters
+        ----------
+        w
+            (d+1)-dimensional input tensor
+
+        Returns
+        -------
+        v
+            A single-element tuple containing the d-dimensional tensor of the adjoint of the symmetrized gradient.
+        """
+        return self.symmetric_gradient_op.adjoint(w)

--- a/src/mrpro/operators/__init__.py
+++ b/src/mrpro/operators/__init__.py
@@ -30,6 +30,7 @@ from mrpro.operators.RearrangeOp import RearrangeOp
 from mrpro.operators.SensitivityOp import SensitivityOp
 from mrpro.operators.SignalModel import SignalModel
 from mrpro.operators.SliceProjectionOp import SliceProjectionOp
+from mrpro.operators.SymmetrizedGradientOp import SymmetrizedGradientOp
 from mrpro.operators.WaveletOp import WaveletOp
 from mrpro.operators.ZeroPadOp import ZeroPadOp
 from mrpro.operators.ZeroOp import ZeroOp
@@ -70,6 +71,7 @@ __all__ = [
     "SensitivityOp",
     "SignalModel",
     "SliceProjectionOp",
+    "SymmetrizedGradientOp",
     "WaveletOp",
     "ZeroOp",
     "ZeroPadOp",

--- a/tests/operators/test_symmetrized_gradient_op.py
+++ b/tests/operators/test_symmetrized_gradient_op.py
@@ -1,0 +1,121 @@
+"""Tests for symmetrized gradient operator."""
+
+from collections.abc import Sequence
+from typing import Literal
+
+import pytest
+import torch
+from einops import repeat
+from mrpro.operators import SymmetrizedGradientOp
+from mrpro.utils import RandomGenerator
+
+from tests import (
+    dotproduct_adjointness_test,
+    forward_mode_autodiff_of_linear_operator_test,
+    gradient_of_linear_operator_test,
+)
+
+
+def create_symmetrized_gradient_op_and_range_domain(
+    dim: Sequence[int], mode: Literal['central', 'forward', 'backward'], pad_mode: Literal['zeros', 'circular']
+) -> tuple[SymmetrizedGradientOp, torch.Tensor, torch.Tensor]:
+    """Create a symmetrized gradient operator and an element from domain and range."""
+    rng = RandomGenerator(seed=0)
+    input_shape = (len(dim), 6, 4, 10, 20, 16)  # First dimension matches number of gradients
+
+    # Generate symmetrized gradient operator
+    symmetrized_gradient_op = SymmetrizedGradientOp(dim, mode, pad_mode)
+
+    u = rng.complex64_tensor(size=input_shape)
+    v = rng.complex64_tensor(size=(len(dim), *input_shape))
+    return symmetrized_gradient_op, u, v
+
+
+@pytest.mark.parametrize('mode', ['central', 'forward', 'backward'])
+def test_symmetrized_gradient_op_forward(
+    mode: Literal['central', 'forward', 'backward'],
+) -> None:
+    """Test symmetrized gradient of a simple linear vector field in 2D."""
+    # Create a test object v = (v0, v1) in 2D
+    size = 10
+    y_coords = repeat(torch.arange(size, dtype=torch.float32), 'y -> 1 y x', x=size)
+    x_coords = repeat(torch.arange(size, dtype=torch.float32), 'x -> 1 y x', y=size)
+    v0 = x_coords + 2 * y_coords  # v0(y, x) = x + 2y
+    v1 = 2 * x_coords + y_coords  # v1(y, x) = 2x + y
+    v0 = v0 - 1j * v0
+    v1 = v1 - 1j * v1
+    v = torch.cat((v0, v1), dim=0)  # shape (2, size, size)
+
+    # Generate and apply symmetrized gradient operator
+    dim = (-1, -2)
+    assert v.shape[0] == len(dim)  # Ensure first dimension of v matches number of dimensions in dim
+    sym_grad_op = SymmetrizedGradientOp(dim=dim, mode=mode)
+    (sym_grad,) = sym_grad_op(v)  # shape (2, 2, size, size)
+
+    # Extract interior (remove borders to avoid boundary effects)
+    sym_00 = sym_grad[0, 0, 1:-1, 1:-1]
+    sym_11 = sym_grad[1, 1, 1:-1, 1:-1]
+    sym_01 = sym_grad[0, 1, 1:-1, 1:-1]
+    sym_10 = sym_grad[1, 0, 1:-1, 1:-1]
+
+    # Verify correct values excluding borders
+    torch.testing.assert_close(sym_00, (1 - 1j) * torch.ones_like(sym_00))
+    torch.testing.assert_close(sym_11, (1 - 1j) * torch.ones_like(sym_11))
+    torch.testing.assert_close(sym_01, (2 - 2j) * torch.ones_like(sym_01))
+    torch.testing.assert_close(sym_10, (2 - 2j) * torch.ones_like(sym_10))
+
+
+@pytest.mark.parametrize('pad_mode', ['zeros', 'circular'])
+@pytest.mark.parametrize('mode', ['central', 'forward', 'backward'])
+@pytest.mark.parametrize('dim', [(-1,), (-2, -1), (-3, -2, -1), (-4,), (1, 3)])
+def test_symmetrized_gradient_op_adjointness(
+    dim: Sequence[int], mode: Literal['central', 'forward', 'backward'], pad_mode: Literal['zeros', 'circular']
+) -> None:
+    """Test symmetrized gradient operator adjoint property."""
+    dotproduct_adjointness_test(*create_symmetrized_gradient_op_and_range_domain(dim, mode, pad_mode))
+
+
+@pytest.mark.parametrize('pad_mode', ['zeros', 'circular'])
+@pytest.mark.parametrize('mode', ['central', 'forward', 'backward'])
+@pytest.mark.parametrize('dim', [(-1,), (-2, -1), (-3, -2, -1), (-4,), (1, 3)])
+def test_symmetrized_gradient_op_grad(
+    dim: Sequence[int], mode: Literal['central', 'forward', 'backward'], pad_mode: Literal['zeros', 'circular']
+) -> None:
+    """Test the gradient of symmetrized gradient operator."""
+    gradient_of_linear_operator_test(*create_symmetrized_gradient_op_and_range_domain(dim, mode, pad_mode))
+
+
+@pytest.mark.parametrize('pad_mode', ['zeros', 'circular'])
+@pytest.mark.parametrize('mode', ['central', 'forward', 'backward'])
+@pytest.mark.parametrize('dim', [(-1,), (-2, -1), (-3, -2, -1), (-4,), (1, 3)])
+def test_symmetrized_gradient_op_forward_mode_autodiff(
+    dim: Sequence[int], mode: Literal['central', 'forward', 'backward'], pad_mode: Literal['zeros', 'circular']
+) -> None:
+    """Test the forward-mode autodiff of the symmetrized gradient operator."""
+    forward_mode_autodiff_of_linear_operator_test(*create_symmetrized_gradient_op_and_range_domain(dim, mode, pad_mode))
+
+
+@pytest.mark.cuda
+def test_symmetrized_gradient_op_cuda() -> None:
+    """Test symmetrized gradient operator works on CUDA devices."""
+
+    # Set dimensional parameters
+    dim = (-3, -2, -1)
+    input_shape = (len(dim), 6, 4, 10, 20, 16)
+
+    # Generate data
+    random_generator = RandomGenerator(seed=0)
+    u = random_generator.complex64_tensor(size=input_shape)
+
+    # Create on CPU, run on CPU
+    symmetrized_gradient_op = SymmetrizedGradientOp(dim, mode='central', pad_mode='circular')
+    operator = symmetrized_gradient_op.H @ symmetrized_gradient_op
+    (symmetrized_gradient_output,) = operator(u)
+    assert symmetrized_gradient_output.is_cpu
+
+    # Transfer to GPU, run on GPU
+    symmetrized_gradient_op = SymmetrizedGradientOp(dim, mode='central', pad_mode='circular')
+    operator = symmetrized_gradient_op.H @ symmetrized_gradient_op
+    operator.cuda()
+    (symmetrized_gradient_output,) = operator(u.cuda())
+    assert symmetrized_gradient_output.is_cuda


### PR DESCRIPTION
(This PR is a fix for the previous PR https://github.com/PTB-MR/mrpro/pull/894 and a direct continuation from https://github.com/PTB-MR/mrpro/pull/903.)

## Summary

- Add `SymmetrizedGradientOp` as a linear operator in `mrpro.operators`. Supports $k$-dimensional spatial dimensions for arbitrary number of dimensions $k$. Add unit tests `tests/operators/test_symmetrized_gradient_op.py` for correctness and adjointness.
- Add example notebook demonstrating Total Generalized Variation image reconstruction for radial undersampled MRI reconstruction using `SymmetrizedGradientOp`.

## Motivation

The symmetrized gradient is required for total generalised variation (TGV) type regularisation, in particular for
second-order TGV as in Bredies (2014). Having a dedicated operator in `mrpro` makes it easier to implement TGV-based
reconstruction methods in a consistent way with the rest of the library,
as demonstrated in the example notebook.

## Notes

No breaking changes expected; existing APIs remain unchanged.