### PR TITLE
Fix mypy errors

### DIFF
--- a/src/mrpro/algorithms/optimizers/pdhg.py
+++ b/src/mrpro/algorithms/optimizers/pdhg.py
@@ -162,12 +162,12 @@ def pdhg(
     if len(g_sum) != n_columns:
         raise ValueError('Number of columns in operator does not match number of functionals in g')
 
+    primal_stepsize_: float | torch.Tensor
+    dual_stepsize_: float | torch.Tensor
     if primal_stepsize is None or dual_stepsize is None:
         # choose primal and dual step size such that their product is 1/|operator|**2
         # to ensure convergence
         operator_norm = operator_matrix.operator_norm(*[torch.randn_like(v) for v in initial_values]).amax()
-        primal_stepsize_: float | torch.Tensor
-        dual_stepsize_: float | torch.Tensor
         if primal_stepsize is None and dual_stepsize is None:
             primal_stepsize_ = dual_stepsize_ = 1.0 / operator_norm
         elif primal_stepsize is None and dual_stepsize is not None:

--- a/src/mrpro/phantoms/fastmri.py
+++ b/src/mrpro/phantoms/fastmri.py
@@ -70,7 +70,7 @@ class FastMRIKDataDataset(torch.utils.data.Dataset):
             slice_idx: int | slice = slice(None)
         else:
             file_idx = int(torch.searchsorted(self._accum_slices, idx + 1))
-            slice_idx = int(idx - self._accum_slices[file_idx])
+            slice_idx = idx - int(self._accum_slices[file_idx].item())
         with h5py.File(self._filenames[file_idx], 'r') as file:
             # data is sometimes zero-padded, we remove the padding
             data = torch.as_tensor(np.array(file['kspace'][slice_idx]))


### PR DESCRIPTION
Fix: pre-commit ci not passing `mypy` hook

Currently we get these errors when mypy is run:

```bash
- hook id: mypy
- exit code: 1

src/mrpro/phantoms/fastmri.py:73: error: Incompatible types in assignment (expression has type "Tensor", variable has type "int | slice[Any, Any, Any]")  [assignment]
src/mrpro/algorithms/optimizers/pdhg.py:173: error: Incompatible types in assignment (expression has type "float", variable has type "Tensor")  [assignment]
src/mrpro/algorithms/optimizers/pdhg.py:176: error: Incompatible types in assignment (expression has type "float", variable has type "Tensor")  [assignment]
src/mrpro/algorithms/optimizers/pdhg.py:178: error: Incompatible types in assignment (expression has type "float", variable has type "Tensor")  [assignment]
src/mrpro/algorithms/optimizers/pdhg.py:179: error: Incompatible types in assignment (expression has type "float", variable has type "Tensor")  [assignment]
tests/algorithms/test_pdhg.py:261: error: Argument "primal_stepsize" to "pdhg" has incompatible type "Tensor"; expected "float | None"  [arg-type]
tests/algorithms/test_pdhg.py:270: error: Argument "dual_stepsize" to "pdhg" has incompatible type "Tensor"; expected "float | None"  [arg-type]
Found 7 errors in 3 files (checked 235 source files)

Error: Process completed with exit code 1.
```

These seem to be caused by 3 main problems:

1. For `src/mrpro/algorithms/optimizers/pdhg.py`, on line 173 , there are 2 variables:

  - `dual_stepsize` (without the underscore at the end): it was from the `pdhg` function signature which declares that it is either `float` or `None`

  - `dual_stepsize_` (with the underscore at the end): it's a new variable created inside the `if / elif` statements. In the first `if` on line 170, it was assigned `1.0 / operator_norm` which is a `Tensor`, but in the `elif` on line 173, it was assigned `dual_stepsize` from the function call which is `float`.
  
A workaround is adding these two lines the statement `if primal_stepsize is None or dual_stepsize is None:` in the `pdhg` function:
```python
    primal_stepsize_: float | torch.Tensor
    dual_stepsize_: float | torch.Tensor
```

to tell `mypy` that `dual_stepsize_` and `primal_stepsize_` can also be `float`.

2. In the call signature of `pdhg`, `dual_stepsize` and `primal_stepsize` can only be `float` or `None`, but in the `test_pdhg.py` test, Tensors are passed to the function. This is fixed by also allowing them to be Tensor in the function call signature.

3. In `fastmri.py`, `self._accum_slices` is a Tensor created on line 52 using `slices` which is a list of `int`s. Later, on line 73, a new integer variable called `slice_idx` was assigned with `idx - self._accum_slices[file_idx]` which is a Tensor. A workaround is to use `idx - int(self._accum_slices[file_idx].item())` instead.

  
