### PR TITLE
phdg: cast stepsizes only once to tensor

### DIFF
--- a/src/mrpro/algorithms/optimizers/pdhg.py
+++ b/src/mrpro/algorithms/optimizers/pdhg.py
@@ -166,19 +166,17 @@ def pdhg(
         # choose primal and dual step size such that their product is 1/|operator|**2
         # to ensure convergence
         operator_norm = operator_matrix.operator_norm(*[torch.randn_like(v) for v in initial_values]).amax()
-        primal_stepsize_: float | torch.Tensor
-        dual_stepsize_: float | torch.Tensor
         if primal_stepsize is None and dual_stepsize is None:
             primal_stepsize_ = dual_stepsize_ = 1.0 / operator_norm
         elif primal_stepsize is None and dual_stepsize is not None:
             primal_stepsize_ = 1 / (operator_norm * dual_stepsize)
-            dual_stepsize_ = dual_stepsize
+            dual_stepsize_ = torch.as_tensor(dual_stepsize)
         elif dual_stepsize is None and primal_stepsize is not None:
             dual_stepsize_ = 1 / (operator_norm * primal_stepsize)
-            primal_stepsize_ = primal_stepsize
+            primal_stepsize_ = torch.as_tensor(primal_stepsize)
     else:
-        primal_stepsize_ = primal_stepsize
-        dual_stepsize_ = dual_stepsize
+        primal_stepsize_ = torch.as_tensor(primal_stepsize)
+        dual_stepsize_ = torch.as_tensor(dual_stepsize)
 
     primals_relaxed = initial_values if initial_relaxed is None else initial_relaxed
     duals = (0 * operator_matrix)(*initial_values) if initial_duals is None else initial_duals


### PR DESCRIPTION
the float stepsize_ will anyways get converted to tensor in the prox functions. just do it once.

lets see if this passes mypy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize PDHG step size handling by converting provided `primal_stepsize`/`dual_stepsize` to tensors in all code paths.
> 
> - **PDHG (`src/mrpro/algorithms/optimizers/pdhg.py`)**:
>   - Consistently cast `primal_stepsize` and `dual_stepsize` to tensors using `torch.as_tensor` across all branches (both provided or only one provided).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba4b072931fb79039b680b2d3b3a773206482121. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->