### PR TITLE
Make reshape_by_idx work on already reshaped data

### DIFF
--- a/src/mrpro/data/KData.py
+++ b/src/mrpro/data/KData.py
@@ -33,9 +33,8 @@ from mrpro.data.KTrajectory import KTrajectory
 from mrpro.data.Rotation import Rotation
 from mrpro.data.traj_calculators.KTrajectoryCalculator import KTrajectoryCalculator
 from mrpro.data.traj_calculators.KTrajectoryIsmrmrd import KTrajectoryIsmrmrd
+from mrpro.utils.summarize import summarize_object
 from mrpro.utils.typing import FileOrPath
-
-from ..utils.summarize import summarize_object
 
 RotationOrTensor = TypeVar('RotationOrTensor', bound=torch.Tensor | Rotation)
 
@@ -274,19 +273,23 @@ class KData(Dataclass):
         """
         shape = self.shape
 
-        def expand(x: T) -> T:
-            return x.expand(*shape[:-4], -1, shape[-3], shape[-2], -1)
+        def flatten_idx(x: T) -> T:
+            """Expand collapsed dimensions and flatten all indices to into "other" dimension."""
+            x = x.expand(*shape[:-4], -1, shape[-3], shape[-2], -1)
+            return rearrange(x, '... coils k2 k1 k0 -> (... k2 k1) coils 1 1 k0')
 
         # First, determine if we can split into k2 and k1 and how large these should be
         acq_indices_other = torch.stack(
-            [expand(getattr(self.header.acq_info.idx, label)) for label in OTHER_LABELS],
+            [flatten_idx(getattr(self.header.acq_info.idx, label)) for label in OTHER_LABELS],
             dim=0,
         )
         _, n_acqs_per_other = torch.unique(acq_indices_other, dim=1, return_counts=True)
         # unique counts of acquisitions for each combination of the label values in "other"
         n_acqs_per_other = torch.unique(n_acqs_per_other)
 
-        acq_indices_other_k2 = torch.cat((acq_indices_other, expand(self.header.acq_info.idx.k2).unsqueeze(0)), dim=0)
+        acq_indices_other_k2 = torch.cat(
+            (acq_indices_other, flatten_idx(self.header.acq_info.idx.k2).unsqueeze(0)), dim=0
+        )
         _, n_acqs_per_other_and_k2 = torch.unique(acq_indices_other_k2, dim=1, return_counts=True)
         # unique counts of acquisitions for each combination of other **and k2**
         n_acqs_per_other_and_k2 = torch.unique(n_acqs_per_other_and_k2)
@@ -324,14 +327,14 @@ class KData(Dataclass):
 
         # Second, determine the sorting order
         acq_indices = np.stack(
-            [expand(getattr(self.header.acq_info.idx, label)).ravel() for label in KDIM_SORT_LABELS],
+            [flatten_idx(getattr(self.header.acq_info.idx, label)).ravel() for label in KDIM_SORT_LABELS],
             axis=0,
         )
         sort_idx = torch.as_tensor(np.lexsort(acq_indices))  # torch has no lexsort as of pytorch 2.6 (March 2025)
 
         # Finally, reshape and sort the tensors in acqinfo and acqinfo.idx, and kdata.
         def sort(x: T) -> T:
-            flat = cast(T, rearrange(expand(x), '... coils k2 k1 k0 -> (... k2 k1) coils k0'))
+            flat = cast(T, rearrange(flatten_idx(x), '... coils k2 k1 k0 -> (... k2 k1) coils k0'))
             return cast(
                 T, rearrange(flat[sort_idx], '(other k2 k1) coils k0 -> other coils k2 k1 k0', k1=n_k1, k2=n_k2)
             )

--- a/tests/data/test_kdata.py
+++ b/tests/data/test_kdata.py
@@ -86,6 +86,13 @@ def test_KData_from_file_diff_nky_for_rep(ismrmrd_cart_invalid_reps) -> None:
     assert kdata.data.shape[-3] == 1, 'k2 should be 1'
 
 
+def test_KData_reshape_by_idx_idempotent(ismrmrd_cart) -> None:
+    """Test reshape_by_idx method is idempotent."""
+    kdata = KData.from_file(ismrmrd_cart.filename, DummyTrajectory())
+    kdata_reshaped = kdata.reshape_by_idx()
+    assert kdata.shape == kdata_reshaped.shape
+
+
 def test_KData_calibration_lines(ismrmrd_cart_with_calibration_lines) -> None:
     """Correct handling of calibration lines."""
     # Exclude calibration lines


### PR DESCRIPTION
Fixes #910 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes KData.reshape_by_idx robust on already-reshaped data by flattening index tensors before computing uniques; adds an idempotency test.
> 
> - **KData.reshape_by_idx**
>   - Flatten acquisition index tensors (`OTHER_LABELS`, `k2`) via `.ravel()` before uniqueness/counts to correctly infer `k1`/`k2` on already-reshaped data.
>   - Minor internal refactor of `expand` helper (no API change).
> - **Tests**
>   - Add `test_KData_reshape_by_idx_idempotent` to verify the method is idempotent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a9cf684f64ac1d660c13d353d04d35dc3ddbf24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->