### PR TITLE
Downgrade action version in self hosted

### DIFF
--- a/.github/workflows/pytest_selfhosted.yml
+++ b/.github/workflows/pytest_selfhosted.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4 # Don't change without a reason. Self hosted runner update might be broken.
 
       - name: Install MRpro and Dependencies
         run: pip install --upgrade --upgrade-strategy eager .[tests]
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload PyTest Coverage Report
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v4 # Don't change without a reason. Self hosted runner update might be broken.
         with:
           name: pytest-report-selfhosted
           path: |
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4 # Don't change without a reason. Self hosted runner update might be broken.
 
       - name: Install MRpro and Dependencies
         run: pip install --upgrade --upgrade-strategy eager .[tests]
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload PyTest Coverage Report
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v4 # Don't change without a reason. Self hosted runner update might be broken.
         with:
           name: pytest-report-selfhosted
           path: |


### PR DESCRIPTION
The change only switches node version. Eventually, the older node version well get deprecated in the runner. Currently, the autoupdate of the github runner is broken and does not update the node version/there is a race condition (https://github.com/actions/runner/issues/4064) . 

Thus, we keep the actions here fixed. -> If you autoupdate and it breaks, you should fix it here or update the runner!

Fix #898