### PR TITLE
Configure Dependabot to ignore specific GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     groups:
       all-actions:
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,14 @@
 version: 2
 updates:
-
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "daily"
-  groups:
-    all-actions:
-      patterns: [ "*" ]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      all-actions:
+        patterns: ["*"]
+    ignore:
+      - # Ignore all updates for actions in pytest_selfhosted as the self hosted runner might not support them
+        update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:patch"]
+        dependency-name: "*"
+        manifest-file: ".github/workflows/pytest_selfhosted.yml.yml"


### PR DESCRIPTION
Ignore updates for actions in pytest_selfhosted to prevent compatibility issues with the self-hosted runner.