### PR TITLE
Run selfhosted runner on reserved GPU

### DIFF
--- a/.github/workflows/slurm_cronjob.py
+++ b/.github/workflows/slurm_cronjob.py
@@ -61,7 +61,8 @@ SBATCH_SUBMIT_COMMAND = """#!/bin/bash
 #SBATCH -o /home/{USER_NAME}/slurm_output/slurm.%j.out # file to save job's STDOUT (%j = JobId)
 #SBATCH -e /home/{USER_NAME}/slurm_output/slurm.%j.err # file to save job's STDERR (%j = JobId)
 #SBATCH --export=NONE   # Purge the job-submitting shell environment
-#SBATCH --gres=gpu:L40S:1 # Request GPU of L40S type
+#SBATCH --gres=gpu:A100mig:1 # Reserved GPU
+#SBATCH --qos=urgent # High priority
 #SBATCH -p equipment_typeG # Request GPU
 
 # display the config file


### PR DESCRIPTION
as suggested by Florian in May.

This should skip some of the long running jobs on the cluster -- as long as AG Schwabe is not also using all of the reserved GPUs.