### PR TITLE
Reduce dependabot github action update frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "quarterly"
   groups:
     all-actions:
       patterns: [ "*" ]


### PR DESCRIPTION
these updates are not urgent and regulary break our CI, lets do them less frequently, and properly check if the updates change anything before merging.

kind of a follow up to #913 