### PR TITLE
Fix numpy warning in brainweb download normalization

### DIFF
--- a/src/mrpro/phantoms/brainweb.py
+++ b/src/mrpro/phantoms/brainweb.py
@@ -304,7 +304,7 @@ def download_brainweb(
         sum_values = sum(values)
         values.pop(ALL_CLASSES.index('bck'))  # noqa: typos
         for i, x in enumerate(values):
-            x = np.divide(x, sum_values, where=sum_values != 0)
+            x = np.divide(x, sum_values, out=np.zeros_like(x, dtype=float), where=sum_values != 0)
             x[sum_values == 0] = 0
             x = (x * (2**8 - 1)).astype(np.uint8)
             values[i] = x


### PR DESCRIPTION
Added `out` parameter to `np.divide` call to avoid UserWarning about uninitialized memory when using `where` without `out`. 

This resolves current test failures due to stricter warnings in numpy >= 2.4.