### PR TITLE
Handle empty fields in dicom file

### DIFF
--- a/src/mrpro/data/IHeader.py
+++ b/src/mrpro/data/IHeader.py
@@ -68,7 +68,12 @@ def get_items(datasets: Sequence[Dataset], name: TagType, target_type: Callable[
     -------
         A list of converted items.
     """
-    return [target_type(item.value) for ds in datasets for item in ds.iterall() if item.tag == Tag(name)]
+    return [
+        target_type(item.value)
+        for ds in datasets
+        for item in ds.iterall()
+        if (item.tag == Tag(name)) and item.value is not None
+    ]
 
 
 def try_reduce_repeat(value: T) -> T:

--- a/tests/data/_DicomTestImage.py
+++ b/tests/data/_DicomTestImage.py
@@ -27,7 +27,7 @@ class DicomTestImage:
         slice_orientation: Rotation | None = None,
         slice_offset: float | Sequence[float] = 0.0,
         cardiac_trigger_delay: float | None = None,
-        te: float = 0.037,
+        te: float | None = 0.037,
         time_after_rpeak: float = 0.333,
         phantom: EllipsePhantom | None = None,
         series_description: str = 'dicom_test_images',
@@ -181,7 +181,7 @@ class DicomTestImage:
                     plane_orientation_sequence
                 )
 
-                mr_echo_sequence[0].EffectiveEchoTime = s_to_ms(self.te)
+                mr_echo_sequence[0].EffectiveEchoTime = s_to_ms(self.te) if self.te is not None else None
                 dataset.PerFrameFunctionalGroupsSequence[-1].MREchoSequence = deepcopy(mr_echo_sequence)
 
                 pixel_measure_sequence[0].SliceThickness = slice_thickness
@@ -201,7 +201,7 @@ class DicomTestImage:
 
             dataset.ImagePositionPatient = (patient_position + slice_direction * self.slice_offset.numpy()).tolist()
             dataset.ImageOrientationPatient = [*phase_direction, *readout_direction]
-            dataset.EchoTime = s_to_ms(self.te)
+            dataset.EchoTime = s_to_ms(self.te) if self.te is not None else None
             dataset.InversionTime = 3.0
             dataset.TriggerTime = s_to_ms(self.time_after_rpeak)
             dataset.PixelSpacing = [inplane_resolution, inplane_resolution]

--- a/tests/data/conftest.py
+++ b/tests/data/conftest.py
@@ -94,6 +94,13 @@ def dcm_2d(ellipse_phantom, tmp_path_factory):
 
 
 @pytest.fixture(scope='session')
+def dcm_2d_with_empty_field(ellipse_phantom, tmp_path_factory):
+    """Single 2D dicom image with an empty dicom field."""
+    dcm_filename = tmp_path_factory.mktemp('mrpro_2d_empty_field') / 'dicom.dcm'
+    return (DicomTestImage(filename=dcm_filename, phantom=ellipse_phantom.phantom, te=None),)
+
+
+@pytest.fixture(scope='session')
 def dcm_2d_multi_echo_times(ellipse_phantoms, tmp_path_factory):
     """Multiple 2D dicom images with different echo times."""
     path = tmp_path_factory.mktemp('mrpro_2d_multi_echo')

--- a/tests/data/test_idata.py
+++ b/tests/data/test_idata.py
@@ -11,6 +11,7 @@ from mrpro.data import IData
     ('dcm_data_fixture'),
     [
         'dcm_2d',
+        'dcm_2d_with_empty_field',
         'dcm_3d',
         'dcm_2d_multi_echo_times',
         'dcm_2d_multi_echo_times_multi_folders',


### PR DESCRIPTION
For some dicom files (e.g. T1 maps) parameters (e.g. repetition time) are left empty in the dicom header. pydicom then uses `None` for these values which led to an error in `get_items()`