### PR TITLE
Fix dicom scaling

### DIFF
--- a/tests/data/_DicomTestImage.py
+++ b/tests/data/_DicomTestImage.py
@@ -32,6 +32,8 @@ class DicomTestImage:
         phantom: EllipsePhantom | None = None,
         series_description: str = 'dicom_test_images',
         series_instance_uid: str | None = None,
+        rescale_slope: float = 1.0,
+        rescale_intercept: float = 0.0,
     ):
         """Initialize DicomTestImage.
 
@@ -63,6 +65,10 @@ class DicomTestImage:
         series_instance_uid
             UID identifying a series, i.e. a set of images which belong together (e.g. multiple slices).
             If None, a new UID is generated.
+        rescale_slope
+            rescale slope for pixel data
+        rescale_intercept
+            rescale intercept for pixel data
         """
 
         if not phantom:
@@ -81,6 +87,8 @@ class DicomTestImage:
         self.slice_orientation: Sequence[SpatialDimension] = (
             transversal_orientation if slice_orientation is None else slice_orientation.as_directions()
         )
+        self.rescale_slope = rescale_slope
+        self.rescale_intercept = rescale_intercept
         self.slice_offset = torch.atleast_1d(torch.as_tensor(slice_offset))
         self.te = te
         self.time_after_rpeak = time_after_rpeak
@@ -148,6 +156,8 @@ class DicomTestImage:
             mr_echo_sequence.append(pydicom.Dataset())
             pixel_measure_sequence = pydicom.Sequence()
             pixel_measure_sequence.append(pydicom.Dataset())
+            pixel_value_transformation_sequence = pydicom.Sequence()
+            pixel_value_transformation_sequence.append(pydicom.Dataset())
             mr_timing_parameters_sequence = pydicom.Sequence()
             mr_timing_parameters_sequence.append(pydicom.Dataset())
 
@@ -188,6 +198,13 @@ class DicomTestImage:
                 pixel_measure_sequence[0].PixelSpacing = [inplane_resolution, inplane_resolution]
                 dataset.PerFrameFunctionalGroupsSequence[-1].PixelMeasuresSequence = deepcopy(pixel_measure_sequence)
 
+                pixel_value_transformation_sequence[0].RescaleSlope = rescale_slope
+                pixel_value_transformation_sequence[0].RescaleIntercept = rescale_intercept
+                pixel_value_transformation_sequence[0].RescaleType = 'US'
+                dataset.PerFrameFunctionalGroupsSequence[-1].PixelValueTransformationSequence = deepcopy(
+                    pixel_value_transformation_sequence
+                )
+
                 mr_timing_parameters_sequence[0].FlipAngle = 15.0
                 mr_timing_parameters_sequence[0].InversionTime = 3.0
                 mr_timing_parameters_sequence[0].RepetitionTime = 25.2
@@ -211,13 +228,21 @@ class DicomTestImage:
             dataset.RepetitionTime = 25.2
             dataset.FrameReferenceDateTime = dt
 
+            dataset.RescaleSlope = rescale_slope
+            dataset.RescaleIntercept = rescale_intercept
+            dataset.RescaleType = 'US'
+
         random = RandomGenerator()
         noise = random.float32_tensor(size=(n_slices, matrix_size_x, matrix_size_y))
 
         # 'MONOCHROME2' means smallest value is black, largest value is white
         set_pixel_data(
             ds=dataset,
-            arr=(repeat(self.img_ref, 'y x -> slices x y', slices=n_slices) + noise).numpy().astype(np.uint16),
+            arr=(
+                repeat((self.img_ref - rescale_intercept) / rescale_slope, 'y x -> slices x y', slices=n_slices) + noise
+            )
+            .numpy()
+            .astype(np.uint16),
             photometric_interpretation='MONOCHROME2',
             bits_stored=16,
         )

--- a/tests/data/conftest.py
+++ b/tests/data/conftest.py
@@ -94,6 +94,17 @@ def dcm_2d(ellipse_phantom, tmp_path_factory):
 
 
 @pytest.fixture(scope='session')
+def dcm_2d_rescale(ellipse_phantom, tmp_path_factory):
+    """Single 2D dicom image with rescaling."""
+    dcm_filename = tmp_path_factory.mktemp('mrpro_2d_rescale') / 'dicom.dcm'
+    return (
+        DicomTestImage(
+            filename=dcm_filename, phantom=ellipse_phantom.phantom, rescale_slope=10.0, rescale_intercept=-100
+        ),
+    )
+
+
+@pytest.fixture(scope='session')
 def dcm_2d_multi_echo_times(ellipse_phantoms, tmp_path_factory):
     """Multiple 2D dicom images with different echo times."""
     path = tmp_path_factory.mktemp('mrpro_2d_multi_echo')
@@ -146,6 +157,22 @@ def dcm_3d(ellipse_phantom, tmp_path_factory):
     path = tmp_path_factory.mktemp('mrpro_3d')
     dcm_filename = path / 'dicom.dcm'
     return (DicomTestImage(filename=dcm_filename, phantom=ellipse_phantom.phantom, slice_offset=[-2.0, 0.0, 2.0, 4.0]),)
+
+
+@pytest.fixture(scope='session')
+def dcm_3d_rescale(ellipse_phantom, tmp_path_factory):
+    """3D dicom image in a single dicom file."""
+    path = tmp_path_factory.mktemp('mrpro_3d_rescale')
+    dcm_filename = path / 'dicom.dcm'
+    return (
+        DicomTestImage(
+            filename=dcm_filename,
+            phantom=ellipse_phantom.phantom,
+            slice_offset=[-2.0, 0.0, 2.0, 4.0],
+            rescale_slope=10.0,
+            rescale_intercept=-100,
+        ),
+    )
 
 
 @pytest.fixture(scope='session')

--- a/tests/data/conftest.py
+++ b/tests/data/conftest.py
@@ -102,9 +102,9 @@ def dcm_2d_rescale(ellipse_phantom, tmp_path_factory):
             filename=dcm_filename, phantom=ellipse_phantom.phantom, rescale_slope=10.0, rescale_intercept=-100
         ),
     )
-  
-  
-@pytest.fixture(scope='session')  
+
+
+@pytest.fixture(scope='session')
 def dcm_2d_with_empty_field(ellipse_phantom, tmp_path_factory):
     """Single 2D dicom image with an empty dicom field."""
     dcm_filename = tmp_path_factory.mktemp('mrpro_2d_empty_field') / 'dicom.dcm'

--- a/tests/data/test_idata.py
+++ b/tests/data/test_idata.py
@@ -12,6 +12,8 @@ from mrpro.data import IData
     [
         'dcm_2d',
         'dcm_3d',
+        'dcm_2d_rescale',
+        'dcm_3d_rescale',
         'dcm_2d_multi_echo_times',
         'dcm_2d_multi_echo_times_multi_folders',
         'dcm_cardiac_2d',
@@ -27,7 +29,10 @@ def test_IData_content_from_dcm(dcm_data_fixture, request):
     idata = IData.from_dicom_folder(dcm_data[0].filename.parent)
     # IData uses complex values but dicom only supports real values
     first_img = torch.real(idata.data.flatten(end_dim=-3)[0])
-    torch.testing.assert_close(first_img, dcm_data[0].img_ref)
+    # Rescaling can lead to loss of precision due to uint16 storage
+    torch.testing.assert_close(
+        first_img, dcm_data[0].img_ref, atol=dcm_data[0].rescale_slope, rtol=dcm_data[0].rescale_slope / (2**16 - 1)
+    )
 
 
 def test_IData_from_dcm_file(dcm_2d):


### PR DESCRIPTION
Rescale intercept and rescale slope can be defined as a global parameter or for each frame in a 3D/M2D dicom file. So far we had only considered the first case. Now both cases work. Tested on Siemens data from three different scanners. 