### PR TITLE
Fix rotation from mixed dim spatial dimensions

### DIFF
--- a/src/mrpro/data/Rotation.py
+++ b/src/mrpro/data/Rotation.py
@@ -624,12 +624,8 @@ class Rotation(torch.nn.Module, Iterable['Rotation']):
         rotation
             Object containing the rotations represented by the basis vectors.
         """
-        basis_broadcast_shape = torch.broadcast_shapes(*(v_.shape for v_ in basis))
         b1, b2, b3 = (
-            torch.stack(
-                [torch.broadcast_to(torch.as_tensor(getattr(v_, axis)), basis_broadcast_shape) for axis in AXIS_ORDER],
-                -1,
-            )
+            torch.stack(torch.broadcast_tensors(*(torch.as_tensor(getattr(v_, ax)) for ax in AXIS_ORDER)), dim=-1)
             for v_ in basis
         )
         matrix = torch.stack((b1, b2, b3), -1)

--- a/src/mrpro/data/Rotation.py
+++ b/src/mrpro/data/Rotation.py
@@ -2030,6 +2030,9 @@ class Rotation(torch.nn.Module, Iterable['Rotation']):
            https://link.springer.com/article/10.1007/s11263-012-0601-0
 
         """
+        if self._single:
+            return self.__class__(self._quaternions[0], inversion=self._is_improper, normalize=False)
+
         if weights is None:
             weights = torch.ones(*self.shape)
         else:

--- a/src/mrpro/data/Rotation.py
+++ b/src/mrpro/data/Rotation.py
@@ -624,7 +624,14 @@ class Rotation(torch.nn.Module, Iterable['Rotation']):
         rotation
             Object containing the rotations represented by the basis vectors.
         """
-        b1, b2, b3 = (torch.stack([torch.as_tensor(getattr(v_, axis)) for axis in AXIS_ORDER], -1) for v_ in basis)
+        basis_broadcast_shape = torch.broadcast_shapes(*(v_.shape for v_ in basis))
+        b1, b2, b3 = (
+            torch.stack(
+                [torch.broadcast_to(torch.as_tensor(getattr(v_, axis)), basis_broadcast_shape) for axis in AXIS_ORDER],
+                -1,
+            )
+            for v_ in basis
+        )
         matrix = torch.stack((b1, b2, b3), -1)
         det = torch.linalg.det(matrix)
         if not allow_improper and (det < 0).any():

--- a/tests/data/test_rotation.py
+++ b/tests/data/test_rotation.py
@@ -1407,17 +1407,20 @@ def test_axis_order_zyx() -> None:
 
 def test_from_to_directions() -> None:
     """Test that from_directions and as_directions are inverse operations"""
-    one = torch.ones(1, 2, 3, 4)
-
     # must be a rotation
-    b1 = SpatialDimension(one * (0.8146), one * (0.4707), one * (-0.3388))
-    b2 = SpatialDimension(one * (-0.4432), one * (0.8820), one * (0.1599))
-    b3 = SpatialDimension(one * (-0.3741), one * (-0.0199), one * (-0.9272))
+    b1 = SpatialDimension(*(torch.as_tensor(v) for v in ([-0.1235, -0.1230], [-0.1411, -0.1639], [0.9823, 0.9788])))
+    b2 = SpatialDimension(*(torch.as_tensor(v) for v in ([-0.0186, -0.0186], [0.99, 0.9865], [0.1399, 0.1629])))
+    b3 = SpatialDimension(*(torch.as_tensor(v) for v in ([0.9922, 0.9922], [0.0010, -0.0018], [0.1249, 0.1245])))
 
     r = Rotation.from_directions(b1, b2, b3)
     torch.testing.assert_close(b1.zyx, r.as_directions()[0].zyx, atol=1e-4, rtol=0)
-    torch.testing.assert_close(b2.zyx, r.as_directions()[1].zyx, atol=1e-4, rtol=0)
-    torch.testing.assert_close(b3.zyx, r.as_directions()[2].zyx, atol=1e-4, rtol=0)
+    # b2 and b3 need broadcasting because of dim=1 along z
+    torch.testing.assert_close(torch.broadcast_to(b2.z, (2,)), r.as_directions()[1].z, atol=1e-4, rtol=0)
+    torch.testing.assert_close(b2.y, r.as_directions()[1].y, atol=1e-4, rtol=0)
+    torch.testing.assert_close(b2.x, r.as_directions()[1].x, atol=1e-4, rtol=0)
+    torch.testing.assert_close(torch.broadcast_to(b3.z, (2,)), r.as_directions()[2].z, atol=1e-4, rtol=0)
+    torch.testing.assert_close(b3.y, r.as_directions()[2].y, atol=1e-4, rtol=0)
+    torch.testing.assert_close(b3.x, r.as_directions()[2].x, atol=1e-4, rtol=0)
 
 
 def test_as_directions() -> None:

--- a/tests/data/test_rotation.py
+++ b/tests/data/test_rotation.py
@@ -1298,6 +1298,15 @@ def test_mean(theta: float) -> None:
     assert math.isclose(r.mean().magnitude(), 0.0, abs_tol=1e-7)
 
 
+def test_mean_single() -> None:
+    """Test mean with a single rotation"""
+    r = Rotation.from_rotvec([0, 0, 0])
+    mean = r.mean()
+    assert r.mean() == mean
+    assert r is not mean
+    assert mean.single
+
+
 @pytest.mark.parametrize('theta', [0.0, np.pi / 8, np.pi / 4, np.pi / 3, np.pi / 2])
 def test_weighted_mean(theta: float) -> None:
     """Test that doubling a weight is equivalent to including a rotation twice."""


### PR DESCRIPTION
The previous `test_from_to_directions` simply tested for a `SpatialDimensions` of shape `(1,1,1,1,1)` because `reduce_repeat` is not called. 

`reduce_repeat` also means that `SpatialDimensions` for the orientation vectors of read, phase and slice can have different shapes. This led to an error when creating the `RotationMatrix`. Now we broadcast before creating the `RotationMatrix`