### PR TITLE
refactor: single normalize_axes function

### DIFF
--- a/src/mrpro/data/Dataclass.py
+++ b/src/mrpro/data/Dataclass.py
@@ -12,7 +12,7 @@ from typing_extensions import Any, Protocol, Self, TypeVar, dataclass_transform,
 
 from mrpro.utils.indexing import HasIndex, Indexer
 from mrpro.utils.reduce_repeat import reduce_repeat
-from mrpro.utils.reshape import broadcasted_concatenate, broadcasted_rearrange
+from mrpro.utils.reshape import broadcasted_concatenate, broadcasted_rearrange, normalize_index
 from mrpro.utils.summarize import summarize_object
 from mrpro.utils.typing import TorchIndexerType
 
@@ -811,13 +811,11 @@ class Dataclass:
             A tuple of the splits.
         """
         shape = self.shape
-        if not -len(shape) <= dim < len(shape):
-            raise ValueError(f'Dimension {dim} out of bounds for shape {shape}')
+        dim = normalize_index(len(shape), dim)
         if dilation < 1:
             raise ValueError('Dilation must be larger than 0')
         if overlap > size:
             raise ValueError('Overlap must be smaller than size')
-        dim = dim % len(shape)
         indices = [
             (*[slice(None)] * dim, slice(start, start + size * dilation, dilation))
             for start in range(0, shape[dim] - size * dilation + 1 + max(0, overlap), size - overlap)

--- a/src/mrpro/data/KData.py
+++ b/src/mrpro/data/KData.py
@@ -33,6 +33,7 @@ from mrpro.data.KTrajectory import KTrajectory
 from mrpro.data.Rotation import Rotation
 from mrpro.data.traj_calculators.KTrajectoryCalculator import KTrajectoryCalculator
 from mrpro.data.traj_calculators.KTrajectoryIsmrmrd import KTrajectoryIsmrmrd
+from mrpro.utils.reshape import normalize_index, normalize_indices
 from mrpro.utils.summarize import summarize_object
 from mrpro.utils.typing import FileOrPath
 
@@ -466,7 +467,7 @@ class KData(Dataclass):
         """
         from mrpro.operators import PCACompressionOp
 
-        coil_dim = -4 % self.data.ndim
+        coil_dim = normalize_index(self.data.ndim, -4)
 
         if n_compressed_coils > (n_current_coils := self.data.shape[coil_dim]):
             raise ValueError(
@@ -478,14 +479,14 @@ class KData(Dataclass):
             raise ValueError('Either batch_dims or joint_dims can be defined not both.')
 
         if joint_dims is not Ellipsis:
-            joint_dims_normalized = [i % self.data.ndim for i in joint_dims]
+            joint_dims_normalized = normalize_indices(self.data.ndim, joint_dims)
             if coil_dim in joint_dims_normalized:
                 raise ValueError('Coil dimension must not be in joint_dims')
-            batch_dims_normalized = [
-                d for d in range(self.data.ndim) if d not in joint_dims_normalized and d is not coil_dim
-            ]
+            batch_dims_normalized = tuple(
+                [d for d in range(self.data.ndim) if d not in joint_dims_normalized and d is not coil_dim]
+            )
         else:
-            batch_dims_normalized = [] if batch_dims is None else [i % self.data.ndim for i in batch_dims]
+            batch_dims_normalized = normalize_indices(self.data.ndim, batch_dims)
             if coil_dim in batch_dims_normalized:
                 raise ValueError('Coil dimension must not be in batch_dims')
 

--- a/src/mrpro/data/Rotation.py
+++ b/src/mrpro/data/Rotation.py
@@ -59,7 +59,7 @@ from typing_extensions import Self, Unpack, overload
 from mrpro.data.SpatialDimension import SpatialDimension
 from mrpro.utils.indexing import Indexer
 from mrpro.utils.reduce_repeat import reduce_repeat
-from mrpro.utils.reshape import broadcasted_rearrange
+from mrpro.utils.reshape import broadcasted_rearrange, normalize_indices
 from mrpro.utils.typing import NestedSequence, TorchIndexerType
 from mrpro.utils.vmf import sample_vmf
 
@@ -2055,11 +2055,7 @@ class Rotation(torch.nn.Module, Iterable['Rotation']):
             weights = weights.reshape(-1)
             dim = list(range(len(self.shape)))
         else:
-            dim = (
-                [d % (quaternions.ndim - 1) for d in dim]
-                if isinstance(dim, Sequence)
-                else [dim % (quaternions.ndim - 1)]
-            )
+            dim = normalize_indices(quaternions.ndim - 1, dim)
             batch_dims = [i for i in range(quaternions.ndim - 1) if i not in dim]
             permute_dims = (*batch_dims, *dim)
             quaternions = quaternions.permute(*permute_dims, -1).flatten(start_dim=len(batch_dims), end_dim=-2)

--- a/src/mrpro/operators/AveragingOp.py
+++ b/src/mrpro/operators/AveragingOp.py
@@ -6,6 +6,7 @@ from warnings import warn
 import torch
 
 from mrpro.operators.LinearOperator import LinearOperator
+from mrpro.utils.reshape import normalize_index
 
 
 class AveragingOp(LinearOperator):
@@ -104,8 +105,9 @@ class AveragingOp(LinearOperator):
             )
             self.domain_size = self._last_domain_size
 
-        adjoint = x.new_zeros(*x.shape[: self.dim], self.domain_size, *x.shape[self.dim + 1 :])
-        placeholder = (slice(None),) * (self.dim % x.ndim)
+        dim = normalize_index(x.ndim, self.dim)
+        adjoint = x.new_zeros(*x.shape[:dim], self.domain_size, *x.shape[dim + 1 :])
+        placeholder = (slice(None),) * dim
         for i, group in enumerate(self.idx):
             if isinstance(group, slice):
                 n = len(range(*group.indices(self.domain_size)))
@@ -115,7 +117,7 @@ class AveragingOp(LinearOperator):
                 n = len(group)
 
             adjoint[(*placeholder, group)] += (
-                x[(*placeholder, i, None)].expand(*x.shape[: self.dim], n, *x.shape[self.dim + 1 :]) / n
+                x[(*placeholder, i, None)].expand(*x.shape[:dim], n, *x.shape[dim + 1 :]) / n
             )
 
         return (adjoint,)

--- a/src/mrpro/operators/PatchOp.py
+++ b/src/mrpro/operators/PatchOp.py
@@ -43,7 +43,7 @@ class PatchOp(LinearOperator):
         self.dim = (dim,) if isinstance(dim, int) else dim
 
         if len(set(self.dim)) != len(self.dim):
-            raise ValueError('Duplicate values in axis are not allowed')
+            raise ValueError('must be unique')
 
         def check(param: int | Sequence[int], name: str) -> tuple[int, ...]:
             if isinstance(param, int):

--- a/src/mrpro/operators/PatchOp.py
+++ b/src/mrpro/operators/PatchOp.py
@@ -43,7 +43,7 @@ class PatchOp(LinearOperator):
         self.dim = (dim,) if isinstance(dim, int) else dim
 
         if len(set(self.dim)) != len(self.dim):
-            raise ValueError('must be unique')
+            raise ValueError('Axis indices must be unique')
 
         def check(param: int | Sequence[int], name: str) -> tuple[int, ...]:
             if isinstance(param, int):

--- a/src/mrpro/operators/functionals/ZeroFunctional.py
+++ b/src/mrpro/operators/functionals/ZeroFunctional.py
@@ -1,10 +1,9 @@
 """Zero functional."""
 
-from collections.abc import Sequence
-
 import torch
 
 from mrpro.operators.Functional import ElementaryProximableFunctional, throw_if_negative_or_complex
+from mrpro.utils.reshape import normalize_indices
 
 
 class ZeroFunctional(ElementaryProximableFunctional):
@@ -41,11 +40,9 @@ class ZeroFunctional(ElementaryProximableFunctional):
         dtype = torch.promote_types(torch.promote_types(x.dtype, self.weight.dtype), self.target.dtype).to_real()
 
         if self.dim is None:
-            normal_dim: Sequence[int] = range(x.ndim)
-        elif not all(-x.ndim <= d < x.ndim for d in self.dim):
-            raise IndexError('Invalid dimension index')
+            normal_dim = tuple(range(x.ndim))
         else:
-            normal_dim = [d % x.ndim for d in self.dim] if x.ndim > 0 else []
+            normal_dim = normalize_indices(x.ndim, self.dim, unique=True)
 
         if self.keepdim:
             new_shape = [1 if i in normal_dim else s for i, s in enumerate(x.shape)]

--- a/src/mrpro/utils/__init__.py
+++ b/src/mrpro/utils/__init__.py
@@ -6,12 +6,12 @@ from mrpro.utils import unit_conversion
 from mrpro.utils.fill_range import fill_range_
 from mrpro.utils.smap import smap
 from mrpro.utils.reduce_repeat import reduce_repeat
-from mrpro.utils.indexing import Indexer, normalize_index
+from mrpro.utils.indexing import Indexer
 from mrpro.utils.pad_or_crop import pad_or_crop
 from mrpro.utils.split_idx import split_idx
 from mrpro.utils.sliding_window import sliding_window
 from mrpro.utils.summarize import summarize_object, summarize_values
-from mrpro.utils.reshape import broadcast_right, broadcasted_rearrange, unsqueeze_left, unsqueeze_right, reduce_view, reshape_broadcasted, ravel_multi_index, unsqueeze_tensors_left, unsqueeze_tensors_right, unsqueeze_at, unsqueeze_tensors_at, broadcasted_concatenate
+from mrpro.utils.reshape import broadcast_right, broadcasted_rearrange, unsqueeze_left, unsqueeze_right, reduce_view, reshape_broadcasted, ravel_multi_index, unsqueeze_tensors_left, unsqueeze_tensors_right, unsqueeze_at, unsqueeze_tensors_at, broadcasted_concatenate, normalize_index, normalize_indices
 from mrpro.utils.TensorAttributeMixin import TensorAttributeMixin
 from mrpro.utils.interpolate import interpolate, apply_lowres
 from mrpro.utils.RandomGenerator import RandomGenerator
@@ -27,6 +27,7 @@ __all__ = [
     "fill_range_",
     "interpolate",
     "normalize_index",
+    "normalize_indices",
     "pad_or_crop",
     "ravel_multi_index",
     "reduce_repeat",

--- a/src/mrpro/utils/fill_range.py
+++ b/src/mrpro/utils/fill_range.py
@@ -2,6 +2,8 @@
 
 import torch
 
+from mrpro.utils.reshape import normalize_index
+
 
 def fill_range_(tensor: torch.Tensor, dim: int) -> None:
     """
@@ -15,10 +17,7 @@ def fill_range_(tensor: torch.Tensor, dim: int) -> None:
     dim
         The dimension along which to fill with increasing values.
     """
-    if not -tensor.ndim <= dim < tensor.ndim:
-        raise IndexError(f'Dimension {dim} is out of range for tensor with {tensor.ndim} dimensions.')
-
-    dim = dim % tensor.ndim
+    dim = normalize_index(tensor.ndim, dim)
     shape = [s if d == dim else 1 for d, s in enumerate(tensor.shape)]
     values = torch.arange(tensor.size(dim), device=tensor.device).reshape(shape)
     tensor[:] = values.expand_as(tensor)

--- a/src/mrpro/utils/filters.py
+++ b/src/mrpro/utils/filters.py
@@ -10,6 +10,8 @@ import numpy as np
 import torch
 from einops import repeat
 
+from mrpro.utils.reshape import normalize_indices
+
 
 def filter_separable(
     x: torch.Tensor,
@@ -43,10 +45,7 @@ def filter_separable(
     if len(dim) != len(kernels):
         raise ValueError('Must provide matching length kernels and dim arguments.')
 
-    # normalize dim to allow negative indexing in input
-    dim = tuple([a % x.ndim for a in dim])
-    if len(dim) != len(set(dim)):
-        raise ValueError(f'Dim must be unique. Normalized dims are {dim}')
+    dim = normalize_indices(x.ndim, dim)
 
     if pad_mode == 'constant' and pad_value == 0:
         # padding is done inside the convolution

--- a/src/mrpro/utils/indexing.py
+++ b/src/mrpro/utils/indexing.py
@@ -11,29 +11,6 @@ from mrpro.utils.reshape import reduce_view
 from mrpro.utils.typing import TorchIndexerType
 
 
-def normalize_index(ndim: int, index: int) -> int:
-    """Normalize possibly negative indices.
-
-    Parameters
-    ----------
-    ndim
-        number of dimensions
-    index
-        index to normalize. negative indices count from the end.
-
-    Raises
-    ------
-    `IndexError`
-        if index is outside ``[-ndim,ndim)``
-    """
-    if 0 <= index < ndim:
-        return index
-    elif -ndim <= index < 0:
-        return ndim + index
-    else:
-        raise IndexError(f'Invalid index {index} for {ndim} data dimensions')
-
-
 @runtime_checkable
 class HasIndex(Protocol):
     """Objects that can be indexed with an `Indexer`."""

--- a/src/mrpro/utils/interpolate.py
+++ b/src/mrpro/utils/interpolate.py
@@ -5,6 +5,8 @@ from typing import Literal
 
 import torch
 
+from mrpro.utils.reshape import normalize_indices
+
 
 def interpolate(
     x: torch.Tensor, size: Sequence[int], dim: Sequence[int], mode: Literal['nearest', 'linear'] = 'linear'
@@ -30,10 +32,7 @@ def interpolate(
     if len(dim) != len(size):
         raise ValueError('Must provide matching length size and dim arguments.')
 
-    # normalize dim to allow negative indexing in input
-    dim = tuple([a % x.ndim for a in dim])
-    if len(dim) != len(set(dim)):
-        raise ValueError(f'Dim must be unique. Normalized dims are {dim}')
+    dim = normalize_indices(x.ndim, dim)
 
     # return input tensor if old and new size match
     if all(x.shape[d] == s for s, d in zip(size, dim, strict=True)):

--- a/src/mrpro/utils/pad_or_crop.py
+++ b/src/mrpro/utils/pad_or_crop.py
@@ -6,8 +6,7 @@ from typing import Literal
 
 import torch
 
-from mrpro.utils.indexing import normalize_index
-from mrpro.utils.reshape import unsqueeze_left
+from mrpro.utils.reshape import normalize_index, unsqueeze_left
 
 
 def pad_or_crop(

--- a/src/mrpro/utils/reduce_repeat.py
+++ b/src/mrpro/utils/reduce_repeat.py
@@ -4,6 +4,8 @@ from collections.abc import Sequence
 
 import torch
 
+from mrpro.utils.reshape import normalize_indices
+
 
 def reduce_repeat(tensor: torch.Tensor, tol: float = 1e-6, dim: Sequence[int] | None = None) -> torch.Tensor:
     """Replace dimensions with all equal values with singletons.
@@ -23,7 +25,7 @@ def reduce_repeat(tensor: torch.Tensor, tol: float = 1e-6, dim: Sequence[int] | 
         return real + 1j * imag
 
     if dim is not None:
-        dim = [d % tensor.ndim for d in dim]
+        dim = normalize_indices(tensor.ndim, dim, unique=False)
 
     def can_be_singleton(d: int) -> bool:
         if dim is not None and d not in dim:

--- a/src/mrpro/utils/reshape.py
+++ b/src/mrpro/utils/reshape.py
@@ -10,6 +10,70 @@ import torch
 from mrpro.utils.typing import endomorph
 
 
+def normalize_index(ndim: int, index: int) -> int:
+    """Normalize possibly negative indices.
+
+    Parameters
+    ----------
+    ndim
+        number of dimensions
+    index
+        index to normalize. negative indices count from the end.
+
+    Raises
+    ------
+    `IndexError`
+        if index is outside ``[-ndim,ndim)``
+    """
+    if 0 <= index < ndim:
+        return index
+    elif -ndim <= index < 0:
+        return ndim + index
+    else:
+        raise IndexError(f'Invalid index {index} for {ndim} data dimensions')
+
+
+def normalize_indices(
+    ndim: int,
+    indices: int | Sequence[int] | None,
+    *,
+    unique: bool = True,
+) -> tuple[int, ...]:
+    """Normalize each index in indices to the range [0, ndim).
+
+    Parameters
+    ----------
+    ndim
+        Number of dimensions.
+    indices
+        One or more axis indices; negative indices count from the end.
+        None means no indices -> empty tuple.
+    unique
+        If True (default), raise ValueError when normalized indices contain duplicates.
+
+    Returns
+    -------
+    Tuple of normalized indices in [0, ndim).
+
+    Raises
+    ------
+    IndexError
+        If any index is outside ``[-ndim, ndim)``.
+    ValueError
+        If unique is True and normalized indices are not unique.
+    """
+    if indices is None:
+        return ()
+
+    if isinstance(indices, int):
+        return (normalize_index(ndim, indices),)
+
+    normalized = tuple(normalize_index(ndim, i) for i in indices)
+    if unique and len(normalized) != len(set(normalized)):
+        raise IndexError(f'Axis indices must be unique after normalization; got {normalized}')
+    return normalized
+
+
 def unsqueeze_right(x: torch.Tensor, n: int) -> torch.Tensor:
     """Unsqueeze multiple times in the rightmost dimension.
 
@@ -205,10 +269,8 @@ def reduce_view(x: torch.Tensor, dim: int | Sequence[int] | None = None) -> torc
     """
     if dim is None:
         dim_: Sequence[int] = range(x.ndim)
-    elif isinstance(dim, Sequence):
-        dim_ = [d % x.ndim for d in dim]
     else:
-        dim_ = [dim % x.ndim]
+        dim_ = normalize_indices(x.ndim, dim, unique=False)
 
     stride = x.stride()
     newsize = [
@@ -441,9 +503,10 @@ def broadcasted_concatenate(tensors: Sequence[torch.Tensor], dim: int, reduce_vi
     n_dim = tensors[0].ndim
     if any(t.ndim != n_dim for t in tensors):
         raise ValueError('All tensors must have the same number of dimensions')
-    if not (-n_dim <= dim < n_dim):
-        raise ValueError(f'Dimension {dim} out of range for tensor of dimension {n_dim}')
-    dim = dim % n_dim
+    try:
+        dim = normalize_index(n_dim, dim)
+    except IndexError as e:
+        raise ValueError(f'Dimension {dim} out of range for tensor of dimension {n_dim}') from e
 
     broadcasted_shape = []
     idx = []

--- a/src/mrpro/utils/reshape.py
+++ b/src/mrpro/utils/reshape.py
@@ -11,7 +11,7 @@ from mrpro.utils.typing import endomorph
 
 
 def normalize_index(ndim: int, index: int) -> int:
-    """Normalize possibly negative indices.
+    """Normalize possibly negative index.
 
     Parameters
     ----------
@@ -59,7 +59,7 @@ def normalize_indices(
     ------
     IndexError
         If any index is outside ``[-ndim, ndim)``.
-    ValueError
+    IndexError
         If unique is True and normalized indices are not unique.
     """
     if indices is None:

--- a/src/mrpro/utils/sliding_window.py
+++ b/src/mrpro/utils/sliding_window.py
@@ -4,6 +4,8 @@ from collections.abc import Sequence
 
 import torch
 
+from mrpro.utils.reshape import normalize_indices
+
 
 def sliding_window(
     x: torch.Tensor,
@@ -45,12 +47,8 @@ def sliding_window(
 
     if dim is None:
         dim = tuple(range(ndim))
-    elif isinstance(dim, int):
-        dim = (dim % ndim,)
     else:
-        dim = tuple(ax % ndim for ax in dim)
-        if len(set(dim)) != len(dim):
-            raise ValueError('Duplicate values in axis are not allowed')
+        dim = normalize_indices(ndim, dim)
 
     n_dim = len(dim)
     window_shape_ = (window_shape,) * n_dim if isinstance(window_shape, int) else tuple(window_shape)

--- a/tests/data/test_dataclass.py
+++ b/tests/data/test_dataclass.py
@@ -370,11 +370,11 @@ def test_dataclass_split_invalid() -> None:
     a = A()
     with pytest.raises(ValueError):
         a.split(dim=0, size=2, dilation=0)
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         a.split(dim=-3, size=2, overlap=-1)
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         a.split(dim=3, size=2)
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         a.split(dim=-4, size=2, overlap=3)
     with pytest.raises(ValueError):
         a.split(dim=0, size=-2)

--- a/tests/operators/functionals/test_functionals.py
+++ b/tests/operators/functionals/test_functionals.py
@@ -6,6 +6,7 @@ import torch
 from mrpro.operators.Functional import ElementaryFunctional, ElementaryProximableFunctional
 from mrpro.operators.functionals import MSE, L1Norm, L1NormViewAsReal, L2NormSquared, ZeroFunctional
 from mrpro.utils import RandomGenerator
+from mrpro.utils.reshape import normalize_indices
 from typing_extensions import TypedDict
 
 from tests.operators.functionals.conftest import (
@@ -42,11 +43,11 @@ def test_functional_shape(functional: type[ElementaryFunctional], shape: torch.S
         # make all dimensions singleton
         expected_shape = (1,) * len(shape)
     elif not keepdim:
-        # remove the dimensions in dim
-        expected_shape = tuple([s for i, s in enumerate(shape) if i not in torch.tensor(dim) % len(shape)])
+        normalized = normalize_indices(len(shape), dim)
+        expected_shape = tuple(s for i, s in enumerate(shape) if i not in normalized)
     elif keepdim:
-        # make the dimensions in dim singleton
-        expected_shape = tuple([s if i not in torch.tensor(dim) % len(shape) else 1 for i, s in enumerate(shape)])
+        normalized = normalize_indices(len(shape), dim)
+        expected_shape = tuple(s if i not in normalized else 1 for i, s in enumerate(shape))
     assert fx.shape == expected_shape
 
 

--- a/tests/operators/test_patch_op.py
+++ b/tests/operators/test_patch_op.py
@@ -53,7 +53,7 @@ def test_patch_op_autodiff(
 
 def test_patch_op_invalid() -> None:
     """Test invalid parameters for PatchOp."""
-    with pytest.raises(ValueError, match='Duplicate values in axis are not allowed'):
+    with pytest.raises(ValueError, match='must be unique'):
         PatchOp(dim=(0, 0), patch_size=3)
 
     with pytest.raises(ValueError, match='patch_size must be positive'):
@@ -96,7 +96,7 @@ def test_patch_op_invalid() -> None:
         PatchOp(dim=(1, 2), patch_size=1, domain_size=(1,))
 
     operator = PatchOp(dim=(0, -1), patch_size=3)
-    with pytest.raises(ValueError, match='Duplicate values in axis are not allowed'):
+    with pytest.raises(IndexError, match='unique'):
         operator(torch.ones(10))
 
     operator = PatchOp(dim=0, patch_size=3)

--- a/tests/operators/test_wavelet_op.py
+++ b/tests/operators/test_wavelet_op.py
@@ -8,6 +8,7 @@ import torch
 from mrpro.operators import WaveletOp
 from mrpro.operators.WaveletOp import WaveletType
 from mrpro.utils import RandomGenerator
+from mrpro.utils.reshape import normalize_indices
 from ptwt.conv_transform import wavedec
 from ptwt.conv_transform_2 import wavedec2
 from ptwt.conv_transform_3 import wavedec3
@@ -36,7 +37,7 @@ def create_wavelet_op_and_domain_range(
     wavelet_stack_length = torch.sum(torch.as_tensor([(np.prod(shape)) for shape in wavelet_op.coefficients_shape]))
 
     # sorted and normed dimensions needed to correctly calculate range
-    dim_sorted = sorted([d % len(img_shape) for d in dim], reverse=True)
+    dim_sorted = sorted(normalize_indices(len(img_shape), dim), reverse=True)
     range_shape = list(img_shape)
     range_shape[dim_sorted[-1]] = int(wavelet_stack_length)
     [range_shape.pop(d) for d in dim_sorted[:-1]]

--- a/tests/utils/test_fill_range.py
+++ b/tests/utils/test_fill_range.py
@@ -17,7 +17,7 @@ def test_fill_range(dtype):
 def test_fill_range_dim_out_of_range():
     """Test fill_range_ with a dimension out of range."""
     tensor = torch.zeros(3, 4)
-    with pytest.raises(IndexError, match='Dimension 2 is out of range'):
+    with pytest.raises(IndexError, match='index 2'):
         fill_range_(tensor, dim=2)
-    with pytest.raises(IndexError, match='Dimension -3 is out of range'):
+    with pytest.raises(IndexError, match='index -3'):
         fill_range_(tensor, dim=-3)

--- a/tests/utils/test_interpolate.py
+++ b/tests/utils/test_interpolate.py
@@ -37,7 +37,7 @@ def test_interpolate_size_dim_mismatch() -> None:
 
 def test_interpolate_unique_dim() -> None:
     """Test non-unique interpolate dimensions."""
-    with pytest.raises(ValueError, match='Dim must be unique'):
+    with pytest.raises(IndexError, match='unique'):
         interpolate(torch.randn((2, 2, 2)), dim=(-1, -2, 1), size=(2, 2, 2))
 
 

--- a/tests/utils/test_reshape.py
+++ b/tests/utils/test_reshape.py
@@ -1,5 +1,7 @@
 """Tests for reshaping utilities."""
 
+from collections.abc import Sequence
+
 import numpy as np
 import pytest
 import torch
@@ -7,6 +9,8 @@ from mrpro.utils import (
     RandomGenerator,
     broadcast_right,
     broadcasted_rearrange,
+    normalize_index,
+    normalize_indices,
     ravel_multi_index,
     reduce_view,
     reshape_broadcasted,
@@ -17,6 +21,57 @@ from mrpro.utils import (
     unsqueeze_tensors_left,
     unsqueeze_tensors_right,
 )
+
+
+@pytest.mark.parametrize(
+    ('ndim', 'index', 'expected'),
+    [
+        (3, 0, 0),
+        (3, 2, 2),
+        (3, -1, 2),
+        (3, -3, 0),
+        (5, -4, 1),
+    ],
+)
+def test_normalize_index(ndim: int, index: int, expected: int) -> None:
+    assert normalize_index(ndim, index) == expected
+
+
+def test_normalize_index_out_of_range() -> None:
+    with pytest.raises(IndexError, match='Invalid index'):
+        normalize_index(2, 3)
+    with pytest.raises(IndexError, match='Invalid index'):
+        normalize_index(1, -2)
+    with pytest.raises(IndexError, match='Invalid index'):
+        normalize_index(0, 0)
+
+
+@pytest.mark.parametrize(
+    ('ndim', 'indices', 'expected'),
+    [
+        (3, 0, (0,)),
+        (3, -1, (2,)),
+        (3, [0, -1], (0, 2)),
+        (3, (1, 2), (1, 2)),
+        (3, (0, 0), (0, 0)),
+    ],
+)
+def test_normalize_indices(ndim: int, indices: int | Sequence[int], expected: tuple[int, ...]) -> None:
+    assert normalize_indices(ndim, indices, unique=False) == expected
+
+
+def test_normalize_indices_duplicate_raises() -> None:
+    with pytest.raises(IndexError, match='must be unique'):
+        normalize_indices(2, (0, -2), unique=True)
+    with pytest.raises(IndexError, match='must be unique'):
+        normalize_indices(1, (0, 0), unique=True)
+
+
+def test_normalize_indices_out_of_range() -> None:
+    with pytest.raises(IndexError, match='Invalid index'):
+        normalize_indices(2, (0, 3))
+    with pytest.raises(IndexError, match='Invalid index'):
+        normalize_indices(1, -2)
 
 
 def test_broadcast_right():

--- a/tests/utils/test_window.py
+++ b/tests/utils/test_window.py
@@ -36,9 +36,9 @@ def test_window_contents(shape, window_shape, axis, stride):
 def test_repeated_axes() -> None:
     """Test that repeated axes raise an error."""
     data = torch.zeros(2, 3, 4)
-    with pytest.raises(ValueError, match='Duplicate values'):
+    with pytest.raises(IndexError, match='unique'):
         _ = sliding_window(data, window_shape=(2, 2), dim=(0, 0))
-    with pytest.raises(ValueError, match='Duplicate values'):
+    with pytest.raises(IndexError, match='unique'):
         _ = sliding_window(data, window_shape=(2, 2), dim=(0, -3))
 
 


### PR DESCRIPTION
we have many places where we normalize axes and through an error. 
we already had a normalize axis function in utils.
lets use that one more consistantly.
i also move it from the indexer helper to utils.reshape  to avoid circular imports ... 