### PR TITLE
Add "Contributors" to copyright  owners

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,8 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 Physikalisch-Technische Bundesanstalt
+   Copyright 2023 Physikalisch-Technische Bundesanstalt,
+   Copyright 2023 MRpro Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Not all code contributed to MRpro is under PTB's copyright, as some contributors are not employed by PTB. Let's make this clear by adding a second copyright line as common practice in other open source projects without copyright assignment.
(according to the counsel of LLMs, this is the correct handling of this). 

What are your opinions?
@schuenke @ckolbPTB 