### PR TITLE
Avoid forward calls in our own code

### DIFF
--- a/src/mrpro/algorithms/optimizers/pdhg.py
+++ b/src/mrpro/algorithms/optimizers/pdhg.py
@@ -219,7 +219,7 @@ def pdhg(
                 duals=duals,
                 solution=tuple(primals),
                 relaxed=primals_relaxed,
-                objective=lambda *x: f_sum.forward(*operator_matrix(*x))[0] + g_sum.forward(*x)[0],
+                objective=lambda *x: f_sum(*operator_matrix(*x))[0] + g_sum(*x)[0],
             )
             continue_iterations = callback(status)
             if continue_iterations is False:

--- a/src/mrpro/operators/CartesianSamplingOp.py
+++ b/src/mrpro/operators/CartesianSamplingOp.py
@@ -342,7 +342,7 @@ class CartesianMaskingOp(LinearOperator):
                 *sampling_op._sorted_grid_shape.zyx,
                 device=sampling_op._fft_idx.device,
             )
-            (mask,) = sampling_op.adjoint(*sampling_op.forward(ones))
+            (mask,) = sampling_op.adjoint(*sampling_op(ones))
         else:
             mask = None
         return cls(mask)
@@ -374,7 +374,7 @@ class CartesianMaskingOp(LinearOperator):
         -------
             Masked k-space data.
         """
-        return self.forward(y)
+        return super().__call__(y)
 
     @property
     def H(self) -> Self:  # noqa: N802

--- a/src/mrpro/operators/ConstraintsOp.py
+++ b/src/mrpro/operators/ConstraintsOp.py
@@ -247,7 +247,7 @@ class InverseConstraintOp(EndomorphOperator):
     @endomorph
     def invert(self, *x_constrained: torch.Tensor) -> tuple[torch.Tensor, ...]:
         """Apply constraint operator."""
-        return self.constraints_op.forward(*x_constrained)
+        return self.constraints_op(*x_constrained)
 
     @property
     def inverse(self) -> 'ConstraintsOp':

--- a/src/mrpro/operators/FastFourierOp.py
+++ b/src/mrpro/operators/FastFourierOp.py
@@ -20,10 +20,10 @@ class FastFourierOp(LinearOperator):
     forward and adjoint [FFT]_.
 
     .. note::
-        The input to both `~FastFourierOp.forward` and `~FastFourierOp.adjoint`
+        The input to both `~FastFourierOp` and `~FastFourierOp.H`
         are assumed to have the zero-frequency in the center of the data. `torch.fft.fftn`
         and `torch.fft.ifftn` expect the zero-frequency to be the first entry in the tensor.
-        Therefore in `~FastFourierOp.forward` and `~FastFourierOp.adjoint`,
+        Therefore in `~FastFourierOp` and `~FastFourierOp.H`,
         first `torch.fft.ifftshift`, then `torch.fft.fftn` or `torch.fft.ifftn`,
         finally `torch.fft.fftshift` are applied.
 

--- a/src/mrpro/operators/FourierOp.py
+++ b/src/mrpro/operators/FourierOp.py
@@ -312,7 +312,7 @@ class FourierGramOp(LinearOperator):
         -------
             Output tensor, same as the forward operation.
         """
-        return self.forward(x)
+        return super().__call__(x)
 
     @property
     def H(self) -> Self:  # noqa: N802

--- a/src/mrpro/operators/LinearOperator.py
+++ b/src/mrpro/operators/LinearOperator.py
@@ -665,7 +665,7 @@ class AdjointLinearOperator(LinearOperator):
         -------
             Tensor resulting from applying the original operator.
         """
-        return self._operator.forward(x)
+        return self._operator(x)
 
     @property
     def H(self) -> LinearOperator:  # noqa: N802

--- a/src/mrpro/operators/NonUniformFastFourierOp.py
+++ b/src/mrpro/operators/NonUniformFastFourierOp.py
@@ -464,7 +464,7 @@ class NonUniformFastFourierOpGramOp(LinearOperator):
         -------
             Output tensor, same shape as the input.
         """
-        return self.forward(x)
+        return super().__call__(x)
 
     @property
     def H(self) -> Self:  # noqa: N802

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -163,13 +163,13 @@ def autodiff_test(
     """
     # Forward-mode autodiff using jvp
     with torch.autograd.detect_anomaly():
-        v_range, jvp = torch.func.jvp(operator.forward, u, u)
+        v_range, jvp = torch.func.jvp(operator, u, u)
     assert all(x.isfinite().all() for x in v_range), 'result is not finite'
     assert all(x.isfinite().all() for x in jvp), 'JVP is not finite'
 
     # Reverse-mode autodiff using vjp
     with torch.autograd.detect_anomaly():
-        (output, vjpfunc) = torch.func.vjp(operator.forward, *u)
+        (output, vjpfunc) = torch.func.vjp(operator, *u)
         vjp = vjpfunc(v_range)
     assert all(x.isfinite().all() for x in output), 'result is not finite'
     assert all(x.isfinite().all() for x in vjp), 'VJP is not finite'
@@ -205,12 +205,12 @@ def gradient_of_linear_operator_test(
         if the gradient is not the adjoint
     """
     # Gradient of the forward via vjp
-    (_, vjpfunc) = torch.func.vjp(operator.forward, u)
+    (_, vjpfunc) = torch.func.vjp(operator, u)
     assert torch.allclose(vjpfunc((v,))[0], operator.adjoint(v)[0], rtol=relative_tolerance, atol=absolute_tolerance)
 
     # Gradient of the adjoint via vjp
     (_, vjpfunc) = torch.func.vjp(operator.adjoint, v)
-    assert torch.allclose(vjpfunc((u,))[0], operator.forward(u)[0], rtol=relative_tolerance, atol=absolute_tolerance)
+    assert torch.allclose(vjpfunc((u,))[0], operator(u)[0], rtol=relative_tolerance, atol=absolute_tolerance)
 
 
 def forward_mode_autodiff_of_linear_operator_test(
@@ -245,8 +245,8 @@ def forward_mode_autodiff_of_linear_operator_test(
     """
     # jvp of the forward
     assert torch.allclose(
-        torch.func.jvp(operator.forward, (u,), (u,))[0][0],
-        operator.forward(u)[0],
+        torch.func.jvp(operator, (u,), (u,))[0][0],
+        operator(u)[0],
         rtol=relative_tolerance,
         atol=absolute_tolerance,
     )


### PR DESCRIPTION
Ìnstead use __call__ to allow for proviling, hooking, etc
https://discuss.pytorch.org/t/is-model-forward-x-the-same-as-model-call-x/33460

We had a few places where ` .forward` was still used