### PR TITLE
Fix mypy for torch 2.11

### DIFF
--- a/src/mrpro/operators/Jacobian.py
+++ b/src/mrpro/operators/Jacobian.py
@@ -44,7 +44,7 @@ class Jacobian(LinearOperator):
             output tensor
         """
         if self._vjp is None:
-            self._f_x0, self._vjp = torch.func.vjp(self._operator, *self._x0)
+            self._f_x0, self._vjp, *_ = torch.func.vjp(self._operator, *self._x0)
         assert self._vjp is not None  # noqa: S101 (hint for mypy)
         return (self._vjp(x)[0],)
 
@@ -69,7 +69,7 @@ class Jacobian(LinearOperator):
             Prefer calling the instance of the Jacobian as ``operator(x)`` over directly calling this method.
             See this PyTorch `discussion <https://discuss.pytorch.org/t/is-model-forward-x-the-same-as-model-call-x/33460/3>`_.
         """
-        self._f_x0, jvp = torch.func.jvp(self._operator, self._x0, x)
+        self._f_x0, jvp, *_ = torch.func.jvp(self._operator, self._x0, x)
         return jvp
 
     @property
@@ -99,7 +99,7 @@ class Jacobian(LinearOperator):
             Value of the Taylor approximation at x
         """
         delta = tuple(ix - ix0 for ix, ix0 in zip(x, self._x0, strict=False))
-        self._f_x0, jvp = torch.func.jvp(self._operator, self._x0, delta)
+        self._f_x0, jvp, *_ = torch.func.jvp(self._operator, self._x0, delta)
         assert self._f_x0 is not None  # noqa: S101 (hint for mypy)
         f_x = tuple(ifx0 + ijvp for ifx0, ijvp in zip(self._f_x0, jvp, strict=False))
         return f_x

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -163,13 +163,13 @@ def autodiff_test(
     """
     # Forward-mode autodiff using jvp
     with torch.autograd.detect_anomaly():
-        v_range, jvp = torch.func.jvp(operator, u, u)
+        v_range, jvp, *_ = torch.func.jvp(operator, u, u)
     assert all(x.isfinite().all() for x in v_range), 'result is not finite'
     assert all(x.isfinite().all() for x in jvp), 'JVP is not finite'
 
     # Reverse-mode autodiff using vjp
     with torch.autograd.detect_anomaly():
-        (output, vjpfunc) = torch.func.vjp(operator, *u)
+        output, vjpfunc, *_ = torch.func.vjp(operator, *u)
         vjp = vjpfunc(v_range)
     assert all(x.isfinite().all() for x in output), 'result is not finite'
     assert all(x.isfinite().all() for x in vjp), 'VJP is not finite'
@@ -205,11 +205,11 @@ def gradient_of_linear_operator_test(
         if the gradient is not the adjoint
     """
     # Gradient of the forward via vjp
-    (_, vjpfunc) = torch.func.vjp(operator, u)
+    _, vjpfunc, *_ = torch.func.vjp(operator, u)
     assert torch.allclose(vjpfunc((v,))[0], operator.adjoint(v)[0], rtol=relative_tolerance, atol=absolute_tolerance)
 
     # Gradient of the adjoint via vjp
-    (_, vjpfunc) = torch.func.vjp(operator.adjoint, v)
+    _, vjpfunc, *_ = torch.func.vjp(operator.adjoint, v)
     assert torch.allclose(vjpfunc((u,))[0], operator(u)[0], rtol=relative_tolerance, atol=absolute_tolerance)
 
 


### PR DESCRIPTION
fixes precommit in CI.

these functions got imprecise return types added - if they would be called with different options, they would return 3 values..