### PR TITLE
Fix PCAOperator

### DIFF
--- a/src/mrpro/operators/PCACompressionOp.py
+++ b/src/mrpro/operators/PCACompressionOp.py
@@ -14,12 +14,15 @@ class PCACompressionOp(LinearOperator):
         self,
         data: torch.Tensor,
         n_components: int,
+        centering: bool = True,
     ) -> None:
         """Construct a PCA based compression operator.
 
-        The operator carries out an SVD followed by a threshold of the `n_components` largest values along the last
-        dimension of a data with shape `(*other, joint_dim, compression_dim)`.
+        The operator carries out an SVD of the correlation followed by a threshold of the `n_components` largest values
+        along the last dimension of a data with shape `(*other, joint_dim, compression_dim)`.
         A single SVD is carried out for everything along `joint_dim`. `other` are batch dimensions.
+
+        You should disable centering for MRF subspace reconstruction, and keep it enabled for coil compression.
 
         Consider combining this operator with `~mrpro.operators.RearrangeOp` to make sure the data is
         in the correct shape before applying.
@@ -30,15 +33,19 @@ class PCACompressionOp(LinearOperator):
             Data of shape `(*other, joint_dim, compression_dim)` to be used to find the principal components.
         n_components
             Number of principal components to keep along the compression_dim.
+        centering
+            Should the data be centered? With centering, only fluctuations around the mean are encoded in the
+            subspace. You should not use centering for qMRI signal compression.
         """
         super().__init__()
+        if centering:
+            data = data - data.mean(-1, keepdim=True)
         # different compression matrices along the *other dimensions
-        data = data - data.mean(-1, keepdim=True)
         correlation = einops.einsum(data, data.conj(), '... joint comp1, ... joint comp2 -> ... comp1 comp2')
-        _, _, v = torch.svd(correlation)
+        _eigenvalues, v = torch.linalg.eigh(correlation)  # faster then svd if we only care about V
         # add joint_dim along which the the compression is the same
-        v = repeat(v, '... comp1 comp2 -> ... joint_dim comp1 comp2', joint_dim=1)
-        self._compression_matrix = v[..., :n_components, :].clone()
+        v = repeat(v.conj(), '... comp1 comp2 -> ... joint_dim  comp2 comp1', joint_dim=1)
+        self._compression_matrix = v[..., -n_components:, :].flip(-2)  # V is sorted in ascending order
 
     def __call__(self, data: torch.Tensor) -> tuple[torch.Tensor,]:
         """Apply PCA-based compression to the input data.

--- a/src/mrpro/operators/PCACompressionOp.py
+++ b/src/mrpro/operators/PCACompressionOp.py
@@ -39,9 +39,9 @@ class PCACompressionOp(LinearOperator):
         """
         super().__init__()
         if centering:
-            data = data - data.mean(-1, keepdim=True)
+            data = data - data.mean(-2, keepdim=True)
         # different compression matrices along the *other dimensions
-        correlation = einops.einsum(data, data.conj(), '... joint comp1, ... joint comp2 -> ... comp1 comp2')
+        correlation = einops.einsum(data.conj(), data, '... joint comp1, ... joint comp2 -> ... comp1 comp2')
         _eigenvalues, v = torch.linalg.eigh(correlation)  # faster then svd if we only care about V
         # add joint_dim along which the the compression is the same
         v = repeat(v.conj(), '... comp1 comp2 -> ... joint_dim  comp2 comp1', joint_dim=1)

--- a/tests/data/test_kdata.py
+++ b/tests/data/test_kdata.py
@@ -353,23 +353,23 @@ def test_KData_remove_readout_os(monkeypatch, random_kheader: KHeader) -> None:
 
 
 def test_KData_compress_coils(ismrmrd_cart_high_res) -> None:
-    """Test coil combination does not alter image content (much)."""
+    """Test coil combination does not alter image content."""
     kdata = KData.from_file(ismrmrd_cart_high_res.filename, DummyTrajectory())
-    kdata = kdata.compress_coils(n_compressed_coils=4)
+    kdata_compressed = kdata.compress_coils(n_compressed_coils=4)
+    assert kdata.shape[-4] != 4, 'coil compression changed original data'
+    assert kdata_compressed.shape[-4] == 4, 'coil compression did not compress to correct number of coils'
+
+    # RSS should stay the same after compression
     ff_op = FastFourierOp(
         dim=(-1, -2),
         recon_matrix=[kdata.header.recon_matrix.x, kdata.header.recon_matrix.y],
         encoding_matrix=[kdata.header.encoding_matrix.x, kdata.header.encoding_matrix.y],
     )
     (reconstructed_img,) = ff_op.adjoint(kdata.data)
-
-    # Image content of each coil is the same. Therefore we only compare one coil image but we need to normalize.
-    reconstructed_img = reconstructed_img[0, 0, 0, ...].abs()
-    reconstructed_img /= reconstructed_img.max()
-    ref_img = ismrmrd_cart_high_res.img_ref[0, 0, 0, ...].abs()
-    ref_img /= ref_img.max()
-
-    assert relative_image_difference(reconstructed_img, ref_img) <= 0.1
+    (reconstructed_img_compressed,) = ff_op.adjoint(kdata_compressed.data)
+    reconstructed_img = reconstructed_img.abs().square().sum(-4).sqrt()
+    reconstructed_img_compressed = reconstructed_img_compressed.abs().square().sum(-4).sqrt()
+    torch.testing.assert_close(reconstructed_img, reconstructed_img_compressed)
 
 
 @pytest.mark.parametrize(

--- a/tests/data/test_kdata.py
+++ b/tests/data/test_kdata.py
@@ -355,21 +355,19 @@ def test_KData_remove_readout_os(monkeypatch, random_kheader: KHeader) -> None:
 def test_KData_compress_coils(ismrmrd_cart_high_res) -> None:
     """Test coil combination does not alter image content."""
     kdata = KData.from_file(ismrmrd_cart_high_res.filename, DummyTrajectory())
-    kdata_compressed = kdata.compress_coils(n_compressed_coils=4)
-    assert kdata.shape[-4] != 4, 'coil compression changed original data'
-    assert kdata_compressed.shape[-4] == 4, 'coil compression did not compress to correct number of coils'
+    kdata_compressed = kdata.compress_coils(n_compressed_coils=2)
+    assert kdata.shape[-4] != 2, 'coil compression changed original data'
+    assert kdata_compressed.shape[-4] == 2, 'coil compression did not compress to correct number of coils'
 
     # RSS should stay the same after compression
     ff_op = FastFourierOp(
-        dim=(-1, -2),
-        recon_matrix=[kdata.header.recon_matrix.x, kdata.header.recon_matrix.y],
-        encoding_matrix=[kdata.header.encoding_matrix.x, kdata.header.encoding_matrix.y],
+        dim=(-1, -2), recon_matrix=kdata.header.recon_matrix, encoding_matrix=kdata.header.encoding_matrix
     )
     (reconstructed_img,) = ff_op.adjoint(kdata.data)
     (reconstructed_img_compressed,) = ff_op.adjoint(kdata_compressed.data)
     reconstructed_img = reconstructed_img.abs().square().sum(-4).sqrt()
     reconstructed_img_compressed = reconstructed_img_compressed.abs().square().sum(-4).sqrt()
-    torch.testing.assert_close(reconstructed_img, reconstructed_img_compressed)
+    assert relative_image_difference(reconstructed_img, reconstructed_img_compressed) <= 0.01
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The PCAOperator has some issues:

1. It was wrong. It did not select the n most important basis vectors, but selected the first n vector componetns of all basis vectors. Kind of a random projection in the end.
1. centering was wrong: we should center around the samples, not the compression dim
1. For use in qMRI we do not want to remove the mean and keep the centering, i.e. encode the signal, not variations around the mean.
1. Finally, the coil_compression test wrongly assumed that compressing M identical coils should result in N identical compressed coils. it should only result in one coil with signal (dominant coil direction) and remaining coils containing noise.

This fixes the operator, improves its speed (use of eigh instead of svd if we only care about the V vector), and adds a `centering ` flag.

Old behavior:
<img width="1001" height="547" alt="image" src="https://github.com/user-attachments/assets/f6ea6b6a-a9a8-4fe1-969a-ca4d6c7d6896" />

New behavior:
<img width="1789" height="590" alt="image" src="https://github.com/user-attachments/assets/eeeb0085-39e9-4a61-aeae-75739f5a2b5f" />

For this code

```python
import matplotlib.pyplot as plt
import torch
import einops
from mrpro.operators.PCACompressionOp import PCACompressionOp
from mrpro.operators.models import MonoExponentialDecay

t2_dict = torch.linspace(10, 300, 120) / 1000
m0_dict = torch.tensor(1.)
te = torch.linspace(0.01, 0.105, 20)

signal_mono_exp = MonoExponentialDecay(
    decay_time=te
)
(signal_dict,) = signal_mono_exp(m0_dict, t2_dict)


signal_dict = einops.rearrange(signal_dict, "time ... -> ... time")

n_components = 3

pca_wrong = PCACompressionOp(
    signal_dict,
    n_components=n_components,
    centering=True,
)
pca_wrong_signal, = pca_wrong.H(*pca_wrong(signal_dict))

pca_correct = PCACompressionOp(
    signal_dict,
    n_components=n_components,
    centering=False,
)
pca_correct_signal, = pca_correct.H(*pca_correct(signal_dict))

_, _, v = torch.svd(signal_dict)
svd_signal = (
    signal_dict @ v[:, :n_components]
) @ v[:, :n_components].conj().T # THIS WAS WRONG IN PCAOperator

fig, ax = plt.subplots(1, 3, figsize=(18, 6), sharey=True)

for sig_idx in range(3):
    ax[0].plot(x, signal_dict[sig_idx, :].real, label=f"Original {sig_idx}")
    ax[0].plot(
        x,
        svd_signal[sig_idx, :].real,
        ls="--",
        label=f"Recon {sig_idx}",
    )
    ax[0].set_title("SVD")

    ax[1].plot(x, signal_dict[sig_idx, :].real, label=f"Original {sig_idx}")
    ax[1].plot(
        x,
        pca_wrong_signal[sig_idx, :].real,
        ls="--",
        label=f"Recon {sig_idx}",
    )
    ax[1].set_title("PCACompressionOp centering=True")

    ax[2].plot(x, signal_dict[sig_idx, :].real, label=f"Original {sig_idx}")
    ax[2].plot(
        x,
        pca_correct_signal[sig_idx, :].real,
        ls="--",
        label=f"Recon {sig_idx}",
    )
    ax[2].set_title("PCACompressionOp centering=False")

for a in ax:
    a.set_xlabel("Echoes")

ax[0].set_ylabel("Real Signal")
ax[0].legend()
ax[1].legend()
ax[2].legend()

plt.tight_layout()
plt.show()
```