### PR TITLE
Improve NUFFT Gram for large datasets

### DIFF
--- a/src/mrpro/operators/NonUniformFastFourierOp.py
+++ b/src/mrpro/operators/NonUniformFastFourierOp.py
@@ -377,6 +377,9 @@ class NonUniformFastFourierOpGramOp(LinearOperator, adjoint_as_backward=True):
 
     This should not be used directly, but rather through the `~NonUniformFastFourierOp.gram` method of a
     `NonUniformFastFourierOp` object.
+
+    .. note::
+        Consider calling .half() on the operator to save memory at the cost of precision.
     """
 
     _kernel: torch.Tensor | None
@@ -421,32 +424,9 @@ class NonUniformFastFourierOpGramOp(LinearOperator, adjoint_as_backward=True):
         # combine joint_dims and nufft_dims
         weight = weight.flatten(start_dim=1, end_dim=-len(nufft_op._dimension_210) - 1).flatten(start_dim=2)
 
-        padded_shape = torch.Size([2 * size for size in nufft_op._im_size])
-        scale = nufft_op.scale.item() ** 2
-
-        if nufft_op._omega.shape[-2] == 3:
-            # Special case for memory-hungry 3D case
-            # We loop over the batch/coil samples to reduce peak memory usage
-            # and we create the kernel in a non-contiguous way, such that after the final
-            # permute, we are back at a contiguous tensor.
-            kernel_shape = list(weight_shape)
-            for d, s in zip(nufft_op._direction_zyx, padded_shape, strict=True):
-                kernel_shape[d] = s
-            try:
-                kernel = weight.new_empty(kernel_shape, dtype=torch.float16)
-            except torch.OutOfMemoryError:
-                kernel = torch.empty(kernel_shape, device='cpu', dtype=torch.float16)
-            kernel = kernel.permute(*permute_zyx)
-
-            for i, (w, o) in enumerate(zip(weight[:, None], nufft_op._omega[:, None], strict=True)):
-                idx = np.unravel_index(i, unflatten_other_shape)
-                kernel[idx] = gram_nufft_kernel(w, o, nufft_op._im_size)[0] * scale
-
-        else:  # 2D or 1D
-            kernel = gram_nufft_kernel(weight, nufft_op._omega, nufft_op._im_size)
-            kernel = kernel * scale
-            kernel = kernel.reshape(*unflatten_other_shape, -1, *kernel.shape[-len(nufft_op._direction_zyx) :])
-        self._kernel = kernel.permute(*unpermute_zyx)
+        kernel = gram_nufft_kernel(weight, nufft_op._omega, nufft_op._im_size)
+        kernel = kernel.reshape(*unflatten_other_shape, -1, *kernel.shape[-len(nufft_op._direction_zyx) :])
+        self._kernel = kernel.permute(*unpermute_zyx) * nufft_op.scale.item() ** 2
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
         """Apply forward of NonUniformFastFourierOpGramOp.
@@ -470,21 +450,11 @@ class NonUniformFastFourierOpGramOp(LinearOperator, adjoint_as_backward=True):
         for d, s in zip(self._dim, self._recon_shape, strict=True):
             spatial_crop[d] = slice(0, s)
 
-        if len(self._recon_shape) <= 2:  # do batch samples at once
-            x = torch.fft.fftn(x, s=padded_shape, dim=self._dim)
-            x.mul_(self._kernel)
-            x = torch.fft.ifftn(x, dim=self._dim, out=x)
-            x = x[tuple(spatial_crop)]
-            out = x.clone()  # clone to deallocate the larger x on exit
-
-        else:  # 3D: loop over batch samples to save memory
-            out = torch.empty_like(x)
-            kernel = self._kernel.expand(*x.shape[:-3], *self._kernel.shape[-3:])
-            for idx in product(*[range(s) for s in x.shape[:-3]]):
-                xi = torch.fft.fftn(x[idx], s=padded_shape, dim=self._dim)
-                xi.mul_(kernel[idx])
-                xi = torch.fft.ifftn(xi, dim=self._dim, out=xi)
-                out[idx] = xi[tuple(spatial_crop)]
+        x = torch.fft.fftn(x, s=padded_shape, dim=self._dim)
+        x.mul_(self._kernel)
+        x = torch.fft.ifftn(x, dim=self._dim, out=x)
+        x = x[tuple(spatial_crop)]
+        out = x.clone()  # clone to deallocate the larger x on exit
 
         return (out,)
 

--- a/src/mrpro/operators/NonUniformFastFourierOp.py
+++ b/src/mrpro/operators/NonUniformFastFourierOp.py
@@ -11,9 +11,9 @@ import torch
 from pytorch_finufft.functional import finufft_type1, finufft_type2
 from typing_extensions import Self
 
+from mrpro.data.DcfData import DcfData
 from mrpro.data.KTrajectory import KTrajectory
 from mrpro.data.SpatialDimension import SpatialDimension
-from mrpro.operators.FastFourierOp import FastFourierOp
 from mrpro.operators.LinearOperator import LinearOperator
 
 
@@ -316,7 +316,9 @@ def symmetrize(kernel: torch.Tensor, rank: int) -> torch.Tensor:
 
 
 def gram_nufft_kernel(
-    weight: torch.Tensor, trajectory: torch.Tensor, recon_shape: tuple[int] | tuple[int, int] | tuple[int, int, int]
+    weight: torch.Tensor,
+    trajectory: torch.Tensor,
+    recon_shape: tuple[int] | tuple[int, int] | tuple[int, int, int],
 ) -> torch.Tensor:
     """Calculate the convolution kernel for the NUFFT gram operator.
 
@@ -356,17 +358,17 @@ def gram_nufft_kernel(
             else:  # second half in the dimension
                 idx.append(slice(kernel_part.size(dim) + 1, None))
                 kernel_part = kernel_part.index_select(
-                    dim, torch.arange(kernel_part.size(dim) - 1, 0, -1, device=kernel.device)
-                )  # flip
+                    dim,
+                    torch.arange(kernel_part.size(dim) - 1, 0, -1, device=kernel.device),
+                )
         kernel[tuple(idx)] = kernel_part
 
     kernel = symmetrize(kernel, rank)
     kernel = torch.fft.hfftn(kernel, dim=list(range(-rank, 0)), norm='backward')
-    kernel = torch.fft.fftshift(kernel, dim=list(range(-rank, 0)))
     return kernel
 
 
-class NonUniformFastFourierOpGramOp(LinearOperator):
+class NonUniformFastFourierOpGramOp(LinearOperator, adjoint_as_backward=True):
     """Gram operator for `NonUniformFastFourierOp`.
 
     Implements the adjoint of the forward operator of the non-uniform Fast Fourier operator, i.e. the gram operator
@@ -381,47 +383,115 @@ class NonUniformFastFourierOpGramOp(LinearOperator):
 
     _kernel: torch.Tensor | None
 
-    def __init__(self, nufft_op: NonUniformFastFourierOp) -> None:
+    def __init__(
+        self,
+        nufft_op: NonUniformFastFourierOp,
+        weight: torch.Tensor | DcfData | None = None,
+    ) -> None:
         """Initialize the gram operator.
 
         Parameters
         ----------
         nufft_op
             The py:class:`NonUniformFastFourierOp` to calculate the gram operator for.
-
+        weight
+            Optional density compensation weights. If provided, calculates F^H W F.
         """
         super().__init__()
-        self.nufft_gram: None | LinearOperator = None
+        self._dim = nufft_op._direction_zyx
+        self._recon_shape = nufft_op._im_size
 
         if not nufft_op._dimension_210:
+            self._kernel = None
             return
 
-        weight = torch.ones(
-            [*nufft_op._traj_broadcast_shape[:-4], 1, *nufft_op._traj_broadcast_shape[-3:]],
-        ).to(nufft_op._omega)
+        if isinstance(weight, DcfData):
+            weight = weight.data
 
-        # We rearrange weight into (sep_dims, joint_dims, nufft_dims)
+        weight_shape = [*nufft_op._traj_broadcast_shape[:-4], 1, *nufft_op._traj_broadcast_shape[-3:]]
+
+        if weight is None:
+            weight = torch.ones(weight_shape, device=nufft_op._omega.device)
+        else:
+            weight = weight.to(nufft_op._omega.device).broadcast_to(weight_shape)
+
         _, permute_zyx, sep_dims_210, permute_210 = nufft_op._separate_joint_dimensions(weight.ndim)
         unpermute_zyx = torch.tensor(permute_zyx).argsort().tolist()
 
         weight = weight.permute(*permute_210)
-        unflatten_other_shape = weight.shape[: -len(nufft_op._dimension_210) - 1]  # -1 for coil
-        # combine sep_dims
-        weight = weight.flatten(end_dim=len(sep_dims_210) - 1) if len(sep_dims_210) else weight[None, :]
-        # combine joint_dims and nufft_dims
+        unflatten_other_shape = weight.shape[: -len(nufft_op._dimension_210) - 1]
+        if sep_dims_210:
+            weight = weight.flatten(end_dim=len(sep_dims_210) - 1)
+        else:
+            weight = weight[None, :]
         weight = weight.flatten(start_dim=1, end_dim=-len(nufft_op._dimension_210) - 1).flatten(start_dim=2)
 
-        kernel = gram_nufft_kernel(weight, nufft_op._omega, nufft_op._im_size)
-        kernel = kernel.reshape(*unflatten_other_shape, -1, *kernel.shape[-len(nufft_op._direction_zyx) :])
-        kernel = kernel.permute(*unpermute_zyx)
-        kernel = kernel * (nufft_op.scale) ** 2
+        padded_shape = torch.Size([2 * size for size in nufft_op._im_size])
+        scale = nufft_op.scale.item() ** 2
 
-        fft = FastFourierOp(
-            dim=nufft_op._direction_zyx,
-            encoding_matrix=[2 * s for s in nufft_op._im_size],
-            recon_matrix=nufft_op._im_size,
-        )
-        self.nufft_gram = fft.H * kernel @ fft
+        if nufft_op._omega.shape[-2] == 3:
+            # Special case for memory-hungry 3D case
+            # We loop over the batch/coil samples to reduce peak memory usage
+            # and we create the kernel in a non-contiguous way, such that after the final
+            # permute, we are back at a contiguous tensor.
+            kernel_shape = list(weight_shape)
+            for d, s in zip(nufft_op._direction_zyx, padded_shape, strict=True):
+                kernel_shape[d] = s
+            try:
+                kernel = weight.new_empty(kernel_shape, dtype=torch.float16)
+            except torch.OutOfMemoryError:
+                kernel = torch.empty(kernel_shape, device='cpu', dtype=torch.float16)
+            kernel = kernel.permute(*permute_zyx)
+
+            for i, (w, o) in enumerate(zip(weight[:, None], nufft_op._omega[:, None], strict=True)):
+                idx = np.unravel_index(i, unflatten_other_shape)
+                kernel[idx] = gram_nufft_kernel(w, o, nufft_op._im_size)[0] * scale
+
+        else:  # 2D or 1D
+            kernel = gram_nufft_kernel(weight, nufft_op._omega, nufft_op._im_size)
+            kernel = kernel * scale
+            kernel = kernel.reshape(*unflatten_other_shape, -1, *kernel.shape[-len(nufft_op._direction_zyx) :])
+        self._kernel = kernel.permute(*unpermute_zyx)
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
+        """Apply forward of NonUniformFastFourierOpGramOp.
+
+        .. note::
+            Prefer calling the instance of the NonUniformFastFourierOpGramOp operator as ``operator(x)`` over
+            directly calling this method. See this PyTorch `discussion <https://discuss.pytorch.org/t/is-model-forward-x-the-same-as-model-call-x/33460/3>`_.
+        """
+        # We do the fft and cropping here directly, as it faster and more memory efficient
+        # then using the operators. As this will be a bottleneck in iterative 3D reconstructions,
+        # it is worth the specialisation.
+
+        # This function on its own is also not autograd save (in-place ops), but we rely on the
+        # adjoint-as-backward trick for linear operators to make it work
+
+        if self._kernel is None:
+            return (x,)
+
+        padded_shape = [2 * s for s in self._recon_shape]
+        spatial_crop: list[slice | EllipsisType] = [..., slice(None), slice(None), slice(None)]
+        for d, s in zip(self._dim, self._recon_shape, strict=True):
+            spatial_crop[d] = slice(0, s)
+
+        if len(self._recon_shape) <= 2:  # do batch samples at once
+            x = torch.fft.fftn(x, s=padded_shape, dim=self._dim)
+            x.mul_(self._kernel)
+            x = torch.fft.ifftn(x, dim=self._dim, out=x)
+            x = x[tuple(spatial_crop)]
+            out = x.clone()  # clone to deallocate the larger x on exit
+
+        else:  # 3D: loop over batch samples to save memory
+            out = torch.empty_like(x)
+            kernel = self._kernel.expand(*x.shape[:-3], *self._kernel.shape[-3:])
+            for idx in product(*[range(s) for s in x.shape[:-3]]):
+                xi = torch.fft.fftn(x[idx], s=padded_shape, dim=self._dim)
+                xi.mul_(kernel[idx])
+                xi = torch.fft.ifftn(xi, dim=self._dim, out=xi)
+                out[idx] = xi[tuple(spatial_crop)]
+
+        return (out,)
 
     def __call__(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
         """Apply the Gram operator of the NonUniformFastFourierOp (NUFFT.H @ NUFFT).
@@ -440,18 +510,6 @@ class NonUniformFastFourierOpGramOp(LinearOperator):
             Output tensor, image-space data after NUFFT.H @ NUFFT has been applied.
         """
         return super().__call__(x)
-
-    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
-        """Apply forward of NonUniformFastFourierOpGramOp.
-
-        .. note::
-            Prefer calling the instance of the NonUniformFastFourierOpGramOp operator as ``operator(x)`` over
-            directly calling this method. See this PyTorch `discussion <https://discuss.pytorch.org/t/is-model-forward-x-the-same-as-model-call-x/33460/3>`_.
-        """
-        if self.nufft_gram is not None:
-            (x,) = self.nufft_gram(x)
-
-        return (x,)
 
     def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
         """Apply the adjoint of the Gram operator.

--- a/src/mrpro/operators/NonUniformFastFourierOp.py
+++ b/src/mrpro/operators/NonUniformFastFourierOp.py
@@ -425,12 +425,12 @@ class NonUniformFastFourierOpGramOp(LinearOperator, adjoint_as_backward=True):
             Optional density compensation weights. If provided, calculates F^H W F.
         """
         super().__init__()
-        self._dim = nufft_op._direction_zyx
-        self._recon_shape = nufft_op._im_size
-
-        if not nufft_op._dimension_210:
+        if not nufft_op._direction_zyx:
             self._kernel = None
             return
+
+        self._dim = nufft_op._direction_zyx
+        self._recon_shape = nufft_op._im_size
 
         if isinstance(weight, DcfData):
             weight = weight.data
@@ -568,26 +568,26 @@ class SubspaceNonUniformFastFourierOpGramOp(LinearOperator, adjoint_as_backward=
             Optional density compensation or k-space weights. If provided, calculates
             the compressed normal operator corresponding to :math:`F^H W F`.
         subspace_dim
-            Dimension of the coefficient channel in the input/output tensors. Spatial
-            dimensions are assumed to remain trailing, matching the usual MR2 image layout.
+            Dimension of the coefficient channel in the input/output tensors.
         """
         super().__init__()
+        if not nufft_op._direction_zyx:
+            self._kernel = None
+            return
+
         self._dim = nufft_op._direction_zyx
         self._recon_shape = nufft_op._im_size
         self._subspace_dim = subspace_dim
 
-        if not nufft_op._dimension_210:
-            self._kernel = None
-            return
-
         if isinstance(subspace_basis, PCACompressionOp):
-            basis = subspace_basis._compression_matrix.mH
+            basis = subspace_basis.compression_matrix.mH
         else:
             basis = subspace_basis
-        basis = basis.squeeze()
         if basis.ndim > 2:
-            raise ValueError(f'Basis cannot contain non-singleton batch dimensions; got squeezed shape {basis.shape}.')
-        elif basis.ndim == 1:  # rank-1 special case, we squeezed the singleton subspace dimension
+            basis = basis.squeeze(tuple(range(basis.ndim - 2)))
+        if basis.ndim > 2:
+            raise ValueError(f'Basis cannot contain non-singleton batch dimensions; got shape {basis.shape}.')
+        if basis.ndim == 1:  # rank-1 special case: only one coefficient
             basis = basis.unsqueeze(-1)
         basis = basis.to(device=nufft_op._omega.device)
 
@@ -625,13 +625,17 @@ class SubspaceNonUniformFastFourierOpGramOp(LinearOperator, adjoint_as_backward=
             subspace_kernel = term if subspace_kernel is None else subspace_kernel + term
 
         assert subspace_kernel is not None  # noqa: S101
+        kernel_shape = [1, 1, 1]
+        for direction, size in zip(self._dim, subspace_kernel.shape[2:], strict=True):
+            kernel_shape[direction] = size
+        subspace_kernel = subspace_kernel.reshape(*subspace_kernel.shape[:2], *kernel_shape)
         self._kernel = subspace_kernel * nufft_op.scale.item() ** 2
 
     @property
     def n_coefficients(self) -> int:
         """Number of compressed coefficient channels."""
         if self._kernel is None:
-            raise RuntimeError('n_coefficients is undefined before the Toeplitz kernel is initialized.')
+            raise RuntimeError('n_coefficients is undefined if there are no NUFFT axes.')
         return self._kernel.shape[0]
 
     @property
@@ -664,15 +668,14 @@ class SubspaceNonUniformFastFourierOpGramOp(LinearOperator, adjoint_as_backward=
             )
         x = x.movedim(subspace_dim, 0)
 
-        spatial_dims = tuple(range(x.ndim - len(self._dim), x.ndim))
         padded_shape = [2 * s for s in self._recon_shape]
-        spatial_crop: list[slice] = [slice(None)] * x.ndim
-        for d, s in zip(spatial_dims, self._recon_shape, strict=True):
+        spatial_crop: list[slice | EllipsisType] = [..., slice(None), slice(None), slice(None)]
+        for d, s in zip(self._dim, self._recon_shape, strict=True):
             spatial_crop[d] = slice(0, s)
 
-        x = torch.fft.fftn(x, s=padded_shape, dim=spatial_dims)
+        x = torch.fft.fftn(x, s=padded_shape, dim=self._dim)
         x = einops.einsum(self._kernel.to(x.dtype), x, 'coeff_out coeff_in ..., coeff_in ... -> coeff_out ...')
-        x = torch.fft.ifftn(x, dim=spatial_dims)
+        x = torch.fft.ifftn(x, dim=self._dim)
         x = x[tuple(spatial_crop)]
         out = x.clone().movedim(0, subspace_dim)
         return (out,)
@@ -683,9 +686,7 @@ class SubspaceNonUniformFastFourierOpGramOp(LinearOperator, adjoint_as_backward=
         Parameters
         ----------
         x
-            Subspace coefficient images. The coefficient axis is given by `subspace_dim`;
-            the selected spatial dimensions are trailing axes, e.g. `(coeff, z, y, x)`
-            for 3D or `(coeff, y, x)` for 2D when `subspace_dim=0`.
+            Subspace coefficient images. The coefficient axis is given by `subspace_dim`
 
         Returns
         -------
@@ -703,9 +704,8 @@ class SubspaceNonUniformFastFourierOpGramOp(LinearOperator, adjoint_as_backward=
         Parameters
         ----------
         x
-            Subspace coefficient images. The coefficient axis is given by `subspace_dim`;
-            the selected spatial dimensions are trailing axes, e.g. `(coeff, z, y, x)`
-            for 3D or `(coeff, y, x)` for 2D when `subspace_dim=0`.
+            Subspace coefficient images. The coefficient axis is given by `subspace_dim`
+
 
         Returns
         -------

--- a/src/mrpro/operators/NonUniformFastFourierOp.py
+++ b/src/mrpro/operators/NonUniformFastFourierOp.py
@@ -360,7 +360,7 @@ def gram_nufft_kernel(
                 kernel_part = kernel_part.index_select(
                     dim,
                     torch.arange(kernel_part.size(dim) - 1, 0, -1, device=kernel.device),
-                )
+                )  # flip
         kernel[tuple(idx)] = kernel_part
 
     kernel = symmetrize(kernel, rank)

--- a/src/mrpro/operators/NonUniformFastFourierOp.py
+++ b/src/mrpro/operators/NonUniformFastFourierOp.py
@@ -316,9 +316,7 @@ def symmetrize(kernel: torch.Tensor, rank: int) -> torch.Tensor:
 
 
 def gram_nufft_kernel(
-    weight: torch.Tensor,
-    trajectory: torch.Tensor,
-    recon_shape: tuple[int] | tuple[int, int] | tuple[int, int, int],
+    weight: torch.Tensor, trajectory: torch.Tensor, recon_shape: tuple[int] | tuple[int, int] | tuple[int, int, int]
 ) -> torch.Tensor:
     """Calculate the convolution kernel for the NUFFT gram operator.
 
@@ -383,11 +381,7 @@ class NonUniformFastFourierOpGramOp(LinearOperator, adjoint_as_backward=True):
 
     _kernel: torch.Tensor | None
 
-    def __init__(
-        self,
-        nufft_op: NonUniformFastFourierOp,
-        weight: torch.Tensor | DcfData | None = None,
-    ) -> None:
+    def __init__(self, nufft_op: NonUniformFastFourierOp, weight: torch.Tensor | DcfData | None = None) -> None:
         """Initialize the gram operator.
 
         Parameters
@@ -414,16 +408,17 @@ class NonUniformFastFourierOpGramOp(LinearOperator, adjoint_as_backward=True):
             weight = torch.ones(weight_shape, device=nufft_op._omega.device)
         else:
             weight = weight.to(nufft_op._omega.device).broadcast_to(weight_shape)
-
+        # We rearrange weight into (sep_dims, joint_dims, nufft_directions)
         _, permute_zyx, sep_dims_210, permute_210 = nufft_op._separate_joint_dimensions(weight.ndim)
         unpermute_zyx = torch.tensor(permute_zyx).argsort().tolist()
 
         weight = weight.permute(*permute_210)
-        unflatten_other_shape = weight.shape[: -len(nufft_op._dimension_210) - 1]
-        if sep_dims_210:
+        unflatten_other_shape = weight.shape[: -len(nufft_op._dimension_210) - 1]  # -1 for coil
+        if sep_dims_210:  # combine sep_dims
             weight = weight.flatten(end_dim=len(sep_dims_210) - 1)
         else:
             weight = weight[None, :]
+        # combine joint_dims and nufft_dims
         weight = weight.flatten(start_dim=1, end_dim=-len(nufft_op._dimension_210) - 1).flatten(start_dim=2)
 
         padded_shape = torch.Size([2 * size for size in nufft_op._im_size])

--- a/src/mrpro/operators/NonUniformFastFourierOp.py
+++ b/src/mrpro/operators/NonUniformFastFourierOp.py
@@ -6,6 +6,7 @@ from itertools import product
 from types import EllipsisType
 from typing import Literal
 
+import einops
 import numpy as np
 import torch
 from pytorch_finufft.functional import finufft_type1, finufft_type2
@@ -15,6 +16,8 @@ from mrpro.data.DcfData import DcfData
 from mrpro.data.KTrajectory import KTrajectory
 from mrpro.data.SpatialDimension import SpatialDimension
 from mrpro.operators.LinearOperator import LinearOperator
+from mrpro.operators.PCACompressionOp import PCACompressionOp
+from mrpro.utils import normalize_index, unsqueeze_right
 
 
 class NonUniformFastFourierOp(LinearOperator, adjoint_as_backward=True):
@@ -200,12 +203,14 @@ class NonUniformFastFourierOp(LinearOperator, adjoint_as_backward=True):
         Parameters
         ----------
         x
-            Coil image data, typically with shape `(..., coils, z, y, x)`.
+            Image-space data with selected spatial dimensions as trailing axes, e.g.
+            `(..., coils, z, y, x)` for 3D or `(..., coils, y, x)` for 2D.
 
         Returns
         -------
-            Coil k-space data at non-uniform locations,
-            with shape `(..., coils, k2, k1, k0)`.
+            K-space data at the non-uniform trajectory locations with the same leading
+            dimensions as the input and trailing sampled dimensions, e.g.
+            `(..., coils, k2, k1, k0)` for 3D or `(..., coils, k1, k0)` for 2D.
         """
         return super().__call__(x)
 
@@ -282,10 +287,35 @@ class NonUniformFastFourierOp(LinearOperator, adjoint_as_backward=True):
             x = x.permute(*unpermute_zyx)
         return (x,)
 
+    def toeplitz(
+        self,
+        weight: torch.Tensor | DcfData | None = None,
+        subspace: torch.Tensor | PCACompressionOp | None = None,
+        subspace_dim: int = 0,
+    ) -> LinearOperator:
+        """Return the Toeplitz Gram operator.
+
+        Parameters
+        ----------
+        weight
+            Optional density compensation or k-space weights. If provided, calculates
+            the normal operator corresponding to :math:`F^H W F`.
+        subspace
+            Optional temporal subspace basis of shape `(n_timepoints, n_coefficients)`, or
+            a `PCACompressionOp` whose adjoint defines the temporal expansion basis.
+        subspace_dim
+            Dimension of the coefficient channel in the input/output tensors when `subspace` is provided.
+        """
+        if subspace is None:
+            return NonUniformFastFourierOpGramOp(self, weight=weight)
+        return SubspaceNonUniformFastFourierOpGramOp(
+            self, subspace_basis=subspace, weight=weight, subspace_dim=subspace_dim
+        )
+
     @property
     def gram(self) -> LinearOperator:
-        """Return the gram operator."""
-        return NonUniformFastFourierOpGramOp(self)
+        """Return the unweighted Toeplitz Gram operator."""
+        return self.toeplitz()
 
     def __repr__(self) -> str:
         """Representation method for NUFFT operator."""
@@ -404,17 +434,14 @@ class NonUniformFastFourierOpGramOp(LinearOperator, adjoint_as_backward=True):
 
         if isinstance(weight, DcfData):
             weight = weight.data
-
         weight_shape = [*nufft_op._traj_broadcast_shape[:-4], 1, *nufft_op._traj_broadcast_shape[-3:]]
-
         if weight is None:
-            weight = torch.ones(weight_shape, device=nufft_op._omega.device)
+            weight = torch.ones(weight_shape, device=nufft_op._omega.device, dtype=nufft_op._omega.dtype.to_real())
         else:
             weight = weight.to(nufft_op._omega.device).broadcast_to(weight_shape)
         # We rearrange weight into (sep_dims, joint_dims, nufft_directions)
         _, permute_zyx, sep_dims_210, permute_210 = nufft_op._separate_joint_dimensions(weight.ndim)
         unpermute_zyx = torch.tensor(permute_zyx).argsort().tolist()
-
         weight = weight.permute(*permute_210)
         unflatten_other_shape = weight.shape[: -len(nufft_op._dimension_210) - 1]  # -1 for coil
         if sep_dims_210:  # combine sep_dims
@@ -427,6 +454,14 @@ class NonUniformFastFourierOpGramOp(LinearOperator, adjoint_as_backward=True):
         kernel = gram_nufft_kernel(weight, nufft_op._omega, nufft_op._im_size)
         kernel = kernel.reshape(*unflatten_other_shape, -1, *kernel.shape[-len(nufft_op._direction_zyx) :])
         self._kernel = kernel.permute(*unpermute_zyx) * nufft_op.scale.item() ** 2
+
+    @property
+    def recon_matrix(self) -> SpatialDimension[int]:
+        """Expected reconstructed image shape as a spatial dimension."""
+        zyx = [1, 1, 1]
+        for direction, size in zip(self._dim, self._recon_shape, strict=True):
+            zyx[direction] = size
+        return SpatialDimension(*zyx)
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
         """Apply forward of NonUniformFastFourierOpGramOp.
@@ -472,7 +507,7 @@ class NonUniformFastFourierOpGramOp(LinearOperator, adjoint_as_backward=True):
 
         Returns
         -------
-            Output tensor, image-space data after NUFFT.H @ NUFFT has been applied.
+            Image-space data after applying `NUFFT.H @ NUFFT`, with the same shape as `x`.
         """
         return super().__call__(x)
 
@@ -489,7 +524,193 @@ class NonUniformFastFourierOpGramOp(LinearOperator, adjoint_as_backward=True):
 
         Returns
         -------
-            Output tensor, same shape as the input.
+            Image-space data after applying the adjoint Gram operator, with the same shape as `x`.
+        """
+        return super().__call__(x)
+
+    @property
+    def H(self) -> Self:  # noqa: N802
+        """Adjoint operator of the gram operator."""
+        return self
+
+
+class SubspaceNonUniformFastFourierOpGramOp(LinearOperator, adjoint_as_backward=True):
+    """Subspace Gram operator for `NonUniformFastFourierOp`.
+
+    This operator acts on temporally compressed coefficient images and applies the
+    compressed normal operator corresponding to a time-varying non-uniform Fourier
+    encoding. The Toeplitz kernel is precomputed once during initialization.
+
+    The current implementation is intentionally restricted to the common MRF case:
+    exactly one varying separate trajectory dimension, interpreted as time, and no
+    additional non-singleton joint trajectory dimensions.
+    """
+
+    _kernel: torch.Tensor | None
+
+    def __init__(
+        self,
+        nufft_op: NonUniformFastFourierOp,
+        subspace_basis: torch.Tensor | PCACompressionOp,
+        weight: torch.Tensor | DcfData | None = None,
+        subspace_dim: int = 0,
+    ) -> None:
+        """Initialize the subspace Gram operator.
+
+        Parameters
+        ----------
+        nufft_op
+            The non-uniform Fourier operator defining the trajectory and spatial geometry.
+        subspace_basis
+            Temporal subspace basis of shape `(n_timepoints, n_coefficients)`, or
+            a `PCACompressionOp` whose adjoint defines the temporal expansion basis.
+        weight
+            Optional density compensation or k-space weights. If provided, calculates
+            the compressed normal operator corresponding to :math:`F^H W F`.
+        subspace_dim
+            Dimension of the coefficient channel in the input/output tensors. Spatial
+            dimensions are assumed to remain trailing, matching the usual MR2 image layout.
+        """
+        super().__init__()
+        self._dim = nufft_op._direction_zyx
+        self._recon_shape = nufft_op._im_size
+        self._subspace_dim = subspace_dim
+
+        if not nufft_op._dimension_210:
+            self._kernel = None
+            return
+
+        if isinstance(subspace_basis, PCACompressionOp):
+            basis = subspace_basis._compression_matrix.mH
+        else:
+            basis = subspace_basis
+        basis = basis.squeeze()
+        if basis.ndim > 2:
+            raise ValueError(f'Basis cannot contain non-singleton batch dimensions; got squeezed shape {basis.shape}.')
+        elif basis.ndim == 1:  # rank-1 special case, we squeezed the singleton subspace dimension
+            basis = basis.unsqueeze(-1)
+        basis = basis.to(device=nufft_op._omega.device)
+
+        if isinstance(weight, DcfData):
+            weight = weight.data
+        weight_shape = [*nufft_op._traj_broadcast_shape[:-4], 1, *nufft_op._traj_broadcast_shape[-3:]]
+        if weight is None:
+            weight = torch.ones(weight_shape, device=nufft_op._omega.device, dtype=nufft_op._omega.dtype.to_real())
+        else:
+            weight = weight.to(nufft_op._omega.device).broadcast_to(weight_shape)
+        _, _permute_zyx, sep_dims_210, permute_210 = nufft_op._separate_joint_dimensions(weight.ndim)
+        weight = weight.permute(*permute_210)
+        if sep_dims_210:
+            weight = weight.flatten(end_dim=len(sep_dims_210) - 1)
+        else:
+            weight = weight[None, :]
+        weight = weight.flatten(start_dim=1, end_dim=-len(nufft_op._dimension_210) - 1).flatten(start_dim=2)
+
+        omega = nufft_op._omega
+
+        if len(sep_dims_210) > 1:
+            raise NotImplementedError(
+                'SubspaceNonUniformFastFourierOpGramOp currently only supports a single varying separate dimension.'
+            )
+        if basis.shape[0] != (n_timepoints := weight.shape[0]):
+            raise ValueError(
+                f'subspace_basis has {basis.shape[0]} time points, but the trajectory varies over {n_timepoints}.'
+            )
+
+        subspace_kernel: torch.Tensor | None = None
+        for basis_row, weight_row, omega_row in zip(basis, weight, omega, strict=True):
+            current = gram_nufft_kernel(weight_row[None], omega_row[None], nufft_op._im_size)[0, 0]
+            coeff_outer = basis_row.conj()[:, None] * basis_row[None, :]
+            term = unsqueeze_right(coeff_outer, current.ndim) * current
+            subspace_kernel = term if subspace_kernel is None else subspace_kernel + term
+
+        assert subspace_kernel is not None  # noqa: S101
+        self._kernel = subspace_kernel * nufft_op.scale.item() ** 2
+
+    @property
+    def n_coefficients(self) -> int:
+        """Number of compressed coefficient channels."""
+        if self._kernel is None:
+            raise RuntimeError('n_coefficients is undefined before the Toeplitz kernel is initialized.')
+        return self._kernel.shape[0]
+
+    @property
+    def recon_matrix(self) -> SpatialDimension[int]:
+        """Expected reconstructed image shape as a spatial dimension."""
+        zyx = [1, 1, 1]
+        for direction, size in zip(self._dim, self._recon_shape, strict=True):
+            zyx[direction] = size
+        return SpatialDimension(*zyx)
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
+        """Apply forward of SubspaceNonUniformFastFourierOpGramOp.
+
+        .. note::
+            Prefer calling the instance of the SubspaceNonUniformFastFourierOpGramOp operator as ``operator(x)`` over
+            directly calling this method. See this PyTorch `discussion <https://discuss.pytorch.org/t/is-model-forward-x-the-same-as-model-call-x/33460/3>`_.
+        """
+        # We do the fft, coefficient mixing, and cropping here directly, as it is faster and more memory efficient
+        # than using separate operators.
+
+        # This function on its own is also not autograd save (in-place ops), but we rely on the
+        # adjoint-as-backward trick for linear operators to make it work.
+        if self._kernel is None:
+            return (x,)
+        subspace_dim = normalize_index(x.ndim, self._subspace_dim)
+        if x.shape[subspace_dim] != self.n_coefficients:
+            raise ValueError(
+                f'Input has {x.shape[self._subspace_dim]} coefficients along subspace_dim={self._subspace_dim}, '
+                f'expected {self.n_coefficients}.'
+            )
+        x = x.movedim(subspace_dim, 0)
+
+        spatial_dims = tuple(range(x.ndim - len(self._dim), x.ndim))
+        padded_shape = [2 * s for s in self._recon_shape]
+        spatial_crop: list[slice] = [slice(None)] * x.ndim
+        for d, s in zip(spatial_dims, self._recon_shape, strict=True):
+            spatial_crop[d] = slice(0, s)
+
+        x = torch.fft.fftn(x, s=padded_shape, dim=spatial_dims)
+        x = einops.einsum(self._kernel.to(x.dtype), x, 'coeff_out coeff_in ..., coeff_in ... -> coeff_out ...')
+        x = torch.fft.ifftn(x, dim=spatial_dims)
+        x = x[tuple(spatial_crop)]
+        out = x.clone().movedim(0, subspace_dim)
+        return (out,)
+
+    def __call__(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
+        """Apply the compressed Toeplitz Gram operator.
+
+        Parameters
+        ----------
+        x
+            Subspace coefficient images. The coefficient axis is given by `subspace_dim`;
+            the selected spatial dimensions are trailing axes, e.g. `(coeff, z, y, x)`
+            for 3D or `(coeff, y, x)` for 2D when `subspace_dim=0`.
+
+        Returns
+        -------
+            Subspace coefficient images after applying the compressed Gram operator,
+            with the same shape as `x`.
+        """
+        return super().__call__(x)
+
+    def adjoint(self, x: torch.Tensor) -> tuple[torch.Tensor,]:
+        """Apply the adjoint of the compressed Toeplitz Gram operator.
+
+        Since the compressed Gram operator is self-adjoint, this method calls the
+        forward operation.
+
+        Parameters
+        ----------
+        x
+            Subspace coefficient images. The coefficient axis is given by `subspace_dim`;
+            the selected spatial dimensions are trailing axes, e.g. `(coeff, z, y, x)`
+            for 3D or `(coeff, y, x)` for 2D when `subspace_dim=0`.
+
+        Returns
+        -------
+            Subspace coefficient images after applying the adjoint compressed Gram operator,
+            with the same shape as `x`.
         """
         return super().__call__(x)
 

--- a/src/mrpro/operators/NonUniformFastFourierOp.py
+++ b/src/mrpro/operators/NonUniformFastFourierOp.py
@@ -462,7 +462,7 @@ class NonUniformFastFourierOpGramOp(LinearOperator, adjoint_as_backward=True):
         """
         # We do the fft and cropping here directly, as it faster and more memory efficient
         # then using the operators. As this will be a bottleneck in iterative 3D reconstructions,
-        # it is worth the specialisation.
+        # it is worth the specialization.
 
         # This function on its own is also not autograd save (in-place ops), but we rely on the
         # adjoint-as-backward trick for linear operators to make it work

--- a/src/mrpro/operators/PCACompressionOp.py
+++ b/src/mrpro/operators/PCACompressionOp.py
@@ -108,3 +108,8 @@ class PCACompressionOp(LinearOperator):
                 f'cannot be multiplied with Data {tuple(data.shape)}.'
             ) from e
         return (result,)
+
+    @property
+    def compression_matrix(self) -> torch.Tensor:
+        """Get the compression matrix."""
+        return self._compression_matrix

--- a/src/mrpro/operators/__init__.py
+++ b/src/mrpro/operators/__init__.py
@@ -35,7 +35,6 @@ from mrpro.operators.MagnitudeOp import MagnitudeOp
 from mrpro.operators.MultiIdentityOp import MultiIdentityOp
 from mrpro.operators.NonUniformFastFourierOp import (
     NonUniformFastFourierOp,
-    SubspaceNonUniformFastFourierOpGramOp,
 )
 from mrpro.operators.OptimizerOp import OptimizerOp
 from mrpro.operators.PatchOp import PatchOp
@@ -94,7 +93,6 @@ __all__ = [
     "SensitivityOp",
     "SignalModel",
     "SliceProjectionOp",
-    "SubspaceNonUniformFastFourierOpGramOp",
     "TimeSegmentedFourierOp",
     "WaveletOp",
     "ZeroOp",

--- a/src/mrpro/operators/__init__.py
+++ b/src/mrpro/operators/__init__.py
@@ -33,7 +33,10 @@ from mrpro.operators.Jacobian import Jacobian
 from mrpro.operators.LinearOperatorMatrix import LinearOperatorMatrix
 from mrpro.operators.MagnitudeOp import MagnitudeOp
 from mrpro.operators.MultiIdentityOp import MultiIdentityOp
-from mrpro.operators.NonUniformFastFourierOp import NonUniformFastFourierOp
+from mrpro.operators.NonUniformFastFourierOp import (
+    NonUniformFastFourierOp,
+    SubspaceNonUniformFastFourierOpGramOp,
+)
 from mrpro.operators.OptimizerOp import OptimizerOp
 from mrpro.operators.PatchOp import PatchOp
 from mrpro.operators.PCACompressionOp import PCACompressionOp
@@ -91,6 +94,7 @@ __all__ = [
     "SensitivityOp",
     "SignalModel",
     "SliceProjectionOp",
+    "SubspaceNonUniformFastFourierOpGramOp",
     "TimeSegmentedFourierOp",
     "WaveletOp",
     "ZeroOp",

--- a/tests/operators/test_non_uniform_fast_fourier_op.py
+++ b/tests/operators/test_non_uniform_fast_fourier_op.py
@@ -427,12 +427,12 @@ def test_non_uniform_fast_fourier_op_gram_cuda() -> None:
     image = rng.complex64_tensor((n_timepoints, 1, 1, *image_shape)).cuda()
 
     nufft_op = create_time_varying_2d_nufft_op(n_timepoints=n_timepoints, image_shape=image_shape).cuda()
-    gram = nufft_op.gram.cuda()
+    gram = nufft_op.gram
     (result,) = gram(image)
     assert result.is_cuda
 
     nufft_op = create_time_varying_2d_nufft_op(n_timepoints=n_timepoints, image_shape=image_shape)
-    gram = nufft_op.gram
+    gram = nufft_op.gram.cuda()
     (result,) = gram(image)
     assert result.is_cuda
 

--- a/tests/operators/test_non_uniform_fast_fourier_op.py
+++ b/tests/operators/test_non_uniform_fast_fourier_op.py
@@ -5,13 +5,8 @@ import pytest
 import torch
 from mrpro.data import DcfData, KData, KTrajectory, SpatialDimension
 from mrpro.data.traj_calculators import KTrajectoryIsmrmrd
-from mrpro.operators import (
-    DensityCompensationOp,
-    FastFourierOp,
-    NonUniformFastFourierOp,
-    PCACompressionOp,
-    SubspaceNonUniformFastFourierOpGramOp,
-)
+from mrpro.operators import DensityCompensationOp, FastFourierOp, NonUniformFastFourierOp, PCACompressionOp
+from mrpro.operators.NonUniformFastFourierOp import SubspaceNonUniformFastFourierOpGramOp
 from mrpro.utils import RandomGenerator
 from torch.autograd.gradcheck import gradcheck
 
@@ -30,21 +25,26 @@ def create_data(img_shape, nkx, nky, nkz, type_kx, type_ky, type_kz) -> tuple[to
 def create_time_varying_2d_nufft_op(
     n_timepoints: int = 4,
     image_shape: tuple[int, int] = (12, 10),
-    dtype: torch.dtype = torch.float32,
 ) -> NonUniformFastFourierOp:
-    """Create a small 2D NUFFT with one radial spoke per time point."""
-    angles = torch.linspace(0, torch.pi, n_timepoints + 1, dtype=dtype)[:-1]
-    readout = torch.linspace(-image_shape[-1] / 2, image_shape[-1] / 2, image_shape[-1], dtype=dtype)
-    kx = (torch.cos(angles)[:, None] * readout[None, :])[:, None, None, :]
-    ky = (torch.sin(angles)[:, None] * readout[None, :])[:, None, None, :]
-    kx = kx[:, None, :, :]
-    ky = ky[:, None, :, :]
-    kz = torch.zeros_like(kx)
-    trajectory = KTrajectory(kz=kz, ky=ky, kx=kx)
+    """Create a small time-varying 2D NUFFT over y/x."""
+    nk = (n_timepoints, 1, 1, *image_shape)
+    trajectory = create_traj(
+        nkx=nk,
+        nky=nk,
+        nkz=(n_timepoints, 1, 1, 1, 1),
+        type_kx='non-uniform',
+        type_ky='non-uniform',
+        type_kz='zero',
+    )
+    encoding_matrix = SpatialDimension(
+        int(trajectory.kz.max() - trajectory.kz.min() + 1),
+        int(trajectory.ky.max() - trajectory.ky.min() + 1),
+        int(trajectory.kx.max() - trajectory.kx.min() + 1),
+    )
     return NonUniformFastFourierOp(
         direction=(-2, -1),
         recon_matrix=SpatialDimension(z=1, y=image_shape[0], x=image_shape[1]),
-        encoding_matrix=SpatialDimension(z=1, y=image_shape[0], x=image_shape[1]),
+        encoding_matrix=encoding_matrix,
         traj=trajectory,
     )
 
@@ -290,6 +290,63 @@ def test_subspace_non_uniform_fast_fourier_op_gram() -> None:
     torch.testing.assert_close(actual, expected, rtol=2e-3, atol=2e-3)
 
 
+def test_subspace_non_uniform_fast_fourier_op_gram_non_contiguous_directions() -> None:
+    """Test subspace Toeplitz Gram over non-contiguous z/x image axes."""
+    rng = RandomGenerator(seed=7)
+    n_coefficients = 2
+    img_shape = (8, 5, 64, 1, 64)
+    nkx = (8, 1, 1, 18, 128)
+    nky = (8, 1, 1, 1, 1)
+    nkz = (8, 1, 1, 18, 128)
+    trajectory = create_traj(nkx, nky, nkz, type_kx='non-uniform', type_ky='zero', type_kz='non-uniform')
+
+    recon_matrix = SpatialDimension(img_shape[-3], img_shape[-2], img_shape[-1])
+    encoding_matrix = SpatialDimension(
+        int(trajectory.kz.max() - trajectory.kz.min() + 1),
+        int(trajectory.ky.max() - trajectory.ky.min() + 1),
+        int(trajectory.kx.max() - trajectory.kx.min() + 1),
+    )
+    direction = [d for d, e in zip(('z', 'y', 'x'), encoding_matrix.zyx, strict=False) if e > 1]
+    nufft_op = NonUniformFastFourierOp(
+        direction=direction,  # type: ignore[arg-type]
+        recon_matrix=recon_matrix,
+        encoding_matrix=encoding_matrix,
+        traj=trajectory,
+    )
+    basis = rng.complex64_tensor((img_shape[0], n_coefficients))
+    alpha = rng.complex64_tensor((n_coefficients, *img_shape[1:]))
+
+    subspace_gram = nufft_op.toeplitz(subspace=basis)
+
+    expanded = einops.einsum(basis, alpha, 'time coeff, coeff coil ... -> time coil ...')
+    (kspace,) = nufft_op(expanded)
+    (backprojected,) = nufft_op.H(kspace)
+    expected = einops.einsum(basis.conj(), backprojected, 'time coeff, time coil ... -> coeff coil ...')
+    (actual,) = subspace_gram(alpha)
+
+    torch.testing.assert_close(actual, expected, rtol=2e-3, atol=2e-3)
+
+
+@pytest.mark.parametrize('n_coefficients', [1, 2])
+def test_subspace_non_uniform_fast_fourier_op_gram_single_timepoint_basis(n_coefficients: int) -> None:
+    """Test single-timepoint bases keep their time and coefficient axes."""
+    rng = RandomGenerator(seed=8)
+    n_timepoints = 1
+    image_shape = (12, 10)
+
+    nufft_op = create_time_varying_2d_nufft_op(n_timepoints=n_timepoints, image_shape=image_shape)
+    basis = rng.complex64_tensor((n_timepoints, n_coefficients))
+    alpha = rng.complex64_tensor((n_coefficients, 1, 1, *image_shape))
+
+    expanded = einops.einsum(basis, alpha, 'time coeff, coeff joint coil ... -> time joint coil ...')
+    (kspace,) = nufft_op(expanded)
+    (backprojected,) = nufft_op.H(kspace)
+    expected = einops.einsum(basis.conj(), backprojected, 'time coeff, time joint coil ... -> coeff joint coil ...')
+    (actual,) = nufft_op.toeplitz(subspace=basis)(alpha)
+
+    torch.testing.assert_close(actual, expected, rtol=2e-3, atol=2e-3)
+
+
 def test_subspace_non_uniform_fast_fourier_op_gram_accepts_pca_operator() -> None:
     """Test subspace Gram accepts a PCACompressionOp as basis input."""
     rng = RandomGenerator(seed=2)
@@ -299,7 +356,7 @@ def test_subspace_non_uniform_fast_fourier_op_gram_accepts_pca_operator() -> Non
     nufft_op = create_time_varying_2d_nufft_op(n_timepoints=n_timepoints, image_shape=image_shape)
     training_signals = rng.complex64_tensor((1, 32, n_timepoints))
     pca_op = PCACompressionOp(training_signals, n_components=n_coefficients, centering=False)
-    basis = pca_op._compression_matrix.squeeze(0).mH
+    basis = pca_op.compression_matrix.squeeze(0).mH
     alpha = rng.complex64_tensor((n_coefficients, 1, 1, *image_shape))
 
     subspace_gram_from_pca = SubspaceNonUniformFastFourierOpGramOp(nufft_op, pca_op)
@@ -338,7 +395,6 @@ def test_non_uniform_fast_fourier_op_gram_autograd() -> None:
     nufft_op = create_time_varying_2d_nufft_op(
         n_timepoints=n_timepoints,
         image_shape=image_shape,
-        dtype=torch.float64,
     )
     operator = nufft_op.toeplitz().double()
     image = rng.complex128_tensor((n_timepoints, 1, 1, *image_shape)).requires_grad_(True)
@@ -354,7 +410,6 @@ def test_subspace_non_uniform_fast_fourier_op_gram_autograd() -> None:
     nufft_op = create_time_varying_2d_nufft_op(
         n_timepoints=n_timepoints,
         image_shape=image_shape,
-        dtype=torch.float64,
     )
     basis = rng.complex128_tensor((n_timepoints, n_coefficients))
     operator = nufft_op.toeplitz(subspace=basis).double()
@@ -397,7 +452,7 @@ def test_non_uniform_fast_fourier_op_subspace_gram_cuda() -> None:
     assert result.is_cuda
 
     nufft_op = create_time_varying_2d_nufft_op(n_timepoints=n_timepoints, image_shape=image_shape).cuda()
-    subspace_gram = nufft_op.toeplitz(subspace=basis)
+    subspace_gram = nufft_op.toeplitz(subspace=basis.cuda())
     (result,) = subspace_gram(coefficients)
     assert result.is_cuda
 

--- a/tests/operators/test_non_uniform_fast_fourier_op.py
+++ b/tests/operators/test_non_uniform_fast_fourier_op.py
@@ -1,12 +1,19 @@
 """Tests for Non-Uniform Fast Fourier operator."""
 
+import einops
 import pytest
 import torch
-from mrpro.data import KData, KTrajectory
-from mrpro.data.SpatialDimension import SpatialDimension
+from mrpro.data import DcfData, KData, KTrajectory, SpatialDimension
 from mrpro.data.traj_calculators import KTrajectoryIsmrmrd
-from mrpro.operators import FastFourierOp, NonUniformFastFourierOp
+from mrpro.operators import (
+    DensityCompensationOp,
+    FastFourierOp,
+    NonUniformFastFourierOp,
+    PCACompressionOp,
+    SubspaceNonUniformFastFourierOpGramOp,
+)
 from mrpro.utils import RandomGenerator
+from torch.autograd.gradcheck import gradcheck
 
 from tests.conftest import COMMON_MR_TRAJECTORIES, create_traj
 from tests.helper import dotproduct_adjointness_test, relative_image_difference
@@ -18,6 +25,28 @@ def create_data(img_shape, nkx, nky, nkz, type_kx, type_ky, type_kz) -> tuple[to
     img = rng.complex64_tensor(size=img_shape)
     trajectory = create_traj(nkx, nky, nkz, type_kx, type_ky, type_kz)
     return img, trajectory
+
+
+def create_time_varying_2d_nufft_op(
+    n_timepoints: int = 4,
+    image_shape: tuple[int, int] = (12, 10),
+    dtype: torch.dtype = torch.float32,
+) -> NonUniformFastFourierOp:
+    """Create a small 2D NUFFT with one radial spoke per time point."""
+    angles = torch.linspace(0, torch.pi, n_timepoints + 1, dtype=dtype)[:-1]
+    readout = torch.linspace(-image_shape[-1] / 2, image_shape[-1] / 2, image_shape[-1], dtype=dtype)
+    kx = (torch.cos(angles)[:, None] * readout[None, :])[:, None, None, :]
+    ky = (torch.sin(angles)[:, None] * readout[None, :])[:, None, None, :]
+    kx = kx[:, None, :, :]
+    ky = ky[:, None, :, :]
+    kz = torch.zeros_like(kx)
+    trajectory = KTrajectory(kz=kz, ky=ky, kx=kx)
+    return NonUniformFastFourierOp(
+        direction=(-2, -1),
+        recon_matrix=SpatialDimension(z=1, y=image_shape[0], x=image_shape[1]),
+        encoding_matrix=SpatialDimension(z=1, y=image_shape[0], x=image_shape[1]),
+        traj=trajectory,
+    )
 
 
 @COMMON_MR_TRAJECTORIES
@@ -237,6 +266,140 @@ def test_non_uniform_fast_fourier_op_repr():
     assert 'Dimension(s) along which NUFFT is applied' in repr_str
     assert 'Reconstructed image size' in repr_str
     assert 'device' in repr_str
+
+
+def test_subspace_non_uniform_fast_fourier_op_gram() -> None:
+    """Test subspace Toeplitz Gram against explicit expand-apply-compress reference."""
+    rng = RandomGenerator(seed=1)
+    n_timepoints, n_coefficients = 4, 2
+    image_shape = (12, 10)
+
+    nufft_op = create_time_varying_2d_nufft_op(n_timepoints=n_timepoints, image_shape=image_shape)
+    basis = rng.complex64_tensor((n_timepoints, n_coefficients))
+    alpha = rng.complex64_tensor((n_coefficients, 1, 1, *image_shape))
+
+    subspace_gram = nufft_op.toeplitz(subspace=basis)
+    assert isinstance(subspace_gram, SubspaceNonUniformFastFourierOpGramOp)
+
+    expanded = einops.einsum(basis, alpha, 'time coeff, coeff joint coil ... -> time joint coil ...')
+    (kspace,) = nufft_op(expanded)
+    (backprojected,) = nufft_op.H(kspace)
+    expected = einops.einsum(basis.conj(), backprojected, 'time coeff, time joint coil ... -> coeff joint coil ...')
+    (actual,) = subspace_gram(alpha)
+
+    torch.testing.assert_close(actual, expected, rtol=2e-3, atol=2e-3)
+
+
+def test_subspace_non_uniform_fast_fourier_op_gram_accepts_pca_operator() -> None:
+    """Test subspace Gram accepts a PCACompressionOp as basis input."""
+    rng = RandomGenerator(seed=2)
+    n_timepoints, n_coefficients = 4, 2
+    image_shape = (12, 10)
+
+    nufft_op = create_time_varying_2d_nufft_op(n_timepoints=n_timepoints, image_shape=image_shape)
+    training_signals = rng.complex64_tensor((1, 32, n_timepoints))
+    pca_op = PCACompressionOp(training_signals, n_components=n_coefficients, centering=False)
+    basis = pca_op._compression_matrix.squeeze(0).mH
+    alpha = rng.complex64_tensor((n_coefficients, 1, 1, *image_shape))
+
+    subspace_gram_from_pca = SubspaceNonUniformFastFourierOpGramOp(nufft_op, pca_op)
+    subspace_gram_from_basis = SubspaceNonUniformFastFourierOpGramOp(nufft_op, basis)
+
+    (actual_from_pca,) = subspace_gram_from_pca(alpha)
+    (actual_from_basis,) = subspace_gram_from_basis(alpha)
+
+    torch.testing.assert_close(actual_from_pca, actual_from_basis)
+
+
+def test_non_uniform_fast_fourier_op_weighted_toeplitz_matches_explicit_dcf_normal_operator() -> None:
+    """Test Toeplitz(weight=dcf) matches the explicit weighted normal operator F^H DCF F."""
+    rng = RandomGenerator(seed=6)
+    n_timepoints = 4
+    image_shape = (12, 10)
+
+    nufft_op = create_time_varying_2d_nufft_op(n_timepoints=n_timepoints, image_shape=image_shape)
+    image = rng.complex64_tensor((n_timepoints, 1, 1, *image_shape))
+    dcf = DcfData(data=rng.float32_tensor((n_timepoints, 1, 1, 1, image_shape[-1])))
+
+    explicit_operator = nufft_op.H @ DensityCompensationOp(dcf) @ nufft_op
+    weighted_toeplitz = nufft_op.toeplitz(weight=dcf)
+
+    (expected,) = explicit_operator(image)
+    (actual,) = weighted_toeplitz(image)
+
+    torch.testing.assert_close(actual, expected, rtol=2e-3, atol=2e-3)
+
+
+def test_non_uniform_fast_fourier_op_gram_autograd() -> None:
+    """Test autograd of the Toeplitz Gram operator."""
+    rng = RandomGenerator(seed=3)
+    n_timepoints = 2
+    image_shape = (5, 4)
+    nufft_op = create_time_varying_2d_nufft_op(
+        n_timepoints=n_timepoints,
+        image_shape=image_shape,
+        dtype=torch.float64,
+    )
+    operator = nufft_op.toeplitz().double()
+    image = rng.complex128_tensor((n_timepoints, 1, 1, *image_shape)).requires_grad_(True)
+
+    gradcheck(operator, (image,), fast_mode=True)
+
+
+def test_subspace_non_uniform_fast_fourier_op_gram_autograd() -> None:
+    """Test autograd of the subspace Toeplitz Gram operator."""
+    rng = RandomGenerator(seed=4)
+    n_timepoints, n_coefficients = 3, 2
+    image_shape = (5, 4)
+    nufft_op = create_time_varying_2d_nufft_op(
+        n_timepoints=n_timepoints,
+        image_shape=image_shape,
+        dtype=torch.float64,
+    )
+    basis = rng.complex128_tensor((n_timepoints, n_coefficients))
+    operator = nufft_op.toeplitz(subspace=basis).double()
+    coefficients = rng.complex128_tensor((n_coefficients, 1, 1, *image_shape)).requires_grad_(True)
+
+    gradcheck(operator, (coefficients,), fast_mode=True)
+
+
+@pytest.mark.cuda
+def test_non_uniform_fast_fourier_op_gram_cuda() -> None:
+    """Test Toeplitz Gram operators work on CUDA devices."""
+    rng = RandomGenerator(seed=5)
+    n_timepoints = 4
+    image_shape = (12, 10)
+    image = rng.complex64_tensor((n_timepoints, 1, 1, *image_shape)).cuda()
+
+    nufft_op = create_time_varying_2d_nufft_op(n_timepoints=n_timepoints, image_shape=image_shape).cuda()
+    gram = nufft_op.gram.cuda()
+    (result,) = gram(image)
+    assert result.is_cuda
+
+    nufft_op = create_time_varying_2d_nufft_op(n_timepoints=n_timepoints, image_shape=image_shape)
+    gram = nufft_op.gram
+    (result,) = gram(image)
+    assert result.is_cuda
+
+
+@pytest.mark.cuda
+def test_non_uniform_fast_fourier_op_subspace_gram_cuda() -> None:
+    """Test subspace Toeplitz Gram operators work on CUDA devices."""
+    rng = RandomGenerator(seed=5)
+    n_timepoints, n_coefficients = 4, 2
+    image_shape = (12, 10)
+    coefficients = rng.complex64_tensor((n_coefficients, 1, 1, *image_shape)).cuda()
+    basis = rng.complex64_tensor((n_timepoints, n_coefficients))
+
+    nufft_op = create_time_varying_2d_nufft_op(n_timepoints=n_timepoints, image_shape=image_shape)
+    subspace_gram = nufft_op.toeplitz(subspace=basis).cuda()
+    (result,) = subspace_gram(coefficients)
+    assert result.is_cuda
+
+    nufft_op = create_time_varying_2d_nufft_op(n_timepoints=n_timepoints, image_shape=image_shape).cuda()
+    subspace_gram = nufft_op.toeplitz(subspace=basis)
+    (result,) = subspace_gram(coefficients)
+    assert result.is_cuda
 
 
 @pytest.mark.cuda


### PR DESCRIPTION
This makes it possible to do iterative reconstruction on large non cartesian 3D datasets by
1. memory efficient in-place operations 
1. avoiding fftshifts
1. avoiding unnesesarry intermedate allocations


Additionally, the optional DCF weighting is now exposed in NonUniformFastFourierOpGramOp. It was already implemented in the backend, but there was no way to use it. Fourier.gram will still not use it, only if created manually with an additional argument `weight `

For subpsace compressed reconstruction, one needs PCA^H Fourier^H Fourier PCA
So for, for example, 500 different trajectories in the Fourier operator and 5 subspace coefficients, we would have to do 500 FFTs and save 500 Toeplitz kernels. This would be to slow for iterative recon inside a neural network.
Instead, we can pull the subspace compressin into the kernel. The kernel is not longer a real valued 2D image, but includes off-diagonal mixing; in this example 5x5x(2*recon_y)x(2*recon_x) and we only require 5 FFTs

Finally, it adds a .toeplitz function on the nufft operator as a .gram with more control about density compensation and subsapce compression. .gram uses it with the default parameters. Gram is a property and cannot take arguments, gram gets chained through, whereas topelitz needs to be called with the options on the nufft operator for more granular control