### PR TITLE
Fix width logic in SliceProjectionOp

### DIFF
--- a/src/mrpro/operators/SliceProjectionOp.py
+++ b/src/mrpro/operators/SliceProjectionOp.py
@@ -158,7 +158,7 @@ class SliceProjectionOp(LinearOperator):
         def _find_width(slice_profile: TensorFunction) -> int:
             # figure out how far along the profile we have to consider values
             # clip up to 0.01 of intensity on both sides
-            test_values = torch.arange(-max_shape, max_shape, max_shape)
+            test_values = torch.linspace(-max_shape, max_shape, 4 * max_shape + 1)
             profile = slice_profile(test_values)
             cdf = torch.cumsum(profile, -1) / profile.sum()
             left = test_values[(cdf > 0.01).int().argmax()]

--- a/tests/operators/test_slice_projection_op.py
+++ b/tests/operators/test_slice_projection_op.py
@@ -260,3 +260,14 @@ def test_slice_projection_op_cuda() -> None:
     assert result.is_cuda
 
     # Creation on GPU is not supported (see docstring)
+
+
+def test_slice_projection_op_width() -> None:
+    """Test profile width via the adjoint"""
+    width = 11
+    input_shape = SpatialDimension(100, 100, 100)
+    slice_profile = SliceSmoothedRectangular(width, 0)
+    operator = SliceProjectionOp(input_shape=input_shape, slice_profile=slice_profile, slice_shift=-0.5)
+    slices = torch.ones(1, 1, 100, 100)
+    (volume,) = operator.adjoint(slices)
+    assert (volume[:, 50, 50] > 0).sum() == width


### PR DESCRIPTION
There was some logic to autodetect width of a profile, i.e. in what range it is nonzero.
But this check was completly broken with a too large step size (only 2 steps over the volume), resulting in wrong effective slice width for width larger than 4 voxels.
See failing test in first commit:

```
    width = 11
    input_shape = SpatialDimension(100, 100, 100)
    slice_profile = SliceSmoothedRectangular(width, 0)
    operator = SliceProjectionOp(input_shape=input_shape, slice_profile=slice_profile, slice_shift=-0.5)
    slices = torch.ones(1, 1, 100, 100)
    (volume,) = operator.adjoint(slices)
    assert (volume[:, 50, 50] > 0).sum() == width
```
```
FAILED tests/operators/test_slice_projection_op.py::test_slice_projection_op_width - assert tensor(4) == 11
```
