### PR TITLE
Improve noise whitening and coil compression

### DIFF
--- a/src/mrpro/algorithms/__init__.py
+++ b/src/mrpro/algorithms/__init__.py
@@ -1,6 +1,16 @@
 """Algorithms for reconstructions, optimization, density and sensitivity map estimation, etc."""
 
-from mrpro.algorithms import csm, optimizers, reconstruction, dcf
+from mrpro.algorithms import csm, dcf, optimizers, reconstruction
 from mrpro.algorithms.prewhiten_kspace import prewhiten_kspace
 from mrpro.algorithms.total_variation_denoising import total_variation_denoising
-__all__ = ["csm", "dcf", "optimizers", "prewhiten_kspace", "reconstruction", "total_variation_denoising"]
+from mrpro.algorithms.varimax import varimax
+
+__all__ = [
+    'csm',
+    'dcf',
+    'optimizers',
+    'prewhiten_kspace',
+    'reconstruction',
+    'total_variation_denoising',
+    'varimax',
+]

--- a/src/mrpro/algorithms/prewhiten_kspace.py
+++ b/src/mrpro/algorithms/prewhiten_kspace.py
@@ -21,10 +21,9 @@ def prewhiten_kspace(kdata: KData, knoise: KNoise, scale_factor: float | torch.T
 
     More information can be found in [ISMa]_ [HAN2014]_ [ROE1990]_.
 
-    If the data has more samples in the 'other'-dimensions (batch/slice/...),
-    the noise covariance matrix is calculated jointly over all samples.
-    Thus, if the noise is not stationary, the noise covariance matrix is not accurate.
-    In this case, the function should be called for each sample separately.
+    If the noise data has more samples in the 'other'-dimensions (batch/slice/...),
+    the covariance matrix is calculated independently for each sample in these dimensions.
+    Singleton leading dimensions in ``knoise`` are broadcast over matching dimensions in ``kdata``.
 
     Parameters
     ----------
@@ -49,21 +48,21 @@ def prewhiten_kspace(kdata: KData, knoise: KNoise, scale_factor: float | torch.T
     .. [ROE1990] Roemer P, Mueller O (1990) The NMR phased array. MRM 16(2)
             https://doi.org/10.1002/mrm.1910160203
     """
-    # Reshape noise to (coil, everything else)
-    noise = rearrange(knoise.data, '... coils k2 k1 k0->coils (... k2 k1 k0)')
+    # Reshape noise to (..., coil, everything else)
+    noise = rearrange(knoise.data, '... coils k2 k1 k0 -> ... coils (k2 k1 k0)')
 
     # Calculate noise covariance matrix and Cholesky decomposition
     noise_cov = (1.0 / (noise.shape[-1])) * einsum(
-        noise, noise.conj(), 'coil1 everythingelse, coil2 everythingelse -> coil1 coil2'
+        noise, noise.conj(), '... coil1 everythingelse, ... coil2 everythingelse -> ... coil1 coil2'
     )
 
     cholsky = torch.linalg.cholesky(noise_cov)
 
     # solve_triangular is numerically more stable than inverting the matrix
-    kdata_flat = rearrange(kdata.data, '... coils k2 k1 k0 -> coils (... k2 k1 k0)')
+    kdata_flat = rearrange(kdata.data, '... coils k2 k1 k0 -> ... coils (k2 k1 k0)')
     whitened = torch.linalg.solve_triangular(cholsky, kdata_flat, upper=False)
     whitened = rearrange(
-        whitened, 'coil (other k2 k1 k0)-> other coil k2 k1 k0', **parse_shape(kdata.data, '... k2 k1 k0')
+        whitened, '... coil (k2 k1 k0) -> ... coil k2 k1 k0', **parse_shape(kdata.data, '... k2 k1 k0')
     )
     whitened = whitened * (scale_factor**0.5)
     whitened = whitened.reshape(kdata.data.shape)

--- a/src/mrpro/algorithms/prewhiten_kspace.py
+++ b/src/mrpro/algorithms/prewhiten_kspace.py
@@ -60,14 +60,14 @@ def prewhiten_kspace(kdata: KData, knoise: KNoise, scale_factor: float | torch.T
     cholsky = torch.linalg.cholesky(noise_cov)
 
     # solve_triangular is numerically more stable than inverting the matrix
-    # but requires a single batch dimension
-    kdata_flat = rearrange(kdata.data, '... coil k2 k1 k0 -> (... k2 k1 k0) coil 1')
-    whitened_flat = torch.linalg.solve_triangular(cholsky, kdata_flat, upper=False)
-    whitened_flatother = rearrange(
-        whitened_flat, '(other k2 k1 k0) coil 1-> other coil k2 k1 k0', **parse_shape(kdata.data, '... k2 k1 k0')
+    kdata_flat = rearrange(kdata.data, '... coils k2 k1 k0 -> coils (... k2 k1 k0)')
+    whitened = torch.linalg.solve_triangular(cholsky, kdata_flat, upper=False)
+    whitened = rearrange(
+           whitened, 'coil (other k2 k1 k0)-> other coil k2 k1 k0', **parse_shape(kdata.data, '... k2 k1 k0')
     )
-    whitened_data = whitened_flatother.reshape(kdata.data.shape) * torch.as_tensor(scale_factor).sqrt()
+    whitened = whitened * (scale_factor**0.5)
+    whitened = whitened.reshape(kdata.data.shape)
     header = deepcopy(kdata.header)
     traj = deepcopy(kdata.traj)
 
-    return KData(header, whitened_data, traj)
+    return KData(header, whitened, traj)

--- a/src/mrpro/algorithms/prewhiten_kspace.py
+++ b/src/mrpro/algorithms/prewhiten_kspace.py
@@ -63,7 +63,7 @@ def prewhiten_kspace(kdata: KData, knoise: KNoise, scale_factor: float | torch.T
     kdata_flat = rearrange(kdata.data, '... coils k2 k1 k0 -> coils (... k2 k1 k0)')
     whitened = torch.linalg.solve_triangular(cholsky, kdata_flat, upper=False)
     whitened = rearrange(
-           whitened, 'coil (other k2 k1 k0)-> other coil k2 k1 k0', **parse_shape(kdata.data, '... k2 k1 k0')
+        whitened, 'coil (other k2 k1 k0)-> other coil k2 k1 k0', **parse_shape(kdata.data, '... k2 k1 k0')
     )
     whitened = whitened * (scale_factor**0.5)
     whitened = whitened.reshape(kdata.data.shape)

--- a/src/mrpro/algorithms/varimax.py
+++ b/src/mrpro/algorithms/varimax.py
@@ -1,0 +1,39 @@
+"""Varimax rotation."""
+
+import torch
+from einops import rearrange
+
+
+def varimax(phi: torch.Tensor, gamma: float = 1.0, n_iterations: int = 20) -> torch.Tensor:
+    """Apply an orthogonal Varimax rotation.
+
+    Parameters
+    ----------
+    phi
+        Input matrix of shape `(*batch, n_components, n_channels)`.
+        Rotation is performed across the `n_components` dimension.
+    gamma
+        Power parameter for the orthomax criterion. `1.0` gives Varimax.
+    n_iterations
+        Number of rotation iterations.
+
+    Returns
+    -------
+        Rotated matrix with the same shape as `phi`.
+    """
+    if n_iterations < 0:
+        raise ValueError('Number of iterations must be non-negative.')
+
+    loadings = rearrange(phi, '... components channels -> ... channels components')
+    n_components = loadings.shape[-1]
+    rotation = torch.eye(n_components, dtype=phi.dtype, device=phi.device)
+
+    for _ in range(n_iterations):
+        rotated = loadings @ rotation
+        squared_magnitude = rotated.abs().square()
+        mean_squared_magnitude = squared_magnitude.mean(dim=-2, keepdim=True)
+        weighted_loadings = rotated * (squared_magnitude - gamma * mean_squared_magnitude)
+        u, _, vh = torch.linalg.svd(loadings.mH @ weighted_loadings)
+        rotation = u @ vh
+
+    return rearrange(loadings @ rotation, '... channels components -> ... components channels')

--- a/src/mrpro/data/KData.py
+++ b/src/mrpro/data/KData.py
@@ -558,7 +558,7 @@ class KData(Dataclass):
         Parameters
         ----------
         knoise
-            Noise measurements. Either a KNoise object or a tensor of shape (coils, k0).
+            Noise measurements. Either a KNoise object or a tensor of shape ``(..., coils, k0)``.
         scale_factor
             Square root is applied on the noise covariance matrix. Used to adjust for effective noise bandwidth
             and difference in sampling rate between noise calibration and actual measurement:

--- a/src/mrpro/data/KData.py
+++ b/src/mrpro/data/KData.py
@@ -7,14 +7,17 @@ import warnings
 from collections.abc import Callable, Mapping, Sequence
 from importlib.metadata import version
 from types import EllipsisType
-from typing import Literal, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 import h5py
 import ismrmrd
 import numpy as np
 import torch
 from einops import rearrange
-from typing_extensions import Self, TypeVar
+from typing_extensions import Self, TypeVar, overload
+
+if TYPE_CHECKING:
+    from mrpro.operators.LinearOperator import LinearOperator
 
 from mrpro.data.acq_filters import has_n_coils, is_image_acquisition
 from mrpro.data.AcqInfo import (
@@ -29,6 +32,7 @@ from mrpro.data.Dataclass import Dataclass
 from mrpro.data.EncodingLimits import EncodingLimits, Limits
 from mrpro.data.enums import AcqFlags
 from mrpro.data.KHeader import KHeader
+from mrpro.data.KNoise import KNoise
 from mrpro.data.KTrajectory import KTrajectory
 from mrpro.data.Rotation import Rotation
 from mrpro.data.traj_calculators.KTrajectoryCalculator import KTrajectoryCalculator
@@ -36,6 +40,9 @@ from mrpro.data.traj_calculators.KTrajectoryIsmrmrd import KTrajectoryIsmrmrd
 from mrpro.utils.reshape import normalize_index, normalize_indices
 from mrpro.utils.summarize import summarize_object
 from mrpro.utils.typing import FileOrPath
+
+if TYPE_CHECKING:
+    from mrpro.operators import LinearOperator
 
 RotationOrTensor = TypeVar('RotationOrTensor', bound=torch.Tensor | Rotation)
 
@@ -416,12 +423,34 @@ class KData(Dataclass):
         )
         return representation
 
+    @overload
     def compress_coils(
-        self: Self,
+        self,
         n_compressed_coils: int,
-        batch_dims: None | Sequence[int] = None,
+        batch_dims: Sequence[int] | None = None,
         joint_dims: Sequence[int] | EllipsisType = ...,
-    ) -> Self:
+        rotate: bool = False,
+        return_compression_op: Literal[False] = False,
+    ) -> Self: ...
+
+    @overload
+    def compress_coils(
+        self,
+        n_compressed_coils: int,
+        batch_dims: Sequence[int] | None = None,
+        joint_dims: Sequence[int] | EllipsisType = ...,
+        rotate: bool = False,
+        return_compression_op: Literal[True] = True,
+    ) -> tuple[Self, 'LinearOperator']: ...
+
+    def compress_coils(
+        self,
+        n_compressed_coils: int,
+        batch_dims: Sequence[int] | None = None,
+        joint_dims: Sequence[int] | EllipsisType = ...,
+        rotate: bool = False,
+        return_compression_op: bool = False,
+    ) -> Self | tuple[Self, 'LinearOperator']:
         """Reduce the number of coils based on a PCA compression.
 
         A PCA is carried out along the coil dimension and the n_compressed_coils virtual coil elements are selected. For
@@ -443,10 +472,16 @@ class KData(Dataclass):
             Dimensions which are combined to calculate single coil compression matrix (e.g. k0, k1, contrast). Default
             is that all dimensions (except for the coil dimension) are joint_dims. Only batch_dim or joint_dim can
             be defined. If joint_dims is not ... batch_dims has to be None
+        rotate
+            Apply a varimax rotation to the compression matrix to distribute the signal more equally across the
+            compressed coils.
+        return_compression_op
+            If True, return the compression operator used for compression along with the compressed data.
 
         Returns
         -------
             Copy of K-space data with compressed coils.
+            (Optional) Compression operator used for compression along with the compressed data.
 
         Raises
         ------
@@ -465,7 +500,7 @@ class KData(Dataclass):
            technique for faster reconstruction with many channels. MRM 26. https://doi.org/10.1016/j.mri.2007.04.010
 
         """
-        from mrpro.operators import PCACompressionOp
+        from mrpro.operators import PCACompressionOp, RearrangeOp
 
         coil_dim = normalize_index(self.data.ndim, -4)
 
@@ -478,38 +513,72 @@ class KData(Dataclass):
         if batch_dims is not None and joint_dims is not Ellipsis:
             raise ValueError('Either batch_dims or joint_dims can be defined not both.')
 
+        all_dims = tuple(range(self.data.ndim))
+        dim_names = (*[f'other{dim}' for dim in all_dims[:-4]], 'coils', 'kz', 'ky', 'kx')
+
         if joint_dims is not Ellipsis:
             joint_dims_normalized = normalize_indices(self.data.ndim, joint_dims)
             if coil_dim in joint_dims_normalized:
                 raise ValueError('Coil dimension must not be in joint_dims')
             batch_dims_normalized = tuple(
-                [d for d in range(self.data.ndim) if d not in joint_dims_normalized and d is not coil_dim]
+                dim for dim in all_dims if dim not in joint_dims_normalized and dim != coil_dim
             )
         else:
             batch_dims_normalized = normalize_indices(self.data.ndim, batch_dims)
             if coil_dim in batch_dims_normalized:
                 raise ValueError('Coil dimension must not be in batch_dims')
+            joint_dims_normalized = tuple(
+                dim for dim in all_dims if dim not in batch_dims_normalized and dim != coil_dim
+            )
 
-        # reshape to (*batch dimension, -1, coils)
-        permute_order = (
-            *batch_dims_normalized,
-            *[i for i in range(self.data.ndim) if i != coil_dim and i not in batch_dims_normalized],
-            coil_dim,
+        batch_pattern = ' '.join(dim_names[dim] for dim in batch_dims_normalized)
+        joint_pattern = ' '.join(dim_names[dim] for dim in joint_dims_normalized)
+        input_pattern = ' '.join(dim_names)
+        to_pca_layout = RearrangeOp(
+            f'{input_pattern} -> {batch_pattern} ({joint_pattern}) coils',
+            {dim_names[dim]: self.data.shape[dim] for dim in joint_dims_normalized},
         )
-        kdata_permuted = self.data.permute(permute_order)
-        kdata_flattened = kdata_permuted.flatten(
-            start_dim=len(batch_dims_normalized), end_dim=-2
-        )  # keep separate dimensions and coil
 
-        pca_compression_op = PCACompressionOp(data=kdata_flattened, n_components=n_compressed_coils)
-        (kdata_coil_compressed_flattened,) = pca_compression_op(kdata_flattened)
+        (kdata_flattened,) = to_pca_layout(self.data)
+        pca_compression_op = PCACompressionOp(data=kdata_flattened, n_components=n_compressed_coils, rotate=rotate)
+        compression_op = to_pca_layout.H @ pca_compression_op @ to_pca_layout
+        (kdata_coil_compressed,) = compression_op(self.data)
         del kdata_flattened
-        # reshape to original dimensions and undo permutation
-        kdata_coil_compressed = torch.reshape(
-            kdata_coil_compressed_flattened, [*kdata_permuted.shape[:-1], n_compressed_coils]
-        ).permute(*np.argsort(permute_order))
 
-        return type(self)(self.header.clone(), kdata_coil_compressed, self.traj.clone())
+        kdata = type(self)(self.header.clone(), kdata_coil_compressed, self.traj.clone())
+        if return_compression_op:
+            return kdata, compression_op
+        return kdata
+
+    def prewhiten(self, knoise: KNoise | torch.Tensor, scale_factor: float | torch.Tensor = 1.0) -> Self:
+        """Calculate noise prewhitening matrix and decorrelate coils.
+
+        This is a convenience wrapper around :func:`mrpro.algorithms.prewhiten_kspace`.
+
+        Parameters
+        ----------
+        knoise
+            Noise measurements. Either a KNoise object or a tensor of shape (coils, k0).
+        scale_factor
+            Square root is applied on the noise covariance matrix. Used to adjust for effective noise bandwidth
+            and difference in sampling rate between noise calibration and actual measurement:
+            ``scale_factor = (T_acq_dwell/T_noise_dwell)*NoiseReceiverBandwidthRatio``
+
+        Returns
+        -------
+            Prewhitened copy of k-space data.
+        """
+        from mrpro.algorithms.prewhiten_kspace import prewhiten_kspace
+
+        if not isinstance(knoise, KNoise):
+            if knoise.ndim == 2:
+                knoise = rearrange(knoise, 'coils k0 -> 1 coils 1 1 k0')
+            else:
+                knoise = rearrange(knoise, '... coils k0 -> ... coils 1 1 k0')
+            knoise = KNoise(knoise)
+
+        whitened = prewhiten_kspace(self, knoise, scale_factor)
+        return type(self)(whitened.header, whitened.data, whitened.traj)
 
     def remove_readout_os(self: Self) -> Self:
         """Remove any oversampling along the readout direction.

--- a/src/mrpro/operators/PCACompressionOp.py
+++ b/src/mrpro/operators/PCACompressionOp.py
@@ -84,7 +84,7 @@ class PCACompressionOp(LinearOperator):
             result = (self._compression_matrix @ data.unsqueeze(-1)).squeeze(-1)
         except RuntimeError as e:
             raise RuntimeError(
-                'Shape or devicemismatch in Compression: '
+                'Shape or device mismatch in Compression: '
                 f'Matrix {tuple(self._compression_matrix.shape)} on {self._compression_matrix.device} '
                 f'cannot be multiplied with Data {tuple(data.shape)} on {data.device}.'
             ) from e

--- a/src/mrpro/operators/PCACompressionOp.py
+++ b/src/mrpro/operators/PCACompressionOp.py
@@ -4,6 +4,7 @@ import einops
 import torch
 from einops import repeat
 
+from mrpro.algorithms.varimax import varimax
 from mrpro.operators.LinearOperator import LinearOperator
 
 
@@ -15,6 +16,7 @@ class PCACompressionOp(LinearOperator):
         data: torch.Tensor,
         n_components: int,
         centering: bool = True,
+        rotate: bool = False,
     ) -> None:
         """Construct a PCA based compression operator.
 
@@ -36,6 +38,9 @@ class PCACompressionOp(LinearOperator):
         centering
             Should the data be centered? With centering, only fluctuations around the mean are encoded in the
             subspace. You should not use centering for qMRI signal compression.
+        rotate
+            Apply a varimax rotation to the compression matrix to distribute the signal more equally across the
+            subspace.
         """
         super().__init__()
         if centering:
@@ -45,7 +50,10 @@ class PCACompressionOp(LinearOperator):
         _eigenvalues, v = torch.linalg.eigh(correlation)  # faster then svd if we only care about V
         # add joint_dim along which the the compression is the same
         v = repeat(v.conj(), '... comp1 comp2 -> ... joint_dim  comp2 comp1', joint_dim=1)
-        self._compression_matrix = v[..., -n_components:, :].flip(-2)  # V is sorted in ascending order
+        v = v[..., -n_components:, :].flip(-2)  # V is sorted in ascending order
+        if rotate:
+            v = varimax(v)
+        self._compression_matrix = v
 
     def __call__(self, data: torch.Tensor) -> tuple[torch.Tensor,]:
         """Apply PCA-based compression to the input data.
@@ -76,9 +84,9 @@ class PCACompressionOp(LinearOperator):
             result = (self._compression_matrix @ data.unsqueeze(-1)).squeeze(-1)
         except RuntimeError as e:
             raise RuntimeError(
-                'Shape mismatch in adjoint Compression: '
-                f'Matrix {tuple(self._compression_matrix.shape)} '
-                f'cannot be multiplied with Data {tuple(data.shape)}.'
+                'Shape or devicemismatch in Compression: '
+                f'Matrix {tuple(self._compression_matrix.shape)} on {self._compression_matrix.device} '
+                f'cannot be multiplied with Data {tuple(data.shape)} on {data.device}.'
             ) from e
         return (result,)
 
@@ -103,8 +111,8 @@ class PCACompressionOp(LinearOperator):
             result = (self._compression_matrix.mH @ data.unsqueeze(-1)).squeeze(-1)
         except RuntimeError as e:
             raise RuntimeError(
-                'Shape mismatch in adjoint Compression: '
-                f'Matrix^H {tuple(self._compression_matrix.mH.shape)} '
-                f'cannot be multiplied with Data {tuple(data.shape)}.'
+                'Shape or device mismatch in adjoint Compression: '
+                f'Matrix^H {tuple(self._compression_matrix.mH.shape)} on {self._compression_matrix.device} '
+                f'cannot be multiplied with Data {tuple(data.shape)} on {data.device}.'
             ) from e
         return (result,)

--- a/tests/algorithms/test_varimax.py
+++ b/tests/algorithms/test_varimax.py
@@ -1,0 +1,64 @@
+"""Tests for Varimax rotation."""
+
+import pytest
+import torch
+from mrpro.algorithms.varimax import varimax
+from mrpro.utils import RandomGenerator
+
+
+@pytest.mark.parametrize('shape', [(3, 8), (2, 3, 8)])
+def test_varimax_shape_dtype(shape: tuple[int, ...]) -> None:
+    """Varimax keeps the input shape, dtype, and device."""
+    phi = RandomGenerator(seed=0).complex64_tensor(shape)
+
+    rotated = varimax(phi, n_iterations=3)
+
+    assert rotated.shape == phi.shape
+    assert rotated.dtype == phi.dtype
+
+
+def test_varimax_preserves_orthogonality_subspace_and_variance() -> None:
+    """Varimax is a rotation and preserves the compression subspace."""
+    data = RandomGenerator(seed=0).complex64_tensor((12, 4))
+    q, _ = torch.linalg.qr(data, mode='reduced')
+    phi = q.mH
+
+    rotated = varimax(phi)
+
+    torch.testing.assert_close(rotated @ rotated.mH, phi @ phi.mH)
+    torch.testing.assert_close(rotated.mH @ rotated, phi.mH @ phi)
+    torch.testing.assert_close(rotated.abs().square().sum(), phi.abs().square().sum())
+
+
+def test_varimax_improves_objective_function() -> None:
+    """Varimax increases the variance of squared component loadings."""
+    data = RandomGenerator(seed=0).complex64_tensor((12, 4))
+    q, _ = torch.linalg.qr(data, mode='reduced')
+    phi = q.mH
+
+    rotated = varimax(phi)
+    objective = phi.abs().square().var(dim=-1).sum()
+    rotated_objective = rotated.abs().square().var(dim=-1).sum()
+
+    assert rotated_objective > objective
+
+
+def test_varimax_batched_matches_individual_rotations() -> None:
+    """Batched Varimax gives the same result as rotating each matrix separately."""
+    data = RandomGenerator(seed=0).complex64_tensor((3, 12, 4))
+    q, _ = torch.linalg.qr(data, mode='reduced')
+    phi = q.mH
+
+    batched = varimax(phi)
+    individual = torch.stack([varimax(single_phi) for single_phi in phi])
+
+    torch.testing.assert_close(batched, individual)
+
+
+def test_varimax_zero_iterations_returns_input() -> None:
+    """Zero iterations should leave the input unchanged."""
+    phi = RandomGenerator(seed=0).complex64_tensor((2, 3, 8))
+
+    rotated = varimax(phi, n_iterations=0)
+
+    torch.testing.assert_close(rotated, phi)

--- a/tests/data/test_kdata.py
+++ b/tests/data/test_kdata.py
@@ -13,7 +13,7 @@ from mrpro.data.acq_filters import has_n_coils, is_coil_calibration_acquisition,
 from mrpro.data.Dataclass import InconsistentDeviceError
 from mrpro.data.traj_calculators import KTrajectoryIsmrmrd
 from mrpro.data.traj_calculators.KTrajectoryCalculator import DummyTrajectory
-from mrpro.operators import FastFourierOp
+from mrpro.operators import FastFourierOp, LinearOperator
 from mrpro.utils import RandomGenerator
 
 from tests import relative_image_difference
@@ -370,11 +370,45 @@ def test_KData_compress_coils(ismrmrd_cart_high_res) -> None:
     assert relative_image_difference(reconstructed_img, reconstructed_img_compressed) <= 0.01
 
 
+def test_KData_compress_coils_return_compression_op(consistently_shaped_kdata: KData) -> None:
+    """Test returning the coil compression operator."""
+    n_compressed_coils = 2
+    orig_kdata_shape = consistently_shaped_kdata.data.shape
+
+    kdata, compression_op = consistently_shaped_kdata.compress_coils(
+        n_compressed_coils=n_compressed_coils, return_compression_op=True
+    )
+    (compressed_data,) = compression_op(consistently_shaped_kdata.data)
+    (expanded_data,) = compression_op.H(kdata.data)
+
+    assert kdata.data.shape == (*orig_kdata_shape[:-4], n_compressed_coils, *orig_kdata_shape[-3:])
+    assert isinstance(compression_op, LinearOperator)
+    torch.testing.assert_close(compressed_data, kdata.data)
+    assert expanded_data.shape == consistently_shaped_kdata.data.shape
+
+
+def test_KData_compress_coils_rotate(consistently_shaped_kdata: KData) -> None:
+    """Test coil compression with varimax rotation."""
+    n_compressed_coils = 2
+
+    kdata, compression_op = consistently_shaped_kdata.compress_coils(
+        n_compressed_coils=n_compressed_coils, return_compression_op=True
+    )
+    (data_expanded,) = compression_op.H(kdata.data)
+
+    kdata_rotated, rotated_compression_op = consistently_shaped_kdata.compress_coils(
+        n_compressed_coils=n_compressed_coils, rotate=True, return_compression_op=True
+    )
+    (data_expanded_rotated,) = rotated_compression_op.H(kdata_rotated.data)
+    torch.testing.assert_close(data_expanded, data_expanded_rotated)
+
+
 @pytest.mark.parametrize(
     ('batch_dims', 'joint_dims'),
     [
         (None, ...),
         ((0,), ...),
+        ((0, 1), ...),
         ((-2, -1), ...),
         (None, (-1, -2, -3)),
         (None, (0, -1, -2, -3)),
@@ -382,6 +416,7 @@ def test_KData_compress_coils(ismrmrd_cart_high_res) -> None:
     ids=[
         'single_compression',
         'batching_along_dim0',
+        'batching_along_leading_dims',
         'batching_along_dim-2_and_dim-1',
         'single_compression_for_last_3_dims',
         'single_compression_for_last_3_and_first_dims',
@@ -417,6 +452,23 @@ def test_KData_compress_coils_error_n_coils(consistently_shaped_kdata: KData) ->
     existing_coils = consistently_shaped_kdata.data.shape[-4]
     with pytest.raises(ValueError, match='greater'):
         consistently_shaped_kdata.compress_coils(existing_coils + 1)
+
+
+def test_KData_prewhiten(random_kheader) -> None:
+    """Test prewhitening with tensor noise input."""
+    n_coils = 4
+    n_k0 = 32
+    random_data = RandomGenerator(0).complex64_tensor((n_coils, n_k0))
+    trajectory = KTrajectory(
+        torch.zeros(1, 1, 1, 1, n_k0), torch.zeros(1, 1, 1, 1, n_k0), torch.zeros(1, 1, 1, 1, n_k0)
+    )
+    kdata = KData(header=random_kheader, data=random_data[None, :, None, None, :], traj=trajectory)
+
+    kdata_white = kdata.prewhiten(random_data)
+    whitened = kdata_white.data.permute(1, 0, 2, 3, 4).reshape(n_coils, -1)
+    covariance = (1.0 / whitened.shape[-1]) * torch.einsum('ax,bx->ab', whitened, whitened.conj())
+
+    torch.testing.assert_close(covariance, torch.eye(n_coils, dtype=torch.complex64))
 
 
 def test_KData_to_file(ismrmrd_cart, tmp_path_factory):

--- a/tests/data/test_kdata.py
+++ b/tests/data/test_kdata.py
@@ -8,7 +8,7 @@ from typing import Literal
 import pytest
 import torch
 from einops import repeat
-from mrpro.data import KData, KHeader, KTrajectory, SpatialDimension
+from mrpro.data import KData, KHeader, KNoise, KTrajectory, SpatialDimension
 from mrpro.data.acq_filters import has_n_coils, is_coil_calibration_acquisition, is_image_acquisition
 from mrpro.data.Dataclass import InconsistentDeviceError
 from mrpro.data.traj_calculators import KTrajectoryIsmrmrd
@@ -454,21 +454,48 @@ def test_KData_compress_coils_error_n_coils(consistently_shaped_kdata: KData) ->
         consistently_shaped_kdata.compress_coils(existing_coils + 1)
 
 
-def test_KData_prewhiten(random_kheader) -> None:
-    """Test prewhitening with tensor noise input."""
+def test_KData_prewhiten() -> None:
+    """Test split and batched prewhitening for tensor and KNoise inputs."""
+    n_batch = 2
     n_coils = 4
-    n_k0 = 32
-    random_data = RandomGenerator(0).complex64_tensor((n_coils, n_k0))
-    trajectory = KTrajectory(
-        torch.zeros(1, 1, 1, 1, n_k0), torch.zeros(1, 1, 1, 1, n_k0), torch.zeros(1, 1, 1, 1, n_k0)
+    n_k0 = 1024
+
+    rng = RandomGenerator(0)
+    kspace_data = rng.complex64_tensor((n_batch, n_coils, 1, 1, n_k0))
+    noise_data = rng.complex64_tensor((n_batch, n_coils, 1, 1, n_k0))
+
+    # create correlation between first two coils
+    noise_data[:, 0] += noise_data[:, 1] / 2
+    kspace_data[..., 0, :, :, :] += kspace_data[..., 1, :, :, :] / 2
+
+    traj = DummyTrajectory()(n_k0, torch.zeros(1, 1, 1, 1, 1), torch.zeros(1, 1, 1, 1, 1))
+    matrix = SpatialDimension(1, 1, n_k0)
+    kdata = KData(header=KHeader(matrix, matrix, matrix, matrix), data=kspace_data, traj=traj)
+    knoise = KNoise(noise_data)
+
+    whitened = kdata.prewhiten(knoise)
+
+    # result should have cloned header
+    assert whitened.header is not kdata.header
+    assert whitened.traj.kx is not kdata.traj.kx
+    assert (whitened.traj.kx == kdata.traj.kx).all()
+
+    # result should be uncorrelated
+    covariance = (1.0 / n_k0) * torch.einsum('ax,bx->ab', whitened.data[0].squeeze(), whitened.data.conj()[0].squeeze())
+    torch.testing.assert_close(covariance, torch.eye(n_coils, dtype=torch.complex64), atol=0.1, rtol=0)
+
+    # batch equivalence
+    split_whitened = torch.cat(
+        [kdata[idx].prewhiten(noise_data[idx, :, 0, 0, :]).data for idx in range(n_batch)],
+        dim=0,
     )
-    kdata = KData(header=random_kheader, data=random_data[None, :, None, None, :], traj=trajectory)
+    tensor_whitened = kdata.prewhiten(noise_data[..., 0, 0, :])
+    torch.testing.assert_close(whitened.data, split_whitened)
+    torch.testing.assert_close(tensor_whitened.data, split_whitened)
 
-    kdata_white = kdata.prewhiten(random_data)
-    whitened = kdata_white.data.permute(1, 0, 2, 3, 4).reshape(n_coils, -1)
-    covariance = (1.0 / whitened.shape[-1]) * torch.einsum('ax,bx->ab', whitened, whitened.conj())
-
-    torch.testing.assert_close(covariance, torch.eye(n_coils, dtype=torch.complex64))
+    shared_noise_whitened = kdata.prewhiten(noise_data[:1, :, 0, 0, :])
+    broadcast_knoise_whitened = kdata.prewhiten(KNoise(noise_data[:1]))
+    torch.testing.assert_close(shared_noise_whitened.data, broadcast_knoise_whitened.data)
 
 
 def test_KData_to_file(ismrmrd_cart, tmp_path_factory):

--- a/tests/operators/test_pca_compression_op.py
+++ b/tests/operators/test_pca_compression_op.py
@@ -86,6 +86,24 @@ def test_pca_compression_op_wrong_shapes() -> None:
         pca_comp_op.adjoint(input_data)
 
 
+def test_pca_compression_op_with_varimax_rotation() -> None:
+    """Test PCA compression with Varimax rotation preserves the PCA subspace."""
+    rng = RandomGenerator(seed=0)
+    data = rng.complex64_tensor((40, 10))
+    pca_comp_op = PCACompressionOp(data=data, n_components=6)
+    rotated_pca_comp_op = PCACompressionOp(data=data, n_components=6, rotate=True)
+
+    assert rotated_pca_comp_op._compression_matrix.shape == pca_comp_op._compression_matrix.shape
+    torch.testing.assert_close(
+        rotated_pca_comp_op._compression_matrix @ rotated_pca_comp_op._compression_matrix.mH,
+        pca_comp_op._compression_matrix @ pca_comp_op._compression_matrix.mH,
+    )
+    torch.testing.assert_close(
+        rotated_pca_comp_op._compression_matrix.mH @ rotated_pca_comp_op._compression_matrix,
+        pca_comp_op._compression_matrix.mH @ pca_comp_op._compression_matrix,
+    )
+
+
 @pytest.mark.cuda
 def test_pca_compression_op_cuda() -> None:
     """Test if PCA compression operator works on CUDA devices."""


### PR DESCRIPTION
- fix memory usage in coil whitening. this used >1TB for 3D datasets...
- add whitening function to KData
- add varimax option for PCA and coil compression to "rotate" thesubspace such that each of the components has more variance, instead of decreasing information content. makes for example coils a bit more statistically similiar to "real" coils.
- add option to coil compression to return a compression operator. usefull for "uncompressing" the data or applying same compression to different data
- improve tests
- improve exceptino message in PCAOperator: it also failed by mixed devices errors, but always showed a shape missmatch message.