### PR TITLE
Fix ismrmrd backward compatiblity

### DIFF
--- a/src/mrpro/data/KData.py
+++ b/src/mrpro/data/KData.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Mapping, Sequence
 from importlib.metadata import version
 from types import EllipsisType
 from typing import TYPE_CHECKING, Literal, cast
+from xml.etree import ElementTree as ET
 
 import h5py
 import ismrmrd
@@ -121,7 +122,18 @@ class KData(Dataclass):
         # Can raise FileNotFoundError
         with ismrmrd.File(filename, 'r') as file:
             dataset = file[list(file.keys())[dataset_idx]]
-            ismrmrd_header = dataset.header
+            try:
+                ismrmrd_header = dataset.header
+            except TypeError:
+                root = ET.fromstring(dataset._contents['xml'][0])  # noqa: S314
+                prefix = root.tag.removesuffix('ismrmrdHeader')
+                measurement = root.find(f'{prefix}measurementInformation')
+                if measurement is not None and measurement.find(f'{prefix}patientPosition') is None:
+                    ET.SubElement(measurement, f'{prefix}patientPosition').text = 'HFS'
+                for encoding in root.findall(f'{prefix}encoding'):
+                    if encoding.find(f'{prefix}trajectory') is None:
+                        ET.SubElement(encoding, f'{prefix}trajectory').text = 'other'
+                ismrmrd_header = ismrmrd.xsd.CreateFromDocument(ET.tostring(root))
             acquisitions = dataset.acquisitions[:]
             try:
                 mtime: int = h5py.h5g.get_objinfo(dataset['data']._contents.id).mtime

--- a/src/mrpro/data/KData.py
+++ b/src/mrpro/data/KData.py
@@ -125,6 +125,7 @@ class KData(Dataclass):
             try:
                 ismrmrd_header = dataset.header
             except TypeError:
+# Ismrmrd files created with ismrmrd<1.15 can lead to errors regarding patientPosition and trajectory type when reading in with ismrmrd >=1.15.
                 root = ET.fromstring(dataset._contents['xml'][0])  # noqa: S314
                 prefix = root.tag.removesuffix('ismrmrdHeader')
                 measurement = root.find(f'{prefix}measurementInformation')

--- a/src/mrpro/data/KData.py
+++ b/src/mrpro/data/KData.py
@@ -125,7 +125,7 @@ class KData(Dataclass):
             try:
                 ismrmrd_header = dataset.header
             except TypeError:
-# Ismrmrd files created with ismrmrd<1.15 can lead to errors regarding patientPosition and trajectory type when reading in with ismrmrd >=1.15.
+                # files created with ismrmrd<1.15 might lack patientPosition and trajectory type
                 root = ET.fromstring(dataset._contents['xml'][0])  # noqa: S314
                 prefix = root.tag.removesuffix('ismrmrdHeader')
                 measurement = root.find(f'{prefix}measurementInformation')

--- a/src/mrpro/data/KHeader.py
+++ b/src/mrpro/data/KHeader.py
@@ -190,7 +190,7 @@ class KHeader(Dataclass):
         if enc.echoTrainLength is not None:
             parameters['echo_train_length'] = enc.echoTrainLength
 
-        if enc.trajectory is not None:
+        if isinstance(enc.trajectory, ismrmrdschema.trajectoryType):
             parameters['trajectory_type'] = enums.TrajectoryType(enc.trajectory.value)
 
         # Either use the series or study time if available
@@ -217,7 +217,7 @@ class KHeader(Dataclass):
             if header.measurementInformation.protocolName is not None:
                 parameters['protocol_name'] = header.measurementInformation.protocolName
 
-            if header.measurementInformation.patientPosition is not None:
+            if isinstance(header.measurementInformation.patientPosition, ismrmrdschema.patientPositionType):
                 parameters['patient_position'] = enums.PatientPosition(
                     header.measurementInformation.patientPosition.value
                 )

--- a/tests/data/test_kdata.py
+++ b/tests/data/test_kdata.py
@@ -1,16 +1,20 @@
 """Tests for the KData class."""
 
 import re
+import shutil
 from collections.abc import Sequence
 from types import EllipsisType
 from typing import Literal
+from xml.etree import ElementTree as ET
 
+import h5py
 import pytest
 import torch
 from einops import repeat
 from mrpro.data import KData, KHeader, KNoise, KTrajectory, SpatialDimension
 from mrpro.data.acq_filters import has_n_coils, is_coil_calibration_acquisition, is_image_acquisition
 from mrpro.data.Dataclass import InconsistentDeviceError
+from mrpro.data.enums import TrajectoryType
 from mrpro.data.traj_calculators import KTrajectoryIsmrmrd
 from mrpro.data.traj_calculators.KTrajectoryCalculator import DummyTrajectory
 from mrpro.operators import FastFourierOp, LinearOperator
@@ -24,6 +28,77 @@ def test_KData_from_file(ismrmrd_cart) -> None:
     """Read in data from file."""
     kdata = KData.from_file(ismrmrd_cart.filename, DummyTrajectory())
     assert kdata is not None
+
+
+def test_KData_from_file_repairs_missing_required_xml_fields(ismrmrd_cart, tmp_path) -> None:
+    """Required fields omitted by older writers are repaired without changing the file."""
+    filename = tmp_path / 'missing_fields.h5'
+    shutil.copy2(ismrmrd_cart.filename, filename)
+    with h5py.File(filename, 'r+') as file:
+        xml = file['dataset/xml'][0]
+        root = ET.fromstring(xml)  # noqa: S314
+        namespace = root.tag.partition('}')[0].removeprefix('{')
+        qualified = lambda name: f'{{{namespace}}}{name}'  # noqa: E731
+        encoding = root.find(qualified('encoding'))
+        assert encoding is not None
+        trajectory = encoding.find(qualified('trajectory'))
+        assert trajectory is not None
+        encoding.remove(trajectory)
+        measurement = ET.Element(qualified('measurementInformation'))
+        ET.SubElement(measurement, qualified('protocolName')).text = 'legacy'
+        acquisition_system = root.find(qualified('acquisitionSystemInformation'))
+        assert acquisition_system is not None
+        root.insert(list(root).index(acquisition_system), measurement)
+        file['dataset/xml'][0] = ET.tostring(root, encoding='utf-8')
+        xml_before = file['dataset/xml'][0]
+
+    kdata = KData.from_file(
+        filename, DummyTrajectory(), header_overwrites={'trajectory_type': TrajectoryType.CARTESIAN}
+    )
+
+    assert kdata.header.patient_position.value == 'HFS'
+    assert kdata.header.trajectory_type.value == 'cartesian'
+    with h5py.File(filename, 'r') as file:
+        assert file['dataset/xml'][0] == xml_before
+
+
+def test_KData_from_file_repairs_invalid_patient_position(ismrmrd_cart, tmp_path) -> None:
+    """Legacy free-text patient positions fall back to the KHeader default."""
+    filename = tmp_path / 'invalid_patient_position.h5'
+    shutil.copy2(ismrmrd_cart.filename, filename)
+    with h5py.File(filename, 'r+') as file:
+        root = ET.fromstring(file['dataset/xml'][0])  # noqa: S314
+        namespace = root.tag.partition('}')[0].removeprefix('{')
+        qualified = lambda name: f'{{{namespace}}}{name}'  # noqa: E731
+        measurement = ET.Element(qualified('measurementInformation'))
+        ET.SubElement(measurement, qualified('patientPosition')).text = 'head first'
+        acquisition_system = root.find(qualified('acquisitionSystemInformation'))
+        assert acquisition_system is not None
+        root.insert(list(root).index(acquisition_system), measurement)
+        file['dataset/xml'][0] = ET.tostring(root, encoding='utf-8')
+
+    with pytest.warns(Warning, match='not a valid'):
+        kdata = KData.from_file(filename, DummyTrajectory())
+    assert kdata.header.patient_position.value == 'HFS'
+
+
+def test_KData_from_file_does_not_repair_unrelated_required_fields(ismrmrd_cart, tmp_path) -> None:
+    """Compatibility handling remains limited to fields with safe defaults."""
+    filename = tmp_path / 'missing_recon_space.h5'
+    shutil.copy2(ismrmrd_cart.filename, filename)
+    with h5py.File(filename, 'r+') as file:
+        root = ET.fromstring(file['dataset/xml'][0])  # noqa: S314
+        namespace = root.tag.partition('}')[0].removeprefix('{')
+        qualified = lambda name: f'{{{namespace}}}{name}'  # noqa: E731
+        encoding = root.find(qualified('encoding'))
+        assert encoding is not None
+        recon_space = encoding.find(qualified('reconSpace'))
+        assert recon_space is not None
+        encoding.remove(recon_space)
+        file['dataset/xml'][0] = ET.tostring(root, encoding='utf-8')
+
+    with pytest.raises(TypeError, match='reconSpace'):
+        KData.from_file(filename, DummyTrajectory())
 
 
 def test_KData_random_cart_undersampling(ismrmrd_cart_random_us) -> None:

--- a/tests/data/test_kdata.py
+++ b/tests/data/test_kdata.py
@@ -97,7 +97,9 @@ def test_KData_from_file_does_not_repair_unrelated_required_fields(ismrmrd_cart,
         encoding.remove(recon_space)
         file['dataset/xml'][0] = ET.tostring(root, encoding='utf-8')
 
-    with pytest.raises(TypeError, match='reconSpace'):
+    # The XML parser raises TypeError with ismrmrd >=1.15; older versions
+    # defer validation to KHeader, which raises ValueError instead.
+    with pytest.raises((TypeError, ValueError), match=r'reconSpace|Missing parameters'):
         KData.from_file(filename, DummyTrajectory())
 
 


### PR DESCRIPTION
This allows us to load  ismrmrd 1.14 compatille data with common issues.
 For example our own data from zenoodo and a4im osi2one data from zenodo.