### PR TITLE
Add KData.from_ismrmrd classmethod for creating KData without mrd file

### DIFF
--- a/src/mrpro/data/KData.py
+++ b/src/mrpro/data/KData.py
@@ -109,7 +109,7 @@ class KData(Dataclass):
             path to the ISMRMRD file or file-like object
         trajectory
             KTrajectoryCalculator to calculate the k-space trajectory or an already calculated KTrajectory
-            If a KTrajectory is given, the shape should be `(acquisisions 1 1 k0)` in the same order as the acquisitions
+            If a KTrajectory is given, the shape should be `(acquisitions 1 1 k0)` in the same order as the acquisitions
             in the ISMRMRD file.
         header_overwrites
             dictionary of key-value pairs to overwrite the header
@@ -129,7 +129,51 @@ class KData(Dataclass):
                 mtime = 0
             modification_time = datetime.datetime.fromtimestamp(mtime)
 
-        acquisitions = [acq for acq in acquisitions if acquisition_filter_criterion(acq)]
+        return cls.from_ismrmrd(
+            ismrmrd_header,
+            acquisitions,
+            trajectory,
+            header_overwrites=header_overwrites,
+            acquisition_filter_criterion=acquisition_filter_criterion,
+            modification_time=modification_time,
+        )
+
+    @classmethod
+    def from_ismrmrd(
+        cls,
+        ismrmrd_header: ismrmrd.xsd.ismrmrdschema.ismrmrd.ismrmrdHeader,
+        acquisitions: Sequence[ismrmrd.Acquisition],
+        trajectory: KTrajectoryCalculator | KTrajectory | KTrajectoryIsmrmrd,
+        header_overwrites: Mapping[str, object] | None = None,
+        acquisition_filter_criterion: Callable | None = is_image_acquisition,
+        modification_time: datetime.datetime | None = None,
+    ) -> Self:
+        """Create KData from an ISMRMRD header and a list of ISMRMRD acquisitions.
+
+        Parameters
+        ----------
+        ismrmrd_header
+            ISMRMRD header (ismrmrd.xsd.ismrmrdschema.ismrmrd.ismrmrdHeader)
+        acquisitions
+            sequence of ISMRMRD acquisitions
+        trajectory
+            KTrajectoryCalculator to calculate the k-space trajectory or an already calculated KTrajectory
+            If a KTrajectory is given, the shape should be `(acquisitions 1 1 k0)` in the same order as the acquisitions
+            in the ISMRMRD file.
+        header_overwrites
+            dictionary of key-value pairs to overwrite the header
+        acquisition_filter_criterion
+            function which returns True if an acquisition should be included in KData
+            If None, no filtering is applied.
+        modification_time
+            optional datetime to use as fallback for the header datetime field.
+            If None, the current time is used as fallback.
+        """
+        if modification_time is None:
+            modification_time = datetime.datetime.now()
+
+        if acquisition_filter_criterion is not None:
+            acquisitions = [acq for acq in acquisitions if acquisition_filter_criterion(acq)]
 
         # we need the same number of receiver coils for all acquisitions
         n_coils_available = {acq.data.shape[0] for acq in acquisitions}

--- a/src/mrpro/data/KData.py
+++ b/src/mrpro/data/KData.py
@@ -153,7 +153,7 @@ class KData(Dataclass):
         Parameters
         ----------
         ismrmrd_header
-            ISMRMRD header (ismrmrd.xsd.ismrmrdschema.ismrmrd.ismrmrdHeader)
+            ISMRMRD header object
         acquisitions
             sequence of ISMRMRD acquisitions
         trajectory

--- a/tests/data/_IsmrmrdRawTestData.py
+++ b/tests/data/_IsmrmrdRawTestData.py
@@ -1,5 +1,6 @@
 """Create ismrmrd datasets."""
 
+import copy
 from pathlib import Path
 from typing import Literal
 
@@ -209,6 +210,8 @@ class IsmrmrdRawTestData:
             sequenceParameters=seq,
             encoding=[encoding],
         )
+        self.ismrmrd_header = header
+        self.acquisitions: list[ismrmrd.Acquisition] = []
 
         dataset.write_xml_header(header.toXML('utf-8'))
 
@@ -234,6 +237,7 @@ class IsmrmrdRawTestData:
             acq.clearAllFlags()
             acq.setFlag(ismrmrd.ACQ_IS_NOISE_MEASUREMENT)
             acq.data[:] = noise.numpy()
+            self.acquisitions.append(copy.deepcopy(acq))
             dataset.append_acquisition(acq)
             scan_counter += 1
             time_stamp += 2
@@ -247,6 +251,7 @@ class IsmrmrdRawTestData:
                 acq.acquisition_time_stamp = time_stamp
                 acq.clearAllFlags()
                 acq.data[:] = data.numpy()
+                self.acquisitions.append(copy.deepcopy(acq))
                 dataset.append_acquisition(acq)
                 scan_counter += 1
                 time_stamp += 2
@@ -282,6 +287,7 @@ class IsmrmrdRawTestData:
 
                 # Set the data and append
                 acq.data[:] = kspace_calibration[:, :, pe_idx].numpy()
+                self.acquisitions.append(copy.deepcopy(acq))
                 dataset.append_acquisition(acq)
                 scan_counter += 1
                 time_stamp += 2
@@ -343,6 +349,7 @@ class IsmrmrdRawTestData:
                         acq.data[:] = kspace_with_noise[:, :, pe_idx].numpy()
                         acq.discard_pre = 0
                         acq.discard_post = 0
+                    self.acquisitions.append(copy.deepcopy(acq))
                     dataset.append_acquisition(acq)
                     scan_counter += 1
                     time_stamp += 3

--- a/tests/data/test_kdata.py
+++ b/tests/data/test_kdata.py
@@ -647,15 +647,34 @@ def test_KData_from_ismrmrd_matches_from_file(ismrmrd_cart) -> None:
     assert kdata_from_ismrmrd.data.shape == kdata_from_file.data.shape
 
 
-def test_KData_from_ismrmrd_no_filter(ismrmrd_cart) -> None:
-    """from_ismrmrd with acquisition_filter_criterion=None should not filter."""
+def test_KData_from_ismrmrd_manual_filter(ismrmrd_cart) -> None:
+    """from_ismrmrd with pre-filtered acquisitions and acquisition_filter_criterion=None should match default."""
     # Pre-filter manually, then pass with no filter criterion
     image_acquisitions = [acq for acq in ismrmrd_cart.acquisitions if is_image_acquisition(acq)]
-    kdata = KData.from_ismrmrd(
-        ismrmrd_cart.ismrmrd_header, image_acquisitions, DummyTrajectory(), acquisition_filter_criterion=None
+    kdata_manual_filtered = KData.from_ismrmrd(
+        ismrmrd_cart.ismrmrd_header,
+        image_acquisitions,
+        DummyTrajectory(),
+        acquisition_filter_criterion=None,
     )
-    kdata_default = KData.from_ismrmrd(ismrmrd_cart.ismrmrd_header, ismrmrd_cart.acquisitions, DummyTrajectory())
-    torch.testing.assert_close(kdata.data, kdata_default.data)
+
+    kdata_default = KData.from_ismrmrd(
+        ismrmrd_cart.ismrmrd_header,
+        ismrmrd_cart.acquisitions,
+        DummyTrajectory(),
+    )
+    torch.testing.assert_close(kdata_manual_filtered.data, kdata_default.data)
+
+
+def test_Kdata_from_ismrmrd_without_filter_raise_warning(ismrmrd_cart) -> None:
+    """from_ismrmrd without filter criterion should raise warning for test data with noise acquisitions."""
+    with pytest.raises(UserWarning, match='There are different numbers of acquisistions'):
+        KData.from_ismrmrd(
+            ismrmrd_cart.ismrmrd_header,
+            ismrmrd_cart.acquisitions,
+            DummyTrajectory(),
+            acquisition_filter_criterion=None,
+        )
 
 
 def test_KData_from_ismrmrd_modification_time(ismrmrd_cart) -> None:

--- a/tests/data/test_kdata.py
+++ b/tests/data/test_kdata.py
@@ -1,5 +1,6 @@
 """Tests for the KData class."""
 
+import datetime
 import re
 from collections.abc import Sequence
 from types import EllipsisType
@@ -558,3 +559,60 @@ def test_KData_repr(consistently_shaped_kdata: KData) -> None:
 \s{5}patient_name: unknown""",
         actual_repr,
     )
+
+
+def test_KData_from_ismrmrd_matches_from_file(ismrmrd_cart) -> None:
+    """from_ismrmrd should produce the same result as from_file."""
+    kdata_from_file = KData.from_file(ismrmrd_cart.filename, DummyTrajectory())
+    kdata_from_ismrmrd = KData.from_ismrmrd(ismrmrd_cart.ismrmrd_header, ismrmrd_cart.acquisitions, DummyTrajectory())
+    torch.testing.assert_close(kdata_from_ismrmrd.data, kdata_from_file.data)
+    torch.testing.assert_close(kdata_from_ismrmrd.traj.as_tensor(), kdata_from_file.traj.as_tensor())
+    assert kdata_from_ismrmrd.data.shape == kdata_from_file.data.shape
+
+
+def test_KData_from_ismrmrd_no_filter(ismrmrd_cart) -> None:
+    """from_ismrmrd with acquisition_filter_criterion=None should not filter."""
+    # Pre-filter manually, then pass with no filter criterion
+    image_acquisitions = [acq for acq in ismrmrd_cart.acquisitions if is_image_acquisition(acq)]
+    kdata = KData.from_ismrmrd(
+        ismrmrd_cart.ismrmrd_header, image_acquisitions, DummyTrajectory(), acquisition_filter_criterion=None
+    )
+    kdata_default = KData.from_ismrmrd(ismrmrd_cart.ismrmrd_header, ismrmrd_cart.acquisitions, DummyTrajectory())
+    torch.testing.assert_close(kdata.data, kdata_default.data)
+
+
+def test_KData_from_ismrmrd_modification_time(ismrmrd_cart) -> None:
+    """from_ismrmrd should use the provided modification_time as fallback."""
+    custom_time = datetime.datetime(2020, 6, 15, 12, 0, 0)
+    kdata = KData.from_ismrmrd(
+        ismrmrd_cart.ismrmrd_header, ismrmrd_cart.acquisitions, DummyTrajectory(), modification_time=custom_time
+    )
+    assert kdata.header.datetime == custom_time
+
+
+def test_KData_from_ismrmrd_default_modification_time(ismrmrd_cart) -> None:
+    """from_ismrmrd without modification_time should fall back to now()."""
+    before = datetime.datetime.now()
+    kdata = KData.from_ismrmrd(ismrmrd_cart.ismrmrd_header, ismrmrd_cart.acquisitions, DummyTrajectory())
+    after = datetime.datetime.now()
+    assert kdata.header.datetime is not None
+    assert before <= kdata.header.datetime <= after
+
+
+def test_KData_from_ismrmrd_header_overwrites(ismrmrd_cart) -> None:
+    """from_ismrmrd should apply header_overwrites."""
+    kdata = KData.from_ismrmrd(
+        ismrmrd_cart.ismrmrd_header, ismrmrd_cart.acquisitions, DummyTrajectory(), header_overwrites={'tr': [12.34]}
+    )
+    assert kdata.header.tr == [12.34]
+
+
+def test_KData_from_ismrmrd_empty_after_filter(ismrmrd_cart) -> None:
+    """from_ismrmrd should raise if no acquisitions remain after filtering."""
+    with pytest.raises(ValueError, match='No acquisitions meeting the given filter criteria were found'):
+        KData.from_ismrmrd(
+            ismrmrd_cart.ismrmrd_header,
+            ismrmrd_cart.acquisitions,
+            DummyTrajectory(),
+            acquisition_filter_criterion=lambda _: False,
+        )


### PR DESCRIPTION
- Adds a new `KData.from_ismrmrd` classmethod that accepts an ISMRMRD header and a sequence of acquisitions directly, without requiring a file on disk.
- Refactors `KData.from_file` to delegate to `from_ismrmrd` after reading the file, keeping file I/O concerns separated from data processing logic.
- The new method accepts an optional `modification_time` parameter (falls back to `datetime.now()`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a public way to create K-space data directly from ISMRMRD headers, acquisitions, and trajectories.
  - Supports optional acquisition filtering, header overrides, and custom modification times.
  - Filtering can be disabled when all acquisitions should be retained.

- **Bug Fixes**
  - Corrected trajectory documentation.

- **Tests**
  - Added coverage for filtering, metadata overrides, modification times, error handling, and consistency with file-based loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->